### PR TITLE
ENABLE_POWER_FOR_ID support

### DIFF
--- a/lightsaber.ino
+++ b/lightsaber.ino
@@ -949,13 +949,10 @@ public:
   // Measure and return the blade identifier resistor.
   float id() {
 #ifdef ENABLE_POWER_FOR_ID
+    ENABLE_POWER_FOR_ID power_pins_to_toggle;
     STDOUT.println("Power for ID enabled. Turning on FETs");
-    pinMode(bladePowerPin1, OUTPUT);
-    pinMode(bladePowerPin2, OUTPUT);
-    pinMode(bladePowerPin3, OUTPUT);
-    digitalWrite(bladePowerPin1, HIGH);
-    digitalWrite(bladePowerPin2, HIGH);
-    digitalWrite(bladePowerPin3, HIGH);
+    power_pins_to_toggle.Init();
+    power_pins_to_toggle.Power(true);
 #endif
     pinMode(bladeIdentifyPin, INPUT_PULLUP);
     delay(100);
@@ -965,9 +962,7 @@ public:
     float amps = (3.3f - volts) / 33000;     // Pull-up is 33k
     float resistor = volts / amps;
 #ifdef ENABLE_POWER_FOR_ID
-    pinMode(bladePowerPin1, LOW);
-    pinMode(bladePowerPin2, LOW);
-    pinMode(bladePowerPin3, LOW);
+    power_pins_to_toggle.Power(false);
 #endif
     STDOUT.print("ID: ");
     STDOUT.print(blade_id);

--- a/lightsaber.ino
+++ b/lightsaber.ino
@@ -948,12 +948,27 @@ public:
 
   // Measure and return the blade identifier resistor.
   float id() {
+#ifdef ENABLE_POWER_FOR_ID
+    STDOUT.println("Power for ID enabled. Turning on FETs");
+    pinMode(bladePowerPin1, OUTPUT);
+    pinMode(bladePowerPin2, OUTPUT);
+    pinMode(bladePowerPin3, OUTPUT);
+    digitalWrite(bladePowerPin1, HIGH);
+    digitalWrite(bladePowerPin2, HIGH);
+    digitalWrite(bladePowerPin3, HIGH);
+#endif
     pinMode(bladeIdentifyPin, INPUT_PULLUP);
     delay(100);
+
     int blade_id = analogRead(bladeIdentifyPin);
     float volts = blade_id * 3.3f / 1024.0f;  // Volts at bladeIdentifyPin
     float amps = (3.3f - volts) / 33000;     // Pull-up is 33k
     float resistor = volts / amps;
+#ifdef ENABLE_POWER_FOR_ID
+    pinMode(bladePowerPin1, LOW);
+    pinMode(bladePowerPin2, LOW);
+    pinMode(bladePowerPin3, LOW);
+#endif
     STDOUT.print("ID: ");
     STDOUT.print(blade_id);
     STDOUT.print(" volts ");


### PR DESCRIPTION
uses a #define ENABLE_POWER_FOR_ID PowerPINS<pin1,pin2,...> supported config file to enable the power on the pins prior to checking the resistance for the blade ID.  Allows support for pogo-pin type connectors for blade IDs where the blade ID resistor is placed on the LED negative as opposed to GND.