### PR TITLE
Fix "blast" effect on ColorChange button press

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -193,7 +193,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifndef DISABLE_COLOR_CHANGE
       case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_ON | BUTTON_AUX):
         ToggleColorChangeMode();
-        break;
+	return true;
 #endif
 	
         // Lockup


### PR DESCRIPTION
I found a missing "return true;" in the prop file that was triggering a blast effect on ToggleColorChangeMode()