### PR TITLE
Play sound when battery reaches min voltage

### DIFF
--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -102,6 +102,7 @@ public:                                                         \
   virtual void SB_##NAME TYPED_ARGS {}
 
 #define SABERBASEFUNCTIONS()					\
+  SABERFUN(LowBatt, (), ());                     		\
   SABERFUN(Clash, (), ());					\
   SABERFUN(Stab, (), ());					\
   SABERFUN(PreOn, (float* delay), (delay));			\

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -741,21 +741,22 @@ public:
 
   virtual void CheckLowBattery() {
     if (battery_monitor.low()) {
-      // TODO: FIXME
       if (current_style() && !current_style()->Charging()) {
-	LowBatteryOff();
-	
-	if (millis() - last_beep_ > 5000) {
+	if (SaberBase::IsOn()) {
+		LowBatteryOff();
+	} else if (millis() - last_beep_ > 15000) {  // (was 5000)
+		STDOUT.print(battery_monitor.battery());
+		STDOUT.println("v");
+		STDOUT.println(" ");
 #ifdef ENABLE_AUDIO
-	  // TODO: allow this to be replaced with WAV file
-	  talkie.Say(talkie_low_battery_15, 15);
+		SaberBase::DoLowBatt();
 #endif
-	  STDOUT << "Battery low :" << battery_monitor.battery() << "\n";
-	  last_beep_ = millis();
+		last_beep_ = millis();
 	}
       }
     }
   }
+
   
   uint32_t last_beep_;
   float current_tick_angle_ = 0.0;

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -745,9 +745,7 @@ public:
 	if (SaberBase::IsOn()) {
 	  LowBatteryOff();
 	} else if (millis() - last_beep_ > 15000) {  // (was 5000)
-	  STDOUT.print(battery_monitor.battery());
-	  STDOUT.println("v");
-	  STDOUT.println(" ");
+	  STDOUT << "Low battery: " << battery_monitor_.battery() << " volts\n";
 	  SaberBase::DoLowBatt();
 	  last_beep_ = millis();
 	}

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -748,9 +748,7 @@ public:
 	  STDOUT.print(battery_monitor.battery());
 	  STDOUT.println("v");
 	  STDOUT.println(" ");
-#ifdef ENABLE_AUDIO
 	  SaberBase::DoLowBatt();
-#endif
 	  last_beep_ = millis();
 	}
       }

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -742,17 +742,16 @@ public:
   virtual void CheckLowBattery() {
     if (battery_monitor.low()) {
       if (current_style() && !current_style()->Charging()) {
-	if (SaberBase::IsOn()) {
-	  LowBatteryOff();
-	} else if (millis() - last_beep_ > 15000) {  // (was 5000)
-	  STDOUT << "Low battery: " << battery_monitor_.battery() << " volts\n";
-	  SaberBase::DoLowBatt();
-	  last_beep_ = millis();
+        LowBatteryOff();
+        if (millis() - last_beep_ > 15000) {  // (was 5000)
+          STDOUT << "Low battery: " << battery_monitor.battery() << " volts\n";
+          SaberBase::DoLowBatt();
+          last_beep_ = millis();
 	}
       }
     }
   }
-  
+
   uint32_t last_beep_;
   float current_tick_angle_ = 0.0;
 

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -743,20 +743,19 @@ public:
     if (battery_monitor.low()) {
       if (current_style() && !current_style()->Charging()) {
 	if (SaberBase::IsOn()) {
-		LowBatteryOff();
+	  LowBatteryOff();
 	} else if (millis() - last_beep_ > 15000) {  // (was 5000)
-		STDOUT.print(battery_monitor.battery());
-		STDOUT.println("v");
-		STDOUT.println(" ");
+	  STDOUT.print(battery_monitor.battery());
+	  STDOUT.println("v");
+	  STDOUT.println(" ");
 #ifdef ENABLE_AUDIO
-		SaberBase::DoLowBatt();
+	  SaberBase::DoLowBatt();
 #endif
-		last_beep_ = millis();
+	  last_beep_ = millis();
 	}
       }
     }
   }
-
   
   uint32_t last_beep_;
   float current_tick_angle_ = 0.0;

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -487,6 +487,9 @@ EFFECT(reload);
 EFFECT(stun);
 EFFECT(unjam);
 
+// battery low
+EFFECT(lowbatt);	// battery low
+
 // TODO: Optimize this and make it possible
 // have the WAV reader use this.
 class EffectFileReader : public FileReader {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -548,10 +548,8 @@ public:
     return current_effect_length_;
   }
 
