### PR TITLE
Two-tone beep for entering/exiting mode_volume_

### DIFF
--- a/props/saber_sa22c_buttons.h
+++ b/props/saber_sa22c_buttons.h
@@ -388,11 +388,13 @@ public:
 #endif
     if (!mode_volume_) {
       mode_volume_ = true;
-      beeper.Beep(0.5, 3000);
+      beeper.Beep(0.1, 2000);
+      beeper.Beep(0.1, 2500);
       STDOUT.println("Enter Volume Menu");
     } else {
       mode_volume_ = false;
-      beeper.Beep(0.5, 3000);
+      beeper.Beep(0.1, 2500);
+      beeper.Beep(0.1, 2000);
       STDOUT.println("Exit Volume Menu");
     }
     return true;


### PR DESCRIPTION
To help indicate to the user when they've entered and exited Volume Mode, changed the .5 second monotone beep to a quick two-tone beep, rising tone means entering mode, falling tone means exiting mode.