### PR TITLE
Smooth Swing Accent changes

### DIFF
--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -70,9 +70,7 @@ public:
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
   virtual void StartSwing() {}
-  virtual float SetSwingVolume(float swing_strength, float AccentSwingVolumeSharpness,
-  float MaxAccentSwingVolume, float MaxAccentSwingDucking, float mixhum) {}
-  virtual bool IsSwingPlaying() {}
+  virtual float SetSwingVolume(float swing_strength, float mixhum) {}
   
 #define SABERFUN(NAME, TYPED_ARGS, ARGS)                        \
 public:                                                         \

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -6,7 +6,6 @@
 // has a corresponding SaberBase::Do* function which invokes that function
 // on all active SaberBases.
 class SaberBase;
-class Effect;
 extern SaberBase* saberbases;
 
 class SaberBase {

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -69,7 +69,7 @@ public:
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
   virtual void StartSwing() {}
-  virtual float SetSwingVolume(float swing_strength, float mixhum) {}
+  virtual void SetSwingVolume(float swing_strength) {}
   
 #define SABERFUN(NAME, TYPED_ARGS, ARGS)                        \
 public:                                                         \

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -69,7 +69,7 @@ public:
   // 1.0 = kDefaultVolume
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
-  virtual void StartSwing(Effect* monophonic, Effect* polyphonic) {}
+  virtual void StartSwing() {}
   virtual float SetSwingVolume(float swing_strength, float AccentSwingVolumeSharpness,
   float MaxAccentSwingVolume, float MaxAccentSwingDucking, float mixhum) {}
   virtual bool IsSwingPlaying() {}

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -69,7 +69,7 @@ public:
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
   virtual void StartSwing() {}
-  virtual void SetSwingVolume(float swing_strength) {}
+  virtual float SetSwingVolume(float swing_strength, float mixhum) {}
   
 #define SABERFUN(NAME, TYPED_ARGS, ARGS)                        \
 public:                                                         \

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -68,7 +68,7 @@ public:
   // 1.0 = kDefaultVolume
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
-  virtual void StartSwing(bool AccentSwing) {}
+  virtual void StartSwing() {}
   virtual void SetSwingVolume(float swing_strength) {}
   
 #define SABERFUN(NAME, TYPED_ARGS, ARGS)                        \

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -68,7 +68,7 @@ public:
   // 1.0 = kDefaultVolume
   // This is really just for sound fonts.
   virtual void SetHumVolume(float volume) {}
-  virtual void StartSwing() {}
+  virtual void StartSwing(bool AccentSwing) {}
   virtual void SetSwingVolume(float swing_strength) {}
   
 #define SABERFUN(NAME, TYPED_ARGS, ARGS)                        \

--- a/lightsaber.ino
+++ b/lightsaber.ino
@@ -183,7 +183,7 @@ SnoozeTouch snooze_touch;
 SnoozeBlock snooze_config(snooze_touch, snooze_digital, snooze_timer);
 #endif
 
-const char version[] = "$Id$";
+const char version[] = "$Id: 0c3909b34a755d918ac8d7077ea1142902bbd0db $";
 
 #include "common/state_machine.h"
 #include "common/monitoring.h"
@@ -541,9 +541,6 @@ public:
     CONFIG_VARIABLE(Transition2Degrees, 160.0f);
     CONFIG_VARIABLE(MaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(AccentSwingSpeedThreshold, 0.0f);
-    CONFIG_VARIABLE(AccentSwingVolumeSharpness, 1.0f);
-    CONFIG_VARIABLE(MaxAccentSwingVolume, 3.0f);
-    CONFIG_VARIABLE(MaxAccentSwingDucking, 0.5f);
   };
 
   int  Version;
@@ -555,9 +552,6 @@ public:
   float Transition2Degrees;
   float MaxSwingVolume;
   float AccentSwingSpeedThreshold;
-  float AccentSwingVolumeSharpness;
-  float MaxAccentSwingVolume;
-  float MaxAccentSwingDucking;
 };
 
 SmoothSwingConfigFile smooth_swing_config;
@@ -3235,4 +3229,3 @@ void loop() {
     last_activity = millis();
   }
 }
-

--- a/lightsaber.ino
+++ b/lightsaber.ino
@@ -183,7 +183,7 @@ SnoozeTouch snooze_touch;
 SnoozeBlock snooze_config(snooze_touch, snooze_digital, snooze_timer);
 #endif
 
-const char version[] = "$Id:$";
+const char version[] = "$Id$";
 
 #include "common/state_machine.h"
 #include "common/monitoring.h"

--- a/lightsaber.ino
+++ b/lightsaber.ino
@@ -183,7 +183,7 @@ SnoozeTouch snooze_touch;
 SnoozeBlock snooze_config(snooze_touch, snooze_digital, snooze_timer);
 #endif
 
-const char version[] = "$Id: 0c3909b34a755d918ac8d7077ea1142902bbd0db $";
+const char version[] = "$Id:$";
 
 #include "common/state_machine.h"
 #include "common/monitoring.h"

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -139,11 +139,8 @@ public:
         // avoid overlapping swings, based on value set in ProffieOSSwingOverlap.  Value is
         // between 0 (no overlap) and 1.0 (full overlap)
         if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
-          RefPtr<BufferedWavPlayer> overlap_swing = swing_player_;
+          swing_player_.Free();
           swing_player_ = PlayPolyphonic(&swng);
-          overlap_swing->set_fade_time(overlap_swing->length() - overlap_swing->pos());
-          overlap_swing->FadeAndStop();
-          overlap_swing.Free();
         }
       }
       else if (!swing_player_) {
@@ -160,7 +157,7 @@ public:
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
         swing_player_->set_volume(accent_volume);
-        mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * swing_strength);
+        mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * accent_volume);
       }
       else {
         swing_player_.Free();

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -39,23 +39,23 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-	guess_monophonic_ = true;
-	STDOUT.print("monophonic");
+        guess_monophonic_ = true;
+        STDOUT.print("monophonic");
       } else {
-	guess_monophonic_ = false;
-	STDOUT.print("hybrid");
+        guess_monophonic_ = false;
+        STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;
       STDOUT.print("polyphonic");
     }
-	
+    
     STDOUT.println(" font.");
     SaberBase::Link(this);
     SetHumVolume(1.0);
     state_ = STATE_OFF;
   }
-
+  
   enum State {
     STATE_OFF,
     STATE_OUT,
@@ -63,7 +63,7 @@ public:
     STATE_HUM_ON,
     STATE_HUM_FADE_OUT,
   };
-
+  
   void Deactivate() {
     lock_player_.Free();
     hum_player_.Free();
@@ -72,7 +72,7 @@ public:
     second_swing_player_.Free();
     SaberBase::Unlink(this);
   }
-
+  
   RefPtr<BufferedWavPlayer> hum_player_;
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
@@ -84,8 +84,8 @@ public:
     if (!next_hum_player_) {
       next_hum_player_ = GetFreeWavPlayer();
       if (!next_hum_player_) {
-	STDOUT.println("Out of WAV players!");
-	return;
+        STDOUT.println("Out of WAV players!");
+        return;
       }
     }
     if (hum_player_) {
@@ -104,7 +104,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-							   
+  
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -114,7 +114,7 @@ public:
     }
     return player;
   }
-
+  
   void Play(Effect* monophonic, Effect* polyphonic) {
     if (polyphonic->files_found()) {
       PlayPolyphonic(polyphonic);
@@ -122,7 +122,7 @@ public:
       PlayMonophonic(monophonic, &hum);
     }
   }
-
+  
   void PlayCommon(Effect* effect) {
     if (guess_monophonic_) {
       PlayMonophonic(effect, &hum);
@@ -136,44 +136,30 @@ public:
         swing_player_ = PlayPolyphonic(&swng);
       } else {
         if (!second_swing_player_) {
-          second_swing_player_ = PlayPolyphonic(&swng);
+          second_swing_player_ = swing_player_;
+          swing_player_ = PlayPolyphonic(&swng);
+          second_swing_player_->set_fade_time(0.2);
+          second_swing_player_->FadeAndStop();
+          second_swing_player_.Free();
         }
       }
     } else {
       PlayMonophonic(&swing, &hum);
     }
   }
-
+  
   float SetSwingVolume(float swing_strength, float mixhum) {
-    if (IsSwingPlaying()) {
-      float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
-      swing_player_->set_volume(accent_volume);
-      if (second_swing_player_) {
-        second_swing_player_->set_volume(accent_volume);
+    if(swing_player_) {
+      if (swing_player_->isPlaying()) {
+        float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
+        swing_player_->set_volume(accent_volume);
+        mixhum = mixhum * config_.ProffieOSMaxSwingDucking;
       }
-      mixhum = mixhum * config_.ProffieOSMaxSwingDucking;
+      else {
+        swing_player_.Free();
+      }
     }
     return mixhum;
-  }
-
-  bool IsSwingPlaying() {
-    if (swing_player_) {
-      if (second_swing_player_) {
-        if(second_swing_player_->isPlaying() || swing_player_->isPlaying()) {
-          return true;
-        }
-      } else {
-        if (!swing_player_->isPlaying()) {
-          swing_player_.Free();
-        }
-        if (!second_swing_player_->isPlaying()) {
-          second_swing_player_.Free();
-        }
-        return false;
-      }
-    } else {
-      return false;
-    }
   }
   void SB_On() override {
     if (monophonic_hum_) {
@@ -183,31 +169,31 @@ public:
       state_ = STATE_OUT;
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
-	hum_player_->set_volume_now(0);
-	hum_player_->PlayOnce(&hum);
-	hum_player_->PlayLoop(&hum);
-	hum_start_ = millis();
+        hum_player_->set_volume_now(0);
+        hum_player_->PlayOnce(&hum);
+        hum_player_->PlayLoop(&hum);
+        hum_start_ = millis();
       }
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&out);
       if (config_.humStart && tmp) {
-	int delay_ms = 1000 * tmp->length() - config_.humStart;
-	if (delay_ms > 0 && delay_ms < 30000) {
-	  hum_start_ += delay_ms;
-	}
+        int delay_ms = 1000 * tmp->length() - config_.humStart;
+        if (delay_ms > 0 && delay_ms < 30000) {
+          hum_start_ += delay_ms;
+        }
       }
     }
   }