-  void SB_LowBatt() override
-  {
+  void SB_LowBatt() override {
     //play the fonts low battery sound if it exists
-    //TODO: if lowbatt does not exist in the font, then play a global sound (instead of a beep or a talkie)
     if (SFX_lowbatt) {
       PlayCommon(&SFX_lowbatt);
     } else {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -551,7 +551,7 @@ public:
   void SB_LowBatt() override
   {
     //play the fonts low battery sound if it exists.  Otherwise try to play a wave file on the root of the SD Card
-    if (SFX_lowbatt.files_found()) {
+    if (SFX_lowbatt) {
       PlayCommon(&SFX_lowbatt);
     } else {
       MountSDCard();

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -548,7 +548,19 @@ public:
     return current_effect_length_;
   }
 
-  void SB_LowBatt() override { PlayCommon(&SFX_lowbatt); }
+  void SB_LowBatt() override
+  {
+    //play the fonts low battery sound if it exists
+    //TODO: if lowbatt does not exist in the font, then play a global sound (instead of a beep or a talkie)
+    if (SFX_lowbatt) {
+      PlayCommon(&SFX_lowbatt);
+    } else {
+      STDOUT << "Battery low :" << battery_monitor.battery() << "\n";
+#ifdef ENABLE_AUDIO
+      talkie.Say(talkie_low_battery_15, 15);
+#endif
+    }
+  }
 	
  private:
   uint32_t last_micros_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -558,10 +558,7 @@ public:
       EnableAmplifier();
       RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
       if (player) {
-        STDOUT.print("Playing low battery lowbatt.wav");
         player->Play("lowbatt.wav");
-      } else {
-        STDOUT.println("No available WAV players.");
       }
     }
   }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -548,21 +548,8 @@ public:
     return current_effect_length_;
   }
 
-  void SB_LowBatt() override
-  {
-    //play the fonts low battery sound if it exists.  Otherwise try to play a wave file on the root of the SD Card
-    if (SFX_lowbatt) {
-      PlayCommon(&SFX_lowbatt);
-    } else {
-      MountSDCard();
-      EnableAmplifier();
-      RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
-      if (player) {
-        player->Play("lowbatt.wav");
-      }
-    }
-  }
-
+  void SB_LowBatt() override { PlayCommon(&SFX_lowbatt); }
+	
  private:
   uint32_t last_micros_;
   uint32_t hum_start_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -555,7 +555,6 @@ public:
     if (SFX_lowbatt) {
       PlayCommon(&SFX_lowbatt);
     } else {
-      STDOUT << "Battery low :" << battery_monitor.battery() << "\n";
 #ifdef ENABLE_AUDIO
       talkie.Say(talkie_low_battery_15, 15);
 #endif

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -548,6 +548,28 @@ public:
     return current_effect_length_;
   }
 
+	void SB_LowBatt() override
+	{
+		STDOUT.println(" ");
+		STDOUT.println("|| SB_LowBatt function start");
+		STDOUT.println(" ");
+
+		//play the fonts low battery sound if it exists.  Otherwise try to play a wave file on the root of the SD Card
+		if (SFX_lowbatt.files_found()) {
+			PlayCommon(&SFX_lowbatt);
+		} else {
+			MountSDCard();
+			EnableAmplifier();
+			RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+			if (player) {
+				STDOUT.print("Playing low battery lowbatt.wav");
+				player->Play("lowbatt.wav");
+			} else {
+				STDOUT.println("No available WAV players.");
+			}
+		}
+	}
+
 
  private:
   uint32_t last_micros_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -548,28 +548,23 @@ public:
     return current_effect_length_;
   }
 
-	void SB_LowBatt() override
-	{
-		STDOUT.println(" ");
-		STDOUT.println("|| SB_LowBatt function start");
-		STDOUT.println(" ");
-
-		//play the fonts low battery sound if it exists.  Otherwise try to play a wave file on the root of the SD Card
-		if (SFX_lowbatt.files_found()) {
-			PlayCommon(&SFX_lowbatt);
-		} else {
-			MountSDCard();
-			EnableAmplifier();
-			RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
-			if (player) {
-				STDOUT.print("Playing low battery lowbatt.wav");
-				player->Play("lowbatt.wav");
-			} else {
-				STDOUT.println("No available WAV players.");
-			}
-		}
-	}
-
+  void SB_LowBatt() override
+  {
+    //play the fonts low battery sound if it exists.  Otherwise try to play a wave file on the root of the SD Card
+    if (SFX_lowbatt.files_found()) {
+      PlayCommon(&SFX_lowbatt);
+    } else {
+      MountSDCard();
+      EnableAmplifier();
+      RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+      if (player) {
+        STDOUT.print("Playing low battery lowbatt.wav");
+        player->Play("lowbatt.wav");
+      } else {
+        STDOUT.println("No available WAV players.");
+      }
+    }
+  }
 
  private:
   uint32_t last_micros_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -549,7 +549,7 @@ public:
   }
 
   void SB_LowBatt() override {
-    //play the fonts low battery sound if it exists
+    // play the fonts low battery sound if it exists
     if (SFX_lowbatt) {
       PlayCommon(&SFX_lowbatt);
     } else {


### PR DESCRIPTION
I've expanded your work on the low battery detection and warning, so that besides shutting the saber off when it reaches min voltage...  I also play a wav file named lowbatt.wav.  the wav file is played every 10-15 seconds.   It looks first at the font/preset location, and if it does not find it, it then looks at the root of the sdcard.