-
+  
   void SB_Off() override {
     if (monophonic_hum_) {
       size_t total = poweroff.files_found() + pwroff.files_found();
       if (total) {
-	state_ = STATE_OFF;
-	if ((rand() % total) < poweroff.files_found()) {
-	  PlayMonophonic(&poweroff, NULL);
-	} else {
-	  PlayMonophonic(&pwroff, NULL);
-	}
+        state_ = STATE_OFF;
+        if ((rand() % total) < poweroff.files_found()) {
+          PlayMonophonic(&poweroff, NULL);
+        } else {
+          PlayMonophonic(&pwroff, NULL);
+        }
       }
     } else {
       state_ = STATE_HUM_FADE_OUT;
@@ -220,24 +206,24 @@ public:
   void SB_Blast() override { Play(&blaster, &blst); }
   void SB_Boot() override { PlayPolyphonic(&boot); }
   void SB_NewFont() override { PlayPolyphonic(&font); }
-
+  
   void SB_BeginLockup() override {
     if (lockup.files_found()) {
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-	  drag.files_found()) {
-	PlayMonophonic(&drag, &drag);
+          drag.files_found()) {
+        PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
         if (bgnlock.files_found()) {
           PlayMonophonic(&bgnlock, &lockup);
         } else {
           PlayMonophonic(&lockup, &lockup);
-	}
+        }
       }
     } else {
       Effect* e = &lock;
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-	  drag.files_found()) {
-	e = &drag;
+          drag.files_found()) {
+        e = &drag;
       }
       if (!lock_player_) {
         if (bgnlock.files_found()) {
@@ -245,26 +231,26 @@ public:
         } else {
           lock_player_ = PlayPolyphonic(e);
         }
-
-	if (lock_player_) {
-	  lock_player_->PlayLoop(e);
-	}
+        
+        if (lock_player_) {
+          lock_player_->PlayLoop(e);
+        }
       }
     }
   }
-
+  
   void SB_EndLockup() override {
     if (lock_player_) {
       // Polyphonic case
       lock_player_->set_fade_time(0.3);
-
+      
       if (endlock.files_found()) { // polyphonic end lock
         if (PlayPolyphonic(&endlock)) {
           // if playing an end lock fade the lockup faster
           lock_player_->set_fade_time(0.003);
-	}
+        }
       }
-
+      
       lock_player_->FadeAndStop();
       lock_player_.Free();
       return;
@@ -278,53 +264,53 @@ public:
       }
     }
   }
-
+  
   void SetHumVolume(float vol) override {
     if (!monophonic_hum_) {
       if (state_ != STATE_OFF && !hum_player_) {
-	hum_player_ = GetFreeWavPlayer();
-	if (hum_player_) {
-	  hum_player_->set_volume_now(0);
-	  hum_player_->PlayOnce(&hum);
-	  hum_player_->PlayLoop(&hum);
-	  hum_start_ = millis();
-	}
+        hum_player_ = GetFreeWavPlayer();
+        if (hum_player_) {
+          hum_player_->set_volume_now(0);
+          hum_player_->PlayOnce(&hum);
+          hum_player_->PlayLoop(&hum);
+          hum_start_ = millis();
+        }
       }
       if (!hum_player_) return;
       uint32_t m = micros();
       switch (state_) {
-	case STATE_OFF:
-	  volume_ = 0.0f;
-	  return;
-	case STATE_OUT:
-	  volume_ = 0.0f;
-	  if (millis() - hum_start_ < 0x7fffffffUL) {
-	    state_ = STATE_HUM_FADE_IN;
-	  }
-	  break;
-	case STATE_HUM_FADE_IN: {
-	  uint32_t delta = m - last_micros_;
-	  volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
-	  if (volume_ >= 1.0f) {
-	    volume_ = 1.0f;
-	    state_ = STATE_HUM_ON;
-	  }
-	  break;
-	}
-	case STATE_HUM_ON:
-	  break;
-	case STATE_HUM_FADE_OUT: {
-	  SaberBase::RequestMotion();
-	  uint32_t delta = m - last_micros_;
-	  volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
-	  if (volume_ <= 0.0f) {
-	    volume_ = 0.0f;
-	    state_ = STATE_OFF;
-	    hum_player_->FadeAndStop();
-	    hum_player_.Free();
-	  }
-	  break;
-	}
+        case STATE_OFF:
+          volume_ = 0.0f;
+          return;
+        case STATE_OUT:
+          volume_ = 0.0f;
+          if (millis() - hum_start_ < 0x7fffffffUL) {
+            state_ = STATE_HUM_FADE_IN;
+          }
+          break;
+        case STATE_HUM_FADE_IN: {
+          uint32_t delta = m - last_micros_;
+          volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
+          if (volume_ >= 1.0f) {
+            volume_ = 1.0f;
+            state_ = STATE_HUM_ON;
+          }
+          break;
+        }
+        case STATE_HUM_ON:
+          break;
+        case STATE_HUM_FADE_OUT: {
+          SaberBase::RequestMotion();
+          uint32_t delta = m - last_micros_;
+          volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
+          if (volume_ <= 0.0f) {
+            volume_ = 0.0f;
+            state_ = STATE_OFF;
+            hum_player_->FadeAndStop();
+            hum_player_.Free();
+          }
+          break;
+        }
       }
       last_micros_ = m;
       vol *= volume_;
@@ -338,7 +324,7 @@ public:
     float speed = sqrtf(gyro.z * gyro.z + gyro.y * gyro.y);
     if (speed > 250.0) {
       if (!swinging_ && state_ != STATE_OFF &&
-	  !(lockup.files_found() && SaberBase::Lockup())) {
+          !(lockup.files_found() && SaberBase::Lockup())) {
         swinging_ = true;
         StartSwing();
       }
@@ -351,8 +337,8 @@ public:
     }
     SetHumVolume(vol);
   }
-
- private:
+  
+private:
   uint32_t last_micros_;
   uint32_t hum_start_;
   bool monophonic_hum_;
@@ -363,3 +349,4 @@ public:
 };
 
 #endif
+

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -69,14 +69,12 @@ public:
     hum_player_.Free();
     next_hum_player_.Free();
     swing_player_.Free();
-    second_swing_player_.Free();
     SaberBase::Unlink(this);
   }
 
   RefPtr<BufferedWavPlayer> hum_player_;
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
-  RefPtr<BufferedWavPlayer> second_swing_player_;
   RefPtr<BufferedWavPlayer> lock_player_;
   
   void PlayMonophonic(Effect* f, Effect* loop)  {
@@ -135,13 +133,11 @@ public:
       if (!swing_player_) {
         swing_player_ = PlayPolyphonic(&swng);
       } else {
-        if (!second_swing_player_) {
-          second_swing_player_ = swing_player_;
-          swing_player_ = PlayPolyphonic(&swng);
-          second_swing_player_->set_fade_time(0.2);
-          second_swing_player_->FadeAndStop();
-          second_swing_player_.Free();
-        }
+        RefPtr<BufferedWavPlayer> second_swing_player_ = swing_player_;
+        swing_player_ = PlayPolyphonic(&swng);
+        second_swing_player_->set_fade_time(0.2);
+        second_swing_player_->FadeAndStop();
+        second_swing_player_.Free();
       }
     } else {
       PlayMonophonic(&swing, &hum);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -343,7 +343,7 @@ public:
         StartSwing();
       }
       float swing_strength = std::min<float>(1.0, speed / config_.ProffieOSSwingSpeedThreshold);
-      SetSwingVolume(swing_strength);
+      SetSwingVolume(swing_strength, 1.0);
     } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold * 0.8) {
       swinging_ = false;
     }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -135,7 +135,9 @@ public:
       if (!swing_player_) {
         swing_player_ = PlayPolyphonic(&swng);
       } else {
-        second_swing_player_ = PlayPolyphonic(&swng);
+        if (!second_swing_player_) {
+          second_swing_player_ = PlayPolyphonic(&swng);
+        }
       }
     } else {
       PlayMonophonic(&swing, &hum);
@@ -161,10 +163,10 @@ public:
           return true;
         }
       } else {
-        if (!swing_player_) {
+        if (!swing_player_->isPlaying()) {
           swing_player_.Free();
         }
-        if (!second_swing_player_) {
+        if (!second_swing_player_->isPlaying()) {
           second_swing_player_.Free();
         }
         return false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -8,9 +8,9 @@ public:
     CONFIG_VARIABLE(volHum, 15);
     CONFIG_VARIABLE(volEff, 16);
     CONFIG_VARIABLE(ProffieOSSwingSpeedThreshold, 250.0f);
-    CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 0.5f);
+    CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 1.0f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
-    CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.6f);
+    CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.5f);
     CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.25f);
   }
   int humStart;
@@ -137,7 +137,7 @@ public:
     if (!guess_monophonic_) {
       if (swing_player_) {
         // avoid overlapping swings, based on value set in ProffieOSSwingOverlap.  Value is
-        // between 0 (no overlap) and 1.0 (full overlap)
+        // between 0 (full overlap) and 1.0 (no overlap)
         if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
           swing_player_.Free();
           swing_player_ = PlayPolyphonic(&swng);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -96,7 +96,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-					  		 
+				  	  		 
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -208,7 +208,7 @@ public:
         PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
         if (bgnlock.files_found()) {
-         PlayMonophonic(&bgnlock, &lockup);
+          PlayMonophonic(&bgnlock, &lockup);
         } else {
           PlayMonophonic(&lockup, &lockup);
       }
@@ -236,13 +236,14 @@ public:
     if (lock_player_) {
       // Polyphonic case
       lock_player_->set_fade_time(0.3);
-      
+
       if (endlock.files_found()) { // polyphonic end lock
         if (PlayPolyphonic(&endlock)) {
           // if playing an end lock fade the lockup faster
           lock_player_->set_fade_time(0.003);
-	}
+	      }
       }
+      
       lock_player_->FadeAndStop();
       lock_player_.Free();
       return;
@@ -257,16 +258,16 @@ public:
       PlayMonophonic(&clash, &hum);
     }
   }
-  
+
   void SetHumVolume(float vol) override {
     if (!monophonic_hum_) {
       if (state_ != STATE_OFF && !hum_player_) {
-        hum_player_ = GetFreeWavPlayer();
-        if (hum_player_) {
-	 hum_player_->set_volume_now(0);
-	 hum_player_->PlayOnce(&hum);
-	 hum_player_->PlayLoop(&hum);
-	 hum_start_ = millis();
+       hum_player_ = GetFreeWavPlayer();
+       if (hum_player_) {
+	      hum_player_->set_volume_now(0);
+	      hum_player_->PlayOnce(&hum);
+	      hum_player_->PlayLoop(&hum);
+	      hum_start_ = millis();
         }
       }
       if (!hum_player_) return;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -159,7 +159,7 @@ public:
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
-        swing_player_->set_fade_time(0.02);
+        swing_player_->set_fade_time(0.04);
         swing_player_->set_volume(accent_volume);
         mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * accent_volume);
       } else {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -144,7 +144,9 @@ public:
           overlap_swing.Free();
         }
       }
-      swing_player_ = PlayPolyphonic(&swng);
+      else if (!swing_player_) {
+        swing_player_ = PlayPolyphonic(&swng);
+      }
     } else {
       PlayMonophonic(&swing, &hum);
     }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -124,7 +124,7 @@ public:
   }
   void StartSwing(Effect* monophonic, Effect* polyphonic) override {
     if (polyphonic->files_found()) {
-        swing_player_ = PlayPolyphonic(polyphonic);
+      swing_player_ = PlayPolyphonic(polyphonic);
     } else {
       PlayMonophonic(monophonic, &hum);
     }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -220,16 +220,14 @@ public:
       }
       if (!lock_player_) {
         if (bgnlock.files_found()) {
-        lock_player_ = PlayPolyphonic(&bgnlock);
-      } else {
+          lock_player_ = PlayPolyphonic(&bgnlock);
+        } else {
           lock_player_ = PlayPolyphonic(e);
         }
-      
-      if (lock_player_) {
-       if (bgnlock.files_found()) {
-        lock_player_ = PlayPolyphonic(&bgnlock);
-        
-        lock_player_->PlayLoop(e);
+	      
+	if (lock_player_) {
+	  lock_player_->PlayLoop(e);
+	}
       }
     }
   }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -146,6 +146,7 @@ public:
       }
       else if (!swing_player_) {
         swing_player_ = PlayPolyphonic(&swng);
+        swing_player_->set_volume_now(0);
       }
     } else {
       PlayMonophonic(&swing, &hum);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -124,9 +124,9 @@ public:
   }
   void StartSwing() override {
     if (!guess_monophonic_) {
-      swing_player_ = PlayPolyphonic(swng);
+      swing_player_ = PlayPolyphonic(&swng);
     } else {
-      PlayMonophonic(swing, &hum);
+      PlayMonophonic(&swing, &hum);
     }
   }
 

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -12,7 +12,7 @@ public:
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.5f);
     CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.0f);
-    CONFIG_VARIABLE(ProffieOSSwingLowerThreshold, 0.8f);
+    CONFIG_VARIABLE(ProffieOSSwingLowerThreshold, 200.0f);
   }
   int humStart;
   int volHum;
@@ -141,11 +141,10 @@ public:
         // avoid overlapping swings, based on value set in ProffieOSSwingOverlap.  Value is
         // between 0 (full overlap) and 1.0 (no overlap)
         if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
-          RefPtr<BufferedWavPlayer> overlap_swing = swing_player_;
+          swing_player_->set_fade_time(swing_player_->length() - swing_player_->pos());
+          swing_player_->FadeAndStop();
+          swing_player_.Free();
           swing_player_ = PlayPolyphonic(&swng);
-          overlap_swing->set_fade_time(overlap_swing->length() - overlap_swing->pos());
-          overlap_swing->FadeAndStop();
-          overlap_swing.Free();
         }
       }
       else if (!swing_player_) {
@@ -160,11 +159,10 @@ public:
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
-        swing_player_->set_fade_time(2);
+        swing_player_->set_fade_time(0.02);
         swing_player_->set_volume(accent_volume);
         mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * accent_volume);
-      }
-      else {
+      } else {
         swing_player_.Free();
       }
     }
@@ -346,8 +344,7 @@ public:
       }
       float swing_strength = std::min<float>(1.0, speed / config_.ProffieOSSwingSpeedThreshold);
       SetSwingVolume(swing_strength, 1.0);
-    } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold * 
-               ProffieOSSwingLowerThreshold, config_.ProffieOSSwingLowerThreshold) {
+    } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold) {
       swinging_ = false;
     }
     float vol = 1.0f;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -11,7 +11,7 @@ public:
     CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 1.0f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.5f);
-    CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.25f);
+    CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.0f);
   }
   int humStart;
   int volHum;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -136,7 +136,7 @@ public:
       if (swing_player_) {
         // avoid overlapping swings, based on value set in ProffieOSSwingOverlap.  Value is
         // between 0 (no overlap) and 1.0 (full overlap)
-        if (swing_player_->pos() / swing_player_->length()) >= config_.ProffieOSSwingOverlap) {
+        if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
           RefPtr<BufferedWavPlayer> overlap_swing = swing_player_;
           swing_player_ = PlayPolyphonic(&swng);
           overlap_swing->set_fade_time(0.1);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -139,7 +139,7 @@ public:
         if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
           RefPtr<BufferedWavPlayer> overlap_swing = swing_player_;
           swing_player_ = PlayPolyphonic(&swng);
-          overlap_swing->set_fade_time(0.1);
+          overlap_swing->set_fade_time(overlap_swing->length() - overlap_swing->pos());
           overlap_swing->FadeAndStop();
           overlap_swing.Free();
         }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -331,7 +331,7 @@ public:
       }
       float swing_strength = std::min<float>(1.0, speed / config_.ProffieOSSwingSpeedThreshold);
       SetSwingVolume(swing_strength);
-    } else {
+    } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold * 0.8) {
       swinging_ = false;
     }
     float vol = 1.0f;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -33,17 +33,17 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-       guess_monophonic_ = true;
-       STDOUT.print("monophonic");
+	guess_monophonic_ = true;
+	STDOUT.print("monophonic");
       } else {
-       guess_monophonic_ = false;
-       STDOUT.print("hybrid");
+	guess_monophonic_ = false;
+	STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;
       STDOUT.print("polyphonic");
     }
-       
+	
     STDOUT.println(" font.");
     SaberBase::Link(this);
     SetHumVolume(1.0);
@@ -76,8 +76,8 @@ public:
     if (!next_hum_player_) {
       next_hum_player_ = GetFreeWavPlayer();
       if (!next_hum_player_) {
-       STDOUT.println("Out of WAV players!");
-       return;
+	STDOUT.println("Out of WAV players!");
+	return;
       }
     }
     if (hum_player_) {
@@ -96,7 +96,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-				  	  		 
+							   
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -122,7 +122,6 @@ public:
       PlayPolyphonic(effect);
     }
   }
-  
   void StartSwing(Effect* monophonic, Effect* polyphonic) override {
     if (polyphonic->files_found()) {
         swing_player_ = PlayPolyphonic(polyphonic);
@@ -130,7 +129,7 @@ public:
       PlayMonophonic(monophonic, &hum);
     }
   }
-  
+
   float SetSwingVolume(float swing_strength, float AccentSwingVolumeSharpness, float MaxAccentSwingVolume,
   float MaxAccentSwingDucking, float mixhum) override {
     if (IsSwingPlaying()) {
@@ -141,7 +140,7 @@ public:
     }
     else return 0.0;
   }
-  
+
   bool IsSwingPlaying() override {
     if (swing_player_) {
       if (swing_player_->isPlaying()) {
@@ -154,7 +153,6 @@ public:
       return false;
     }
   }
-  
   void SB_On() override {
     if (monophonic_hum_) {
       state_ = STATE_HUM_ON;
@@ -163,17 +161,17 @@ public:
       state_ = STATE_OUT;
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
-       hum_player_->set_volume_now(0);
-       hum_player_->PlayOnce(&hum);
-       hum_player_->PlayLoop(&hum);
-       hum_start_ = millis();
+	hum_player_->set_volume_now(0);
+	hum_player_->PlayOnce(&hum);
+	hum_player_->PlayLoop(&hum);
+	hum_start_ = millis();
       }
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&out);
       if (config_.humStart && tmp) {
-       int delay_ms = 1000 * tmp->length() - config_.humStart;
-       if (delay_ms > 0 && delay_ms < 30000) {
-         hum_start_ += delay_ms;
-       }
+	int delay_ms = 1000 * tmp->length() - config_.humStart;
+	if (delay_ms > 0 && delay_ms < 30000) {
+	  hum_start_ += delay_ms;
+	}
       }
     }
   }
@@ -182,12 +180,12 @@ public:
     if (monophonic_hum_) {
       size_t total = poweroff.files_found() + pwroff.files_found();
       if (total) {
-       state_ = STATE_OFF;
-       if ((rand() % total) < poweroff.files_found()) {
-         PlayMonophonic(&poweroff, NULL);
-       } else {
-         PlayMonophonic(&pwroff, NULL);
-       }
+	state_ = STATE_OFF;
+	if ((rand() % total) < poweroff.files_found()) {
+	  PlayMonophonic(&poweroff, NULL);
+	} else {
+	  PlayMonophonic(&pwroff, NULL);
+	}
       }
     } else {
       state_ = STATE_HUM_FADE_OUT;
@@ -204,19 +202,20 @@ public:
   void SB_BeginLockup() override {
     if (lockup.files_found()) {
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-         drag.files_found()) {
-        PlayMonophonic(&drag, &drag);
+	  drag.files_found()) {
+	PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
         if (bgnlock.files_found()) {
           PlayMonophonic(&bgnlock, &lockup);
         } else {
           PlayMonophonic(&lockup, &lockup);
+	}
       }
     } else {
       Effect* e = &lock;
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-         drag.files_found()) {
-       e = &drag;
+	  drag.files_found()) {
+	e = &drag;
       }
       if (!lock_player_) {
         if (bgnlock.files_found()) {
@@ -241,9 +240,9 @@ public:
         if (PlayPolyphonic(&endlock)) {
           // if playing an end lock fade the lockup faster
           lock_player_->set_fade_time(0.003);
-	      }
+	}
       }
-      
+
       lock_player_->FadeAndStop();
       lock_player_.Free();
       return;
@@ -255,59 +254,58 @@ public:
       } else {
         PlayMonophonic(&clash, &hum);
       }
-      PlayMonophonic(&clash, &hum);
     }
   }
 
   void SetHumVolume(float vol) override {
     if (!monophonic_hum_) {
       if (state_ != STATE_OFF && !hum_player_) {
-       hum_player_ = GetFreeWavPlayer();
-       if (hum_player_) {
-	      hum_player_->set_volume_now(0);
-	      hum_player_->PlayOnce(&hum);
-	      hum_player_->PlayLoop(&hum);
-	      hum_start_ = millis();
-        }
+	hum_player_ = GetFreeWavPlayer();
+	if (hum_player_) {
+	  hum_player_->set_volume_now(0);
+	  hum_player_->PlayOnce(&hum);
+	  hum_player_->PlayLoop(&hum);
+	  hum_start_ = millis();
+	}
       }
       if (!hum_player_) return;
       uint32_t m = micros();
       switch (state_) {
-       case STATE_OFF:
-         volume_ = 0.0f;
-         return;
-       case STATE_OUT:
-         volume_ = 0.0f;
-         if (millis() - hum_start_ < 0x7fffffffUL) {
-           state_ = STATE_HUM_FADE_IN;
-	 }
-         break;
-       case STATE_HUM_FADE_IN: {
-         uint32_t delta = m - last_micros_;
-         volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
-         if (volume_ >= 1.0f) {
-           volume_ = 1.0f;
-           state_ = STATE_HUM_ON;
-         }
-         break;
-       }
-       case STATE_HUM_ON:
-         break;
-       case STATE_HUM_FADE_OUT: {
-         SaberBase::RequestMotion();
-         uint32_t delta = m - last_micros_;
-         volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
-         if (volume_ <= 0.0f) {
-           volume_ = 0.0f;
-           state_ = STATE_OFF;
-           hum_player_->FadeAndStop();
-           hum_player_.Free();
-         }
-         break;
-       }
-     }
-     last_micros_ = m;
-     vol *= volume_;
+	case STATE_OFF:
+	  volume_ = 0.0f;
+	  return;
+	case STATE_OUT:
+	  volume_ = 0.0f;
+	  if (millis() - hum_start_ < 0x7fffffffUL) {
+	    state_ = STATE_HUM_FADE_IN;
+	  }
+	  break;
+	case STATE_HUM_FADE_IN: {
+	  uint32_t delta = m - last_micros_;
+	  volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
+	  if (volume_ >= 1.0f) {
+	    volume_ = 1.0f;
+	    state_ = STATE_HUM_ON;
+	  }
+	  break;
+	}
+	case STATE_HUM_ON:
+	  break;
+	case STATE_HUM_FADE_OUT: {
+	  SaberBase::RequestMotion();
+	  uint32_t delta = m - last_micros_;
+	  volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
+	  if (volume_ <= 0.0f) {
+	    volume_ = 0.0f;
+	    state_ = STATE_OFF;
+	    hum_player_->FadeAndStop();
+	    hum_player_.Free();
+	  }
+	  break;
+	}
+      }
+      last_micros_ = m;
+      vol *= volume_;
     }
     if (!hum_player_) return;
     hum_player_->set_volume(vol);
@@ -318,7 +316,7 @@ public:
     float speed = sqrtf(gyro.z * gyro.z + gyro.y * gyro.y);
     if (speed > 250.0) {
       if (!swinging_ && state_ != STATE_OFF &&
-          !(lockup.files_found() && SaberBase::Lockup())) {
+	  !(lockup.files_found() && SaberBase::Lockup())) {
         swinging_ = true;
         StartSwing(&swing, &swng);
       }
@@ -331,8 +329,8 @@ public:
     }
     SetHumVolume(vol);
   }
-  
-private:
+
+ private:
   uint32_t last_micros_;
   uint32_t hum_start_;
   bool monophonic_hum_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -39,23 +39,23 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-        guess_monophonic_ = true;
-        STDOUT.print("monophonic");
+	guess_monophonic_ = true;
+	STDOUT.print("monophonic");
       } else {
-        guess_monophonic_ = false;
-        STDOUT.print("hybrid");
+	guess_monophonic_ = false;
+	STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;
       STDOUT.print("polyphonic");
     }
-    
+	
     STDOUT.println(" font.");
     SaberBase::Link(this);
     SetHumVolume(1.0);
     state_ = STATE_OFF;
   }
-  
+
   enum State {
     STATE_OFF,
     STATE_OUT,
@@ -63,7 +63,7 @@ public:
     STATE_HUM_ON,
     STATE_HUM_FADE_OUT,
   };
-  
+
   void Deactivate() {
     lock_player_.Free();
     hum_player_.Free();
@@ -72,7 +72,7 @@ public:
     second_swing_player_.Free();
     SaberBase::Unlink(this);
   }
-  
+
   RefPtr<BufferedWavPlayer> hum_player_;
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
@@ -84,8 +84,8 @@ public:
     if (!next_hum_player_) {
       next_hum_player_ = GetFreeWavPlayer();
       if (!next_hum_player_) {
-        STDOUT.println("Out of WAV players!");
-        return;
+	STDOUT.println("Out of WAV players!");
+	return;
       }
     }
     if (hum_player_) {
@@ -104,7 +104,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-  
+							   
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -114,7 +114,7 @@ public:
     }
     return player;
   }
-  
+
   void Play(Effect* monophonic, Effect* polyphonic) {
     if (polyphonic->files_found()) {
       PlayPolyphonic(polyphonic);
@@ -122,7 +122,7 @@ public:
       PlayMonophonic(monophonic, &hum);
     }
   }
-  
+
   void PlayCommon(Effect* effect) {
     if (guess_monophonic_) {
       PlayMonophonic(effect, &hum);
@@ -147,7 +147,7 @@ public:
       PlayMonophonic(&swing, &hum);
     }
   }
-  
+
   float SetSwingVolume(float swing_strength, float mixhum) {
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
@@ -161,6 +161,7 @@ public:
     }
     return mixhum;
   }
+  
   void SB_On() override {
     if (monophonic_hum_) {
       state_ = STATE_HUM_ON;
@@ -169,31 +170,31 @@ public:
       state_ = STATE_OUT;
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
-        hum_player_->set_volume_now(0);
-        hum_player_->PlayOnce(&hum);
-        hum_player_->PlayLoop(&hum);
-        hum_start_ = millis();
+	hum_player_->set_volume_now(0);
+	hum_player_->PlayOnce(&hum);
+	hum_player_->PlayLoop(&hum);
+	hum_start_ = millis();
       }
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&out);
       if (config_.humStart && tmp) {
-        int delay_ms = 1000 * tmp->length() - config_.humStart;
-        if (delay_ms > 0 && delay_ms < 30000) {
-          hum_start_ += delay_ms;
-        }
+	int delay_ms = 1000 * tmp->length() - config_.humStart;
+	if (delay_ms > 0 && delay_ms < 30000) {
+	  hum_start_ += delay_ms;
+	}
       }
     }
   }
-  
+
   void SB_Off() override {
     if (monophonic_hum_) {
       size_t total = poweroff.files_found() + pwroff.files_found();
       if (total) {
-        state_ = STATE_OFF;
-        if ((rand() % total) < poweroff.files_found()) {
-          PlayMonophonic(&poweroff, NULL);
-        } else {
-          PlayMonophonic(&pwroff, NULL);
-        }
+	state_ = STATE_OFF;
+	if ((rand() % total) < poweroff.files_found()) {
+	  PlayMonophonic(&poweroff, NULL);
+	} else {
+	  PlayMonophonic(&pwroff, NULL);
+	}
       }
     } else {
       state_ = STATE_HUM_FADE_OUT;
@@ -206,24 +207,24 @@ public:
   void SB_Blast() override { Play(&blaster, &blst); }
   void SB_Boot() override { PlayPolyphonic(&boot); }
   void SB_NewFont() override { PlayPolyphonic(&font); }
-  
+
   void SB_BeginLockup() override {
     if (lockup.files_found()) {
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-          drag.files_found()) {
-        PlayMonophonic(&drag, &drag);
+	  drag.files_found()) {
+	PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
         if (bgnlock.files_found()) {
           PlayMonophonic(&bgnlock, &lockup);
         } else {
           PlayMonophonic(&lockup, &lockup);
-        }
+	}
       }
     } else {
       Effect* e = &lock;
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-          drag.files_found()) {
-        e = &drag;
+	  drag.files_found()) {
+	e = &drag;
       }
       if (!lock_player_) {
         if (bgnlock.files_found()) {
@@ -231,26 +232,26 @@ public:
         } else {
           lock_player_ = PlayPolyphonic(e);
         }
-        
-        if (lock_player_) {
-          lock_player_->PlayLoop(e);
-        }
+
+	if (lock_player_) {
+	  lock_player_->PlayLoop(e);
+	}
       }
     }
   }
-  
+
   void SB_EndLockup() override {
     if (lock_player_) {
       // Polyphonic case
       lock_player_->set_fade_time(0.3);
-      
+
       if (endlock.files_found()) { // polyphonic end lock
         if (PlayPolyphonic(&endlock)) {
           // if playing an end lock fade the lockup faster
           lock_player_->set_fade_time(0.003);
-        }
+	}
       }
-      
+
       lock_player_->FadeAndStop();
       lock_player_.Free();
       return;
@@ -264,53 +265,53 @@ public:
       }
     }
   }
-  
+
   void SetHumVolume(float vol) override {
     if (!monophonic_hum_) {
       if (state_ != STATE_OFF && !hum_player_) {
-        hum_player_ = GetFreeWavPlayer();
-        if (hum_player_) {
-          hum_player_->set_volume_now(0);
-          hum_player_->PlayOnce(&hum);
-          hum_player_->PlayLoop(&hum);
-          hum_start_ = millis();
-        }
+	hum_player_ = GetFreeWavPlayer();
+	if (hum_player_) {
+	  hum_player_->set_volume_now(0);
+	  hum_player_->PlayOnce(&hum);
+	  hum_player_->PlayLoop(&hum);
+	  hum_start_ = millis();
+	}
       }
       if (!hum_player_) return;
       uint32_t m = micros();
       switch (state_) {
-        case STATE_OFF:
-          volume_ = 0.0f;
-          return;
-        case STATE_OUT:
-          volume_ = 0.0f;
-          if (millis() - hum_start_ < 0x7fffffffUL) {
-            state_ = STATE_HUM_FADE_IN;
-          }
-          break;
-        case STATE_HUM_FADE_IN: {
-          uint32_t delta = m - last_micros_;
-          volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
-          if (volume_ >= 1.0f) {
-            volume_ = 1.0f;
-            state_ = STATE_HUM_ON;
-          }
-          break;
-        }
-        case STATE_HUM_ON:
-          break;
-        case STATE_HUM_FADE_OUT: {
-          SaberBase::RequestMotion();
-          uint32_t delta = m - last_micros_;
-          volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
-          if (volume_ <= 0.0f) {
-            volume_ = 0.0f;
-            state_ = STATE_OFF;
-            hum_player_->FadeAndStop();
-            hum_player_.Free();
-          }
-          break;
-        }
+	case STATE_OFF:
+	  volume_ = 0.0f;
+	  return;
+	case STATE_OUT:
+	  volume_ = 0.0f;
+	  if (millis() - hum_start_ < 0x7fffffffUL) {
+	    state_ = STATE_HUM_FADE_IN;
+	  }
+	  break;
+	case STATE_HUM_FADE_IN: {
+	  uint32_t delta = m - last_micros_;
+	  volume_ += (delta / 1000000.0) / 0.2; // 0.2 seconds
+	  if (volume_ >= 1.0f) {
+	    volume_ = 1.0f;
+	    state_ = STATE_HUM_ON;
+	  }
+	  break;
+	}
+	case STATE_HUM_ON:
+	  break;
+	case STATE_HUM_FADE_OUT: {
+	  SaberBase::RequestMotion();
+	  uint32_t delta = m - last_micros_;
+	  volume_ -= (delta / 1000000.0) / 0.2; // 0.2 seconds
+	  if (volume_ <= 0.0f) {
+	    volume_ = 0.0f;
+	    state_ = STATE_OFF;
+	    hum_player_->FadeAndStop();
+	    hum_player_.Free();
+	  }
+	  break;
+	}
       }
       last_micros_ = m;
       vol *= volume_;
@@ -324,7 +325,7 @@ public:
     float speed = sqrtf(gyro.z * gyro.z + gyro.y * gyro.y);
     if (speed > 250.0) {
       if (!swinging_ && state_ != STATE_OFF &&
-          !(lockup.files_found() && SaberBase::Lockup())) {
+	  !(lockup.files_found() && SaberBase::Lockup())) {
         swinging_ = true;
         StartSwing();
       }
@@ -337,8 +338,8 @@ public:
     }
     SetHumVolume(vol);
   }
-  
-private:
+
+ private:
   uint32_t last_micros_;
   uint32_t hum_start_;
   bool monophonic_hum_;
@@ -349,4 +350,3 @@ private:
 };
 
 #endif
-

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -33,11 +33,11 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-       guess_monophonic_ = true;
-       STDOUT.print("monophonic");
+			 guess_monophonic_ = true;
+			 STDOUT.print("monophonic");
       } else {
-       guess_monophonic_ = false;
-       STDOUT.print("hybrid");
+			 guess_monophonic_ = false;
+			 STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -199,7 +199,7 @@ public:
     } else {
       state_ = STATE_HUM_FADE_OUT;
       PlayPolyphonic(&in);
-    }
+    } 
   }
   void SB_Clash() override { Play(&clash, &clsh); }
   void SB_Stab() override { PlayCommon(&stab); }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -11,6 +11,7 @@ public:
     CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 0.5f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.6f);
+	  CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.25f);
   }
   int humStart;
   int volHum;
@@ -19,6 +20,7 @@ public:
   float ProffieOSSwingVolumeSharpness;
   float ProffieOSMaxSwingVolume;
   float ProffieOSSwingOverlap;
+  float ProffieOSSmoothSwingDucking;
 };
 
 // Monophonic sound fonts are the most common.
@@ -153,15 +155,23 @@ public:
     }
   }
 
-  void SetSwingVolume(float swing_strength) override {
+  float SetSwingVolume(float swing_strength, mixhum) override {
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
         swing_player_->set_volume(accent_volume);
+        mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * swing_strength);
       }
       else {
         swing_player_.Free();
       }
+    }
+    // in the off chance this gets reduced below 0, we don't want to pass a negative number
+    // to the mixer.
+    if (mixhum > 0) {
+      return mixhum;
+    } else {
+      return 0.0;
     }
   }
   

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -139,13 +139,15 @@ public:
         // avoid overlapping swings, based on value set in ProffieOSSwingOverlap.  Value is
         // between 0 (full overlap) and 1.0 (no overlap)
         if (swing_player_->pos() / swing_player_->length() >= config_.ProffieOSSwingOverlap) {
-          swing_player_.Free();
+          RefPtr<BufferedWavPlayer> overlap_swing = swing_player_;
           swing_player_ = PlayPolyphonic(&swng);
+          overlap_swing->set_fade_time(overlap_swing->length() - overlap_swing->pos());
+          overlap_swing->FadeAndStop();
+          overlap_swing.Free();
         }
       }
       else if (!swing_player_) {
         swing_player_ = PlayPolyphonic(&swng);
-        swing_player_->set_volume_now(0);
       }
     } else {
       PlayMonophonic(&swing, &hum);
@@ -156,6 +158,7 @@ public:
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
+        swing_player_->set_fade_time(2);
         swing_player_->set_volume(accent_volume);
         mixhum = mixhum - mixhum * (config_.ProffieOSSmoothSwingDucking * accent_volume);
       }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -9,14 +9,12 @@ public:
     CONFIG_VARIABLE(volEff, 16);
     CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 0.5f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
-    CONFIG_VARIABLE(ProffieOSMaxSwingDucking, 1.0f);
   }
   int humStart;
   int volHum;
   int volEff;
   float ProffieOSSwingVolumeSharpness;
   float ProffieOSMaxSwingVolume;
-  float ProffieOSMaxSwingDucking;
 };
 
 // Monophonic sound fonts are the most common.
@@ -144,18 +142,16 @@ public:
     }
   }
 
-  float SetSwingVolume(float swing_strength, float mixhum) {
+  float SetSwingVolume(float swing_strength) override {
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;
         swing_player_->set_volume(accent_volume);
-        mixhum = mixhum * config_.ProffieOSMaxSwingDucking;
       }
       else {
         swing_player_.Free();
       }
     }
-    return mixhum;
   }
   
   void SB_On() override {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -122,11 +122,11 @@ public:
       PlayPolyphonic(effect);
     }
   }
-  void StartSwing(Effect* monophonic, Effect* polyphonic) override {
-    if (polyphonic->files_found()) {
-      swing_player_ = PlayPolyphonic(polyphonic);
+  void StartSwing() override {
+    if (!guess_monophonic_) {
+      swing_player_ = PlayPolyphonic(swng);
     } else {
-      PlayMonophonic(monophonic, &hum);
+      PlayMonophonic(swing, &hum);
     }
   }
 
@@ -318,7 +318,7 @@ public:
       if (!swinging_ && state_ != STATE_OFF &&
 	  !(lockup.files_found() && SaberBase::Lockup())) {
         swinging_ = true;
-        StartSwing(&swing, &swng);
+        StartSwing();
       }
     } else {
       swinging_ = false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -155,7 +155,7 @@ public:
     }
   }
 
-  float SetSwingVolume(float swing_strength, mixhum) override {
+  float SetSwingVolume(float swing_strength, float mixhum) override {
     if(swing_player_) {
       if (swing_player_->isPlaying()) {
         float accent_volume = powf(swing_strength, config_.ProffieOSSwingVolumeSharpness) * config_.ProffieOSMaxSwingVolume;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -43,7 +43,7 @@ public:
       guess_monophonic_ = false;
       STDOUT.print("polyphonic");
     }
-      
+       
     STDOUT.println(" font.");
     SaberBase::Link(this);
     SetHumVolume(1.0);
@@ -96,7 +96,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-							 
+					  		 
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -173,7 +173,7 @@ public:
        int delay_ms = 1000 * tmp->length() - config_.humStart;
        if (delay_ms > 0 && delay_ms < 30000) {
          hum_start_ += delay_ms;
-        }
+       }
       }
     }
   }
@@ -205,7 +205,7 @@ public:
     if (lockup.files_found()) {
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
          drag.files_found()) {
-       PlayMonophonic(&drag, &drag);
+        PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
         if (bgnlock.files_found()) {
          PlayMonophonic(&bgnlock, &lockup);
@@ -219,15 +219,16 @@ public:
        e = &drag;
       }
       if (!lock_player_) {
+        if (bgnlock.files_found()) {
+        lock_player_ = PlayPolyphonic(&bgnlock);
+      } else {
           lock_player_ = PlayPolyphonic(e);
-      }
+        }
       
       if (lock_player_) {
        if (bgnlock.files_found()) {
         lock_player_ = PlayPolyphonic(&bgnlock);
-        } else {
-          lock_player_ = PlayPolyphonic(e);
-        }
+        
         lock_player_->PlayLoop(e);
       }
     }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -11,7 +11,7 @@ public:
     CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 0.5f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.6f);
-	  CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.25f);
+    CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.25f);
   }
   int humStart;
   int volHum;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -33,23 +33,23 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-        guess_monophonic_ = true;
-        STDOUT.print("monophonic");
+       guess_monophonic_ = true;
+       STDOUT.print("monophonic");
       } else {
-        guess_monophonic_ = false;
-        STDOUT.print("hybrid");
+       guess_monophonic_ = false;
+       STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;
       STDOUT.print("polyphonic");
     }
-    
+      
     STDOUT.println(" font.");
     SaberBase::Link(this);
     SetHumVolume(1.0);
     state_ = STATE_OFF;
   }
-  
+
   enum State {
     STATE_OFF,
     STATE_OUT,
@@ -57,14 +57,15 @@ public:
     STATE_HUM_ON,
     STATE_HUM_FADE_OUT,
   };
-  
+
   void Deactivate() {
     lock_player_.Free();
     hum_player_.Free();
     next_hum_player_.Free();
+    swing_player_.Free();
     SaberBase::Unlink(this);
   }
-  
+
   RefPtr<BufferedWavPlayer> hum_player_;
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
@@ -75,8 +76,8 @@ public:
     if (!next_hum_player_) {
       next_hum_player_ = GetFreeWavPlayer();
       if (!next_hum_player_) {
-        STDOUT.println("Out of WAV players!");
-        return;
+       STDOUT.println("Out of WAV players!");
+       return;
       }
     }
     if (hum_player_) {
@@ -95,7 +96,7 @@ public:
     hum_player_->PlayOnce(f);
     if (loop) hum_player_->PlayLoop(loop);
   }
-  
+							 
   RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
     EnableAmplifier();
     RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
@@ -105,7 +106,7 @@ public:
     }
     return player;
   }
-  
+
   void Play(Effect* monophonic, Effect* polyphonic) {
     if (polyphonic->files_found()) {
       PlayPolyphonic(polyphonic);
@@ -113,7 +114,7 @@ public:
       PlayMonophonic(monophonic, &hum);
     }
   }
-  
+
   void PlayCommon(Effect* effect) {
     if (guess_monophonic_) {
       PlayMonophonic(effect, &hum);
@@ -162,31 +163,31 @@ public:
       state_ = STATE_OUT;
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
-        hum_player_->set_volume_now(0);
-        hum_player_->PlayOnce(&hum);
-        hum_player_->PlayLoop(&hum);
-        hum_start_ = millis();
+       hum_player_->set_volume_now(0);
+       hum_player_->PlayOnce(&hum);
+       hum_player_->PlayLoop(&hum);
+       hum_start_ = millis();
       }
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&out);
       if (config_.humStart && tmp) {
-        int delay_ms = 1000 * tmp->length() - config_.humStart;
-        if (delay_ms > 0 && delay_ms < 30000) {
-          hum_start_ += delay_ms;
+       int delay_ms = 1000 * tmp->length() - config_.humStart;
+       if (delay_ms > 0 && delay_ms < 30000) {
+         hum_start_ += delay_ms;
         }
       }
     }
   }
-  
+
   void SB_Off() override {
     if (monophonic_hum_) {
       size_t total = poweroff.files_found() + pwroff.files_found();
       if (total) {
-        state_ = STATE_OFF;
-        if ((rand() % total) < poweroff.files_found()) {
-          PlayMonophonic(&poweroff, NULL);
-        } else {
-          PlayMonophonic(&pwroff, NULL);
-        }
+       state_ = STATE_OFF;
+       if ((rand() % total) < poweroff.files_found()) {
+         PlayMonophonic(&poweroff, NULL);
+       } else {
+         PlayMonophonic(&pwroff, NULL);
+       }
       }
     } else {
       state_ = STATE_HUM_FADE_OUT;
@@ -199,32 +200,39 @@ public:
   void SB_Blast() override { Play(&blaster, &blst); }
   void SB_Boot() override { PlayPolyphonic(&boot); }
   void SB_NewFont() override { PlayPolyphonic(&font); }
-  
+
   void SB_BeginLockup() override {
     if (lockup.files_found()) {
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-          drag.files_found()) {
-        PlayMonophonic(&drag, &drag);
+         drag.files_found()) {
+       PlayMonophonic(&drag, &drag);
       } else if (lockup.files_found()) {
-        
+        if (bgnlock.files_found()) {
+         PlayMonophonic(&bgnlock, &lockup);
+        } else {
           PlayMonophonic(&lockup, &lockup);
       }
     } else {
       Effect* e = &lock;
       if (SaberBase::Lockup() == SaberBase::LOCKUP_DRAG &&
-          drag.files_found()) {
-        e = &drag;
+         drag.files_found()) {
+       e = &drag;
       }
       if (!lock_player_) {
           lock_player_ = PlayPolyphonic(e);
       }
       
       if (lock_player_) {
+       if (bgnlock.files_found()) {
+        lock_player_ = PlayPolyphonic(&bgnlock);
+        } else {
+          lock_player_ = PlayPolyphonic(e);
+        }
         lock_player_->PlayLoop(e);
       }
     }
   }
-  
+
   void SB_EndLockup() override {
     if (lock_player_) {
       // Polyphonic case

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -33,11 +33,11 @@ public:
     guess_monophonic_ = false;
     if (monophonic_hum_) {
       if ((clash.files_found() || blaster.files_found() || swing.files_found())) {
-			 guess_monophonic_ = true;
-			 STDOUT.print("monophonic");
+       guess_monophonic_ = true;
+       STDOUT.print("monophonic");
       } else {
-			 guess_monophonic_ = false;
-			 STDOUT.print("hybrid");
+       guess_monophonic_ = false;
+       STDOUT.print("hybrid");
       }
     } else {
       guess_monophonic_ = false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -18,6 +18,7 @@ public:
   float ProffieOSSwingSpeedThreshold;
   float ProffieOSSwingVolumeSharpness;
   float ProffieOSMaxSwingVolume;
+  float ProffieOSSwingOverlap;
 };
 
 // Monophonic sound fonts are the most common.

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -12,6 +12,7 @@ public:
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
     CONFIG_VARIABLE(ProffieOSSwingOverlap, 0.5f);
     CONFIG_VARIABLE(ProffieOSSmoothSwingDucking, 0.0f);
+    CONFIG_VARIABLE(ProffieOSSwingLowerThreshold, 0.8f);
   }
   int humStart;
   int volHum;
@@ -21,6 +22,7 @@ public:
   float ProffieOSMaxSwingVolume;
   float ProffieOSSwingOverlap;
   float ProffieOSSmoothSwingDucking;
+  float ProffieOSSwingLowerThreshold;
 };
 
 // Monophonic sound fonts are the most common.
@@ -344,7 +346,8 @@ public:
       }
       float swing_strength = std::min<float>(1.0, speed / config_.ProffieOSSwingSpeedThreshold);
       SetSwingVolume(swing_strength, 1.0);
-    } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold * 0.8) {
+    } else if (swinging_ && speed <= config_.ProffieOSSwingSpeedThreshold * 
+               ProffieOSSwingLowerThreshold, config_.ProffieOSSwingLowerThreshold) {
       swinging_ = false;
     }
     float vol = 1.0f;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -7,7 +7,7 @@ public:
     CONFIG_VARIABLE(humStart, 100);
     CONFIG_VARIABLE(volHum, 15);
     CONFIG_VARIABLE(volEff, 16);
-	  CONFIG_VARIABLE(ProffieOSSwingSpeedThreshold, 250.0f);
+    CONFIG_VARIABLE(ProffieOSSwingSpeedThreshold, 250.0f);
     CONFIG_VARIABLE(ProffieOSSwingVolumeSharpness, 0.5f);
     CONFIG_VARIABLE(ProffieOSMaxSwingVolume, 3.0f);
   }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -164,7 +164,9 @@ public:
           }
           if (on_) {
             // We need to stop setting the volume when off, or playback may never stop.
-            delegate_->SetSwingVolume(swing_strength); 
+            if (accent_swings_present) {
+              mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
+            }
             A.set_volume(mixhum * mixab);
             B.set_volume(mixhum * (1.0 - mixab));
           }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -166,12 +166,7 @@ public:
 	    // We need to stop setting the volume when off, or playback may never stop.
 	    A.set_volume(mixhum * mixab);
 	    B.set_volume(mixhum * (1.0 - mixab));
-      if (delegate_->IsSwingPlaying()) {
-        mixhum = delegate_->SetSwingVolume(swing_strength,
-        smooth_swing_config.AccentSwingVolumeSharpness,
-        smooth_swing_config.MaxAccentSwingVolume,
-        smooth_swing_config.MaxAccentSwingDucking, mixhum);
-	    }
+      mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
 	  }
           break;
         }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -16,7 +16,7 @@ public:
       STDOUT.println("Warning, swingl and swingh should have the same number of files.");
     }
     swings_ = std::min<size_t>(swingl.files_found(), swingh.files_found());
-    //check for swngxx files to use as accent swings
+    // check for swngxx files to use as accent swings
     if ((swng.files_found() || swing.files_found()) > 0 && smooth_swing_config.AccentSwingSpeedThreshold > 0.0) {
       STDOUT.println("Accent Swings Enabled.");
       STDOUT.print("Polyphonic swings: ");

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -143,18 +143,7 @@ public:
             1.0 - mixhum * smooth_swing_config.MaximumHumDucking / 100.0;
 
           mixhum *= smooth_swing_config.MaxSwingVolume;
-
-	  if (on_) {
-	  // We need to stop setting the volume when off, or playback may never stop.
-      A.set_volume(mixhum * mixab);
-      B.set_volume(mixhum * (1.0 - mixab));
-      if (delegate_->IsSwingPlaying()) {
-        mixhum = delegate_->SetSwingVolume(swing_strength,
-        smooth_swing_config.AccentSwingVolumeSharpness,
-        smooth_swing_config.MaxAccentSwingVolume,
-        smooth_swing_config.MaxAccentSwingDucking, mixhum);
-      }
-      if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
+       if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
         STDOUT.print("speed: ");
         STDOUT.print(speed);
         STDOUT.print(" R: ");
@@ -170,15 +159,23 @@ public:
         STDOUT.print("  mixab: ");
         STDOUT.print(mixab);
         STDOUT.print("  hum_volume: ");
-        STDOUT.print(hum_volume);
-        STDOUT.print("  accent_volume: ");
-        STDOUT.println(accent_volume);
+        STDOUT.println(hum_volume);
       }
-      break;
-        }
-        A.set_volume(0);
-        B.set_volume(0);
-        state_ = SwingState::OUT;
+	    if (on_) {
+	      // We need to stop setting the volume when off, or playback may never stop.
+        A.set_volume(mixhum * mixab);
+        B.set_volume(mixhum * (1.0 - mixab));
+        if (delegate_->IsSwingPlaying()) {
+          mixhum = delegate_->SetSwingVolume(swing_strength,
+          smooth_swing_config.AccentSwingVolumeSharpness,
+          smooth_swing_config.MaxAccentSwingVolume,
+          smooth_swing_config.MaxAccentSwingDucking, mixhum);
+	      }
+        break;
+      }
+      A.set_volume(0);
+      B.set_volume(0);
+      state_ = SwingState::OUT;
 
       case SwingState::OUT:
         if (!A.isOff() || !B.isOff()) {

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -119,7 +119,7 @@ public:
         if (speed >=smooth_swing_config.AccentSwingSpeedThreshold &&
             accent_swings_present &&
             (A.player->isPlaying() || B.player->isPlaying())) {
-          delegate_->StartSwing();
+          delegate_->StartSwing(true);
         }
         if (speed >= smooth_swing_config.SwingStrengthThreshold * 0.9) {
           float swing_strength =
@@ -130,7 +130,7 @@ public:
           // that is done.
           while (A.end() < 0.0) {
             B.midpoint = A.midpoint + 180.0;
-	    Swap();
+            Swap();
           }
           float mixab = 0.0;
           if (A.begin() < 0.0)
@@ -162,12 +162,12 @@ public:
             STDOUT.print("  hum_volume: ");
             STDOUT.println(hum_volume);
           }
-	  if (on_) {
-	    // We need to stop setting the volume when off, or playback may never stop.
-      delegate_->SetSwingVolume(swing_strength);
-	    A.set_volume(mixhum * mixab);
-	    B.set_volume(mixhum * (1.0 - mixab));
-	  }
+          if (on_) {
+            // We need to stop setting the volume when off, or playback may never stop.
+            delegate_->SetSwingVolume(swing_strength); 
+            A.set_volume(mixhum * mixab);
+            B.set_volume(mixhum * (1.0 - mixab));
+          }
           break;
         }
         A.set_volume(0);
@@ -194,8 +194,8 @@ private:
     }
     void Play(Effect* effect, float start = 0.0) {
       if (!player) {
-	player = GetFreeWavPlayer();
-	if (!player) return;
+        player = GetFreeWavPlayer();
+        if (!player) return;
       }
       player->set_volume(0.0);
       player->PlayOnce(effect, start);

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -8,6 +8,7 @@
 class SmoothSwingV2 : public SaberBasePassThrough {
 public:
   SmoothSwingV2() : SaberBasePassThrough() {}
+
   void Activate(SaberBase* base_font) {
     STDOUT.println("Activating SmoothSwing V2");
     SetDelegate(base_font);
@@ -28,16 +29,19 @@ public:
       STDOUT.print("Accent Swings NOT Detected: ");
     }
   }
+
   void Deactivate() {
     SetDelegate(NULL);
     A.Free();
     B.Free();
   }
+
   void Swap() {
     Data C = A;
     A = B;
     B = C;
   }
+
   // Should only be done when the volume is near zero.
   void PickRandomSwing() {
     if (!on_) return;
@@ -57,8 +61,9 @@ public:
     float t1_offset = random(1000) / 1000.0 * 50 + 10;
     A.SetTransition(t1_offset, smooth_swing_config.Transition1Degrees);
     B.SetTransition(t1_offset + 180.0,
-                    smooth_swing_config.Transition2Degrees);
+      smooth_swing_config.Transition2Degrees);
   }
+
   void SB_On() override {
     on_ = true;
     // Starts hum, etc.
@@ -74,11 +79,13 @@ public:
     B.Off();
     delegate_->SB_Off();
   }
+
   enum class SwingState {
     OFF, // waiting for swing to start
     ON,  // swinging
     OUT, // Waiting for sound to fade out
   };
+
   void SB_Motion(const Vec3& raw_gyro, bool clear) override {
     if (clear) {
       gyro_filter_.filter(raw_gyro);
@@ -116,65 +123,64 @@ public:
         }
         if (speed >= smooth_swing_config.SwingStrengthThreshold * 0.9) {
           float swing_strength =
-          std::min<float>(1.0, speed / smooth_swing_config.SwingSensitivity);
+            std::min<float>(1.0, speed / smooth_swing_config.SwingSensitivity);
           A.rotate(-speed * delta / 1000000.0);
           // If the current transition is done, switch A & B,
           // and set the next transition to be 180 degrees from the one
           // that is done.
           while (A.end() < 0.0) {
             B.midpoint = A.midpoint + 180.0;
-            Swap();
+	    Swap();
           }
-          float accent_volume = 0.0;
           float mixab = 0.0;
           if (A.begin() < 0.0)
             mixab = clamp(- A.begin() / A.width, 0.0, 1.0);
-          
+
           float mixhum =
-          powf(swing_strength, smooth_swing_config.SwingSharpness);
-          
+            powf(swing_strength, smooth_swing_config.SwingSharpness);
+
           hum_volume =
-          1.0 - mixhum * smooth_swing_config.MaximumHumDucking / 100.0;
-          
+            1.0 - mixhum * smooth_swing_config.MaximumHumDucking / 100.0;
+
           mixhum *= smooth_swing_config.MaxSwingVolume;
-          
-          if (on_) {
-            // We need to stop setting the volume when off, or playback may never stop.
-            A.set_volume(mixhum * mixab);
-            B.set_volume(mixhum * (1.0 - mixab));
-            //This volume will scale with swing speed but is modulated by AccentSwingVolumeSharpness.
-            if (delegate_->IsSwingPlaying()) {
-              mixhum = delegate_->SetSwingVolume(swing_strength,
-              smooth_swing_config.AccentSwingVolumeSharpness,
-              smooth_swing_config.MaxAccentSwingVolume,
-              smooth_swing_config.MaxAccentSwingDucking, mixhum);
-            }
+
+	      if (on_) {
+	        // We need to stop setting the volume when off, or playback may never stop.
+	        A.set_volume(mixhum * mixab);
+	        B.set_volume(mixhum * (1.0 - mixab));
+          if (delegate_->IsSwingPlaying()) {
+            mixhum = delegate_->SetSwingVolume(swing_strength,
+            smooth_swing_config.AccentSwingVolumeSharpness,
+            smooth_swing_config.MaxAccentSwingVolume,
+            smooth_swing_config.MaxAccentSwingDucking, mixhum);
           }
-          if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
-            STDOUT.print("speed: ");
-            STDOUT.print(speed);
-            STDOUT.print(" R: ");
-            STDOUT.print(-speed * delta / 1000000.0);
-            STDOUT.print(" MP: ");
-            STDOUT.print(A.midpoint);
-            STDOUT.print(" B: ");
-            STDOUT.print(A.begin());
-            STDOUT.print(" E: ");
-            STDOUT.print(A.end());
-            STDOUT.print("  mixhum: ");
-            STDOUT.print(mixhum);
-            STDOUT.print("  mixab: ");
-            STDOUT.print(mixab);
-            STDOUT.print("  hum_volume: ");
-            STDOUT.print(hum_volume);
-            STDOUT.print("  accent_volume: ");
-            STDOUT.println(accent_volume);
-          }
+	      }
+        if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
+          STDOUT.print("speed: ");
+          STDOUT.print(speed);
+          STDOUT.print(" R: ");
+          STDOUT.print(-speed * delta / 1000000.0);
+          STDOUT.print(" MP: ");
+          STDOUT.print(A.midpoint);
+          STDOUT.print(" B: ");
+          STDOUT.print(A.begin());
+          STDOUT.print(" E: ");
+          STDOUT.print(A.end());
+          STDOUT.print("  mixhum: ");
+          STDOUT.print(mixhum);
+          STDOUT.print("  mixab: ");
+          STDOUT.print(mixab);
+          STDOUT.print("  hum_volume: ");
+          STDOUT.print(hum_volume);
+          STDOUT.print("  accent_volume: ");
+          STDOUT.println(accent_volume);
+        }
           break;
         }
         A.set_volume(0);
         B.set_volume(0);
         state_ = SwingState::OUT;
+
       case SwingState::OUT:
         if (!A.isOff() || !B.isOff()) {
           if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
@@ -187,6 +193,7 @@ public:
     // Must always set hum volume, or fade-out doesn't work.
     delegate_->SetHumVolume(hum_volume);
   }
+
 private:
   struct Data {
     void set_volume(float v) {
@@ -194,8 +201,8 @@ private:
     }
     void Play(Effect* effect, float start = 0.0) {
       if (!player) {
-        player = GetFreeWavPlayer();
-        if (!player) return;
+	player = GetFreeWavPlayer();
+	if (!player) return;
       }
       player->set_volume(0.0);
       player->PlayOnce(effect, start);
@@ -233,11 +240,12 @@ private:
   };
   Data A;
   Data B;
+
   uint32_t last_random_ = 0;
   bool on_ = false;;
+  bool accent_swings_present = false;
   BoxFilter<Vec3, 3> gyro_filter_;
   int swings_;
-  bool accent_swings_present = false;
   uint32_t last_micros_;
   SwingState state_ = SwingState::OFF;;
 };

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -143,39 +143,41 @@ public:
             1.0 - mixhum * smooth_swing_config.MaximumHumDucking / 100.0;
 
           mixhum *= smooth_swing_config.MaxSwingVolume;
-       if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
-        STDOUT.print("speed: ");
-        STDOUT.print(speed);
-        STDOUT.print(" R: ");
-        STDOUT.print(-speed * delta / 1000000.0);
-        STDOUT.print(" MP: ");
-        STDOUT.print(A.midpoint);
-        STDOUT.print(" B: ");
-        STDOUT.print(A.begin());
-        STDOUT.print(" E: ");
-        STDOUT.print(A.end());
-        STDOUT.print("  mixhum: ");
-        STDOUT.print(mixhum);
-        STDOUT.print("  mixab: ");
-        STDOUT.print(mixab);
-        STDOUT.print("  hum_volume: ");
-        STDOUT.println(hum_volume);
-      }
-	    if (on_) {
-	      // We need to stop setting the volume when off, or playback may never stop.
-        A.set_volume(mixhum * mixab);
-        B.set_volume(mixhum * (1.0 - mixab));
-        if (delegate_->IsSwingPlaying()) {
-          mixhum = delegate_->SetSwingVolume(swing_strength,
-          smooth_swing_config.AccentSwingVolumeSharpness,
-          smooth_swing_config.MaxAccentSwingVolume,
-          smooth_swing_config.MaxAccentSwingDucking, mixhum);
-	      }
-        break;
-      }
-      A.set_volume(0);
-      B.set_volume(0);
-      state_ = SwingState::OUT;
+
+          if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
+            STDOUT.print("speed: ");
+            STDOUT.print(speed);
+            STDOUT.print(" R: ");
+            STDOUT.print(-speed * delta / 1000000.0);
+            STDOUT.print(" MP: ");
+            STDOUT.print(A.midpoint);
+            STDOUT.print(" B: ");
+            STDOUT.print(A.begin());
+            STDOUT.print(" E: ");
+            STDOUT.print(A.end());
+            STDOUT.print("  mixhum: ");
+            STDOUT.print(mixhum);
+            STDOUT.print("  mixab: ");
+            STDOUT.print(mixab);
+            STDOUT.print("  hum_volume: ");
+            STDOUT.println(hum_volume);
+          }
+	  if (on_) {
+	    // We need to stop setting the volume when off, or playback may never stop.
+	    A.set_volume(mixhum * mixab);
+	    B.set_volume(mixhum * (1.0 - mixab));
+      if (delegate_->IsSwingPlaying()) {
+        mixhum = delegate_->SetSwingVolume(swing_strength,
+        smooth_swing_config.AccentSwingVolumeSharpness,
+        smooth_swing_config.MaxAccentSwingVolume,
+        smooth_swing_config.MaxAccentSwingDucking, mixhum);
+	    }
+	  }
+          break;
+        }
+        A.set_volume(0);
+        B.set_volume(0);
+        state_ = SwingState::OUT;
 
       case SwingState::OUT:
         if (!A.isOff() || !B.isOff()) {

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -24,7 +24,7 @@ public:
       STDOUT.print("Monophonic swings: ");
       STDOUT.println(swing.files_found());
       accent_swings_present = true;
-    }else{
+    } else {
       accent_swings_present = false;
       STDOUT.print("Accent Swings NOT Detected: ");
     }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -164,9 +164,7 @@ public:
           }
           if (on_) {
             // We need to stop setting the volume when off, or playback may never stop.
-            if (accent_swings_present) {
-              mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
-            }
+            mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
             A.set_volume(mixhum * mixab);
             B.set_volume(mixhum * (1.0 - mixab));
           }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -119,7 +119,7 @@ public:
         if (speed >=smooth_swing_config.AccentSwingSpeedThreshold &&
             accent_swings_present &&
             (A.player->isPlaying() || B.player->isPlaying())) {
-          delegate_->StartSwing(&swing, &swng);
+          delegate_->StartSwing();
         }
         if (speed >= smooth_swing_config.SwingStrengthThreshold * 0.9) {
           float swing_strength =

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -164,9 +164,9 @@ public:
           }
 	  if (on_) {
 	    // We need to stop setting the volume when off, or playback may never stop.
+      mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
 	    A.set_volume(mixhum * mixab);
 	    B.set_volume(mixhum * (1.0 - mixab));
-      mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
 	  }
           break;
         }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -115,7 +115,7 @@ public:
         state_ = SwingState::ON;
         
       case SwingState::ON:
-        //trigger accent swing
+        // trigger accent swing
         if (speed >=smooth_swing_config.AccentSwingSpeedThreshold &&
             accent_swings_present &&
             (A.player->isPlaying() || B.player->isPlaying())) {

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -119,7 +119,7 @@ public:
         if (speed >=smooth_swing_config.AccentSwingSpeedThreshold &&
             accent_swings_present &&
             (A.player->isPlaying() || B.player->isPlaying())) {
-          delegate_->StartSwing(true);
+          delegate_->StartSwing();
         }
         if (speed >= smooth_swing_config.SwingStrengthThreshold * 0.9) {
           float swing_strength =

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -164,7 +164,7 @@ public:
           }
 	  if (on_) {
 	    // We need to stop setting the volume when off, or playback may never stop.
-      mixhum = delegate_->SetSwingVolume(swing_strength, mixhum);
+      delegate_->SetSwingVolume(swing_strength);
 	    A.set_volume(mixhum * mixab);
 	    B.set_volume(mixhum * (1.0 - mixab));
 	  }

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -130,7 +130,7 @@ public:
           // that is done.
           while (A.end() < 0.0) {
             B.midpoint = A.midpoint + 180.0;
-            Swap();
+	    Swap();
           }
           float mixab = 0.0;
           if (A.begin() < 0.0)
@@ -194,8 +194,8 @@ private:
     }
     void Play(Effect* effect, float start = 0.0) {
       if (!player) {
-        player = GetFreeWavPlayer();
-        if (!player) return;
+	player = GetFreeWavPlayer();
+	if (!player) return;
       }
       player->set_volume(0.0);
       player->PlayOnce(effect, start);

--- a/sound/smooth_swing_v2.h
+++ b/sound/smooth_swing_v2.h
@@ -144,38 +144,37 @@ public:
 
           mixhum *= smooth_swing_config.MaxSwingVolume;
 
-	      if (on_) {
-	        // We need to stop setting the volume when off, or playback may never stop.
-	        A.set_volume(mixhum * mixab);
-	        B.set_volume(mixhum * (1.0 - mixab));
-          if (delegate_->IsSwingPlaying()) {
-            mixhum = delegate_->SetSwingVolume(swing_strength,
-            smooth_swing_config.AccentSwingVolumeSharpness,
-            smooth_swing_config.MaxAccentSwingVolume,
-            smooth_swing_config.MaxAccentSwingDucking, mixhum);
-          }
-	      }
-        if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
-          STDOUT.print("speed: ");
-          STDOUT.print(speed);
-          STDOUT.print(" R: ");
-          STDOUT.print(-speed * delta / 1000000.0);
-          STDOUT.print(" MP: ");
-          STDOUT.print(A.midpoint);
-          STDOUT.print(" B: ");
-          STDOUT.print(A.begin());
-          STDOUT.print(" E: ");
-          STDOUT.print(A.end());
-          STDOUT.print("  mixhum: ");
-          STDOUT.print(mixhum);
-          STDOUT.print("  mixab: ");
-          STDOUT.print(mixab);
-          STDOUT.print("  hum_volume: ");
-          STDOUT.print(hum_volume);
-          STDOUT.print("  accent_volume: ");
-          STDOUT.println(accent_volume);
-        }
-          break;
+	  if (on_) {
+	  // We need to stop setting the volume when off, or playback may never stop.
+      A.set_volume(mixhum * mixab);
+      B.set_volume(mixhum * (1.0 - mixab));
+      if (delegate_->IsSwingPlaying()) {
+        mixhum = delegate_->SetSwingVolume(swing_strength,
+        smooth_swing_config.AccentSwingVolumeSharpness,
+        smooth_swing_config.MaxAccentSwingVolume,
+        smooth_swing_config.MaxAccentSwingDucking, mixhum);
+      }
+      if (monitor.ShouldPrint(Monitoring::MonitorSwings)) {
+        STDOUT.print("speed: ");
+        STDOUT.print(speed);
+        STDOUT.print(" R: ");
+        STDOUT.print(-speed * delta / 1000000.0);
+        STDOUT.print(" MP: ");
+        STDOUT.print(A.midpoint);
+        STDOUT.print(" B: ");
+        STDOUT.print(A.begin());
+        STDOUT.print(" E: ");
+        STDOUT.print(A.end());
+        STDOUT.print("  mixhum: ");
+        STDOUT.print(mixhum);
+        STDOUT.print("  mixab: ");
+        STDOUT.print(mixab);
+        STDOUT.print("  hum_volume: ");
+        STDOUT.print(hum_volume);
+        STDOUT.print("  accent_volume: ");
+        STDOUT.println(accent_volume);
+      }
+      break;
         }
         A.set_volume(0);
         B.set_volume(0);


### PR DESCRIPTION
I couldn't get a clean pull from my current fork, so made a new one.  white space is still a mess on smoothswingv2.h but it's better than I was able to get on my original attempt.

Changes are, in brief

- added two new variables for smoothswing.ini (threshold and volume)
- added one new Data object in smooth_swing_v2.h to play the accent swing.  I gave up trying to pass the sounds up to the hybrid font.  This way works well enough
- I check for the presence of swng files
- select random swng file
- set volume of swing to match config file
- play swing file

It all seems to work well, I've tested on a couple fonts with good results.