### PR TITLE
DimBlade change in real-time

### DIFF
--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -295,6 +295,11 @@ SaberBase::ColorChangeMode SaberBase::color_change_mode_ =
 bool SaberBase::on_ = false;
 uint32_t SaberBase::last_motion_request_ = 0;
 uint32_t SaberBase::current_variation_ = 0;
+#ifdef ENABLE_MENU_DIMBLADE
+SaberBase::DimChangeMode SaberBase::dim_change_mode_ =
+  SaberBase::DIM_CHANGE_MODE_NONE;
+uint32_t SaberBase::current_brightness_; // does not need to be initialized, takes setting from config.h
+#endif
 
 #include "common/box_filter.h"
 
@@ -582,7 +587,7 @@ ArgParserInterface* CurrentArgParser;
 #undef CONFIG_PROP
 
 #ifndef PROP_TYPE
-#include "props/saber.h"
+#include "props/saber_aat_1_button.h"
 #endif
 
 PROP_TYPE prop;

--- a/blades/dim_blade.h
+++ b/blades/dim_blade.h
@@ -1,13 +1,24 @@
 #ifndef BLADES_DIM_BLADE_WRAPPER_H
 #define BLADES_DIM_BLADE_WRAPPER_H
 
-class DimBladeWrapper : public BladeWrapper, BladeStyle {
+class DimBladeWrapper : public BladeWrapper, BladeStyle 
+#ifdef ENABLE_MENU_DIMBLADE
+      ,protected SaberBase
+#endif
+      {
 public:
   DimBladeWrapper(BladeBase* blade, int fraction) {
     blade_ = blade;
+#ifdef ENABLE_MENU_DIMBLADE
+    SaberBase::SetBrightness((float)fraction/16384.0*100.0);
+#else
     fraction_ = fraction;
-  }
+#endif
+    }
   void set(int led, Color16 c) override {
+#ifdef ENABLE_MENU_DIMBLADE
+    int fraction_ = SaberBase::GetCurrentBrightness();
+#endif
     Color16 ret;
     ret.r = clampi32((c.r * fraction_) >> 14, 0, 65535);
     ret.g = clampi32((c.g * fraction_) >> 14, 0, 65535);
@@ -62,7 +73,9 @@ public:
   
 private:
   BladeStyle *current_style_ = nullptr;
+#ifndef ENABLE_MENU_DIMBLADE
   int fraction_;
+#endif
 };
 
 // Reduces the brightness of the blade.

--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -81,6 +81,10 @@ public:
     ENTER_COLOR_CHANGE,
     EXIT_COLOR_CHANGE,
     CHANGE_COLOR,
+#ifdef ENABLE_MENU_DIMBLADE
+    ENTER_DIM_CHANGE,
+    EXIT_DIM_CHANGE,
+#endif
   };
 
   // 1.0 = kDefaultVolume
@@ -196,12 +200,42 @@ public:                                                         \
     }
   }
 
+#ifdef ENABLE_MENU_DIMBLADE
+  static uint32_t GetCurrentBrightness() {
+    return current_brightness_;//value from 0~16384
+  }
+  // For smooth updates or restore.
+  static void SetBrightness(float v) {
+    current_brightness_ = (int)(v * 16384 / 100.0);  
+    current_brightness_ = clampi32(current_brightness_, 0, 16384) ;
+  }
+
+  enum DimChangeMode {
+    DIM_CHANGE_MODE_NONE,
+    DIM_CHANGE_MODE_SMOOTH
+  };
+
+  static DimChangeMode GetDimChangeMode() { return dim_change_mode_; }
+  static void SetDimChangeMode(DimChangeMode  mode) {
+    dim_change_mode_ = mode;
+    if (mode == DIM_CHANGE_MODE_NONE) {
+      DoChange(EXIT_DIM_CHANGE);
+    } else {
+      DoChange(ENTER_DIM_CHANGE);
+    }
+  }
+#endif
+
 private:
   static bool on_;
   static LockupType lockup_;
   static uint32_t last_motion_request_;
   static uint32_t current_variation_;
   static ColorChangeMode color_change_mode_;
+#ifdef ENABLE_MENU_DIMBLADE
+  static uint32_t current_brightness_;
+  static DimChangeMode dim_change_mode_;
+#endif
   SaberBase* next_saber_;
 };
 

--- a/config/default_proffieboard_config.h
+++ b/config/default_proffieboard_config.h
@@ -12,7 +12,7 @@
 #include "proffieboard_config.h"
 #define NUM_BLADES 2
 #define NUM_BUTTONS 2
-#define VOLUME 1000
+#define VOLUME 100
 const unsigned int maxLedsPerStrip = 144;
 #define CLASH_THRESHOLD_G 1.0
 #define ENABLE_AUDIO
@@ -20,11 +20,12 @@ const unsigned int maxLedsPerStrip = 144;
 #define ENABLE_WS2811
 #define ENABLE_SD
 #define ENABLE_SERIAL
+#define ENABLE_MENU_DIMBLADE
 #endif
 
 #ifdef CONFIG_PRESETS
 Preset presets[] = {
-  { "TeensySF", "tracks/venus.wav",
+  { "common;TeensySF", "tracks/venus.wav", //menu sounds are in common folder
     StyleNormalPtr<CYAN, WHITE, 300, 800>(),
     StyleNormalPtr<CYAN, WHITE, 300, 800>(), "cyan"},
   { "SmthJedi", "tracks/mars.wav",
@@ -68,7 +69,9 @@ Preset presets[] = {
     StyleNormalPtr<BLACK, BLACK, 300, 800>(), "Battery\nLevel"}
 };
 BladeConfig blades[] = {
- { 0, WS2811BladePtr<97, WS2811_800kHz>(),
+ { 0, DimBlade(56.7,WS2811BladePtr<97, WS2811_800kHz>()), // sets initial blade brightness to 100.0% 
+                                                           // can be altered via menu or serial commands 
+                                                           // when ENABLE_MENU_DIMBLADE is defined
      SimpleBladePtr<CreeXPE2WhiteTemplate<550>,
                     CreeXPE2BlueTemplate<240>,
                     CreeXPE2BlueTemplate<240>, NoLED, bladePowerPin4, bladePowerPin5, bladePowerPin6, -1>(),

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -839,6 +839,18 @@ public:
 
 #endif
 
+#ifdef ENABLE_MENU_DIMBLADE
+   if (SaberBase::GetDimChangeMode() == SaberBase::DIM_CHANGE_MODE_SMOOTH) {
+        float delta = fmodf(fusor.angle2() - current_tick_angle_, M_PI * 2);//+ or - 2*pi from start point 0
+        current_tick_angle_ = fusor.angle2();
+        if (delta > M_PI) delta -= 2 * M_PI;//prevent pi jumps
+        if (delta < -M_PI) delta += 2 * M_PI;//prevent pi jumps
+        int32_t brightness_ = SaberBase::GetCurrentBrightness() + (int32_t)(delta * 5000); //a =+/- 1.5
+        brightness_ = clampi32(brightness_, 0, 16384);
+        SaberBase::SetBrightness((float)brightness_ / 16384.0 * 100);
+    }
+#endif
+
     Vec3 mss = fusor.mss();
     if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
         (mss.x > 7 || mss.x < -6)  &&
@@ -864,6 +876,23 @@ public:
 
 #ifdef IDLE_OFF_TIME
   uint32_t last_on_time_;
+#endif
+
+#ifdef ENABLE_MENU_DIMBLADE
+  //bool change_brightness_ = false;
+  //bool BrightnessChangeMode() { return change_brightness_; }
+  void ToggleBrightnessChangeMode() {
+    if (SaberBase::GetDimChangeMode() == SaberBase::DIM_CHANGE_MODE_NONE) {     
+      current_tick_angle_ = fusor.angle2();
+      //change_brightness_ =  true;
+      SaberBase::SetDimChangeMode(SaberBase::DIM_CHANGE_MODE_SMOOTH);
+    } else {
+        //change_brightness_ = false;
+        STDOUT.print("brightness set to: ");
+        STDOUT.println((float)SaberBase::GetCurrentBrightness()*100.0/16384.0);
+        SaberBase::SetDimChangeMode(SaberBase::DIM_CHANGE_MODE_NONE);
+    }
+  }
 #endif
 
 #ifndef DISABLE_COLOR_CHANGE
@@ -1283,6 +1312,24 @@ public:
     }
     if (!strcmp(cmd, "ccmode")) {
       ToggleColorChangeMode();
+      return true;
+    }
+#endif
+
+#ifdef ENABLE_MENU_DIMBLADE
+    if (!strcmp(cmd, "get_dim")) {
+      STDOUT.println((float)SaberBase::GetCurrentBrightness()/ 16384.0 *100.0);
+      return true;
+    }
+
+    if (!strcmp(cmd, "dimmode")) {
+      ToggleBrightnessChangeMode();
+      return true;
+    }
+
+    if (arg && (!strcmp(cmd, "dim"))) {
+      size_t dim = strtol(arg, NULL, 0);
+      SaberBase::SetBrightness((float)dim);
       return true;
     }
 #endif

--- a/props/saber_aat_1_button.h
+++ b/props/saber_aat_1_button.h
@@ -1,0 +1,294 @@
+// Saber Art and Tech Buttons props file, includes the following changes
+// Also include prop_base.h, for it contains the volume menu by rotating the Hilt
+//
+// Button configs:
+//
+// 1 Button:
+// Activate - short click while OFF
+// Activate Muted - fast double click while OFF
+// Turn off blade - hold and wait till blade is off while ON
+// Lockup - hold + hit clash while ON pointing the blade tip up
+// Drag - hold + hit clash while ON pointing the blade tip down
+// Blaster Blocks - short click while ON
+// Force Effects - Twist the hilt while ON
+// Play/Stop Music - hold and release while OFF
+// Next Preset - Hold and clash  while OFF
+// Prev Preset - Hold and twist while OFF
+// Enter/Exit menu   - hold and wait while off/in menu mode
+// Next menu/confirm - short click while in menu mode
+
+//TWIST;
+// Force effect while on
+// revert to first (default) preset while OFF
+// Color Change mode - Twist hilt while in Colorchange mode to change blade color
+// Volume Change mode - Twist hilt while in Volumechange mode to increase or decrease volume 
+// Birghtess Change mode - Twist hilt while in Brightness change mode to increase or decrease the brigtness of the blade 
+
+#ifndef PROPS_SABER_AAT_BUTTONS_H
+#define PROPS_SABER_AAT_BUTTONS_H
+
+#include "prop_base.h"
+
+#undef PROP_TYPE
+#define PROP_TYPE SaberAatButtons
+
+// The Saber class implements the basic states and actions
+// for the saber.
+class SaberAatButtons : public PropBase {
+public:
+  SaberAatButtons() : PropBase() {}
+  const char* name() override { return "SaberAatButtons"; }
+
+  enum MenuType {
+    MENU_NONE,  
+    MENU_COLOR,
+    //MENU_VOLUME,
+    MENU_DIM,
+    NUM_MENUS
+  };
+  
+  bool CfgMenu(){
+      
+      //Go to next menu (increment enum) 
+      menu_ = static_cast<MenuType>((menu_ + 1) % NUM_MENUS); 
+      
+      //do Menu item
+      switch(menu_){
+          case MENU_COLOR:
+//             ToggleMenuChangeMode(); // we are entering menu mode
+             if (!SaberBase::IsOn()){
+                 On();
+                 delay(250);//wait for saber to activate
+             }
+            //no need to play sound, is handled by Colorchange itself
+            ToggleColorChangeMode();
+            return true;
+            break;
+          // case MENU_VOLUME:
+            // if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+                // ToggleColorChangeMode();//Turn Colorchange control off
+            // }
+            // ToggleVolumeChangeMode();
+            // STDOUT.println("Enter Volume Menu");
+            // return true;
+            // break;
+          case MENU_DIM:
+            if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) { // this should match previous menu
+                ToggleColorChangeMode();//Turn Volume control off
+                SaveVolumeIfNeeded();
+            }
+            ToggleBrightnessChangeMode();
+            STDOUT.println("Enter Brightness Menu");
+            return true;
+            break;
+          case MENU_NONE:
+            ExitMenu();
+            return false;
+            break;
+          case NUM_MENUS:
+            return false;//just to eliminate compiler warning
+            break;
+      }
+    return false  ;
+  }
+ 
+  void ExitMenu(){
+       bool exiting_ = false;
+       menu_ = MENU_NONE;
+       
+        if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+          // Just exit color change mode.
+          // Don't turn saber off.
+          ToggleColorChangeMode();
+          exiting_ = true;
+        }
+        
+        // if (VolumeChangeMode()){
+          // ToggleVolumeChangeMode();
+          // SaveVolumeIfNeeded();
+          // STDOUT.println("Exit Volume Menu");
+          // exiting_ = true;
+        // }
+
+        if (SaberBase::GetDimChangeMode() != SaberBase::DIM_CHANGE_MODE_NONE) { 
+          ToggleBrightnessChangeMode();
+          STDOUT.println("Exit Brightness Menu");
+          exiting_ = true;
+        }
+        
+//        if (exiting_){
+//            if (SaberBase::GetMenuChangeMode() != SaberBase::MENU_CHANGE_MODE_NONE) {
+//              ToggleMenuChangeMode();
+//              STDOUT.println("Exit Menu-mode");
+//              exiting_ = true;
+//            }
+//        }
+  }
+  
+
+  bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
+
+
+    // pointing up/down
+    if (accel_.x < -0.15) {
+      pointing_down_ = true;
+    } else {
+      pointing_down_ = false;   
+    }
+    //for up down with hysteresis, uncomment following
+    //if (accel_.x > 0.15) {
+    //  pointing_down_ = false;
+    //}
+    // if (accel_.x < -0.15) {
+    //   pointing_down_ = true;
+    // }
+    
+    
+    if(menu_ == MENU_NONE){     
+            switch (EVENTID(button, event, modifiers)) {
+                case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ON):
+                  //pointing up/down detection used to be here
+                  return true;
+
+                case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF):
+                      aux_on_ = false;
+                      On();
+                    return true;
+
+                    // Handle double-click with preon
+                case EVENTID(BUTTON_POWER, EVENT_DOUBLE_CLICK, MODE_OFF):
+                    if (on_pending_) {
+                      if (SetMute(true)) {
+                        unmute_on_deactivation_ = true;
+                      }
+                      return true;
+                    }
+                    return false;
+
+                case EVENTID(BUTTON_POWER, EVENT_DOUBLE_CLICK, MODE_ON):
+                    if (millis() - activated_ < 500) {
+                      if (SetMute(true)) {
+                        unmute_on_deactivation_ = true;
+                      }
+                    }
+                    return true;
+
+                case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_ON):
+                      SaberBase::DoBlast();
+                    return true;
+
+                case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
+                      SaberBase::DoForce();
+                    return true;
+
+                case EVENTID(BUTTON_POWER, EVENT_HELD_LONG, MODE_ON):
+                    if (!SaberBase::Lockup()) {
+                      Off();
+                      return true;
+                    }
+                    break;
+
+                case EVENTID(BUTTON_POWER, EVENT_HELD_LONG, MODE_OFF):
+                      CfgMenu();//enter config menu
+                    return true;
+
+                case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+                    if (!SaberBase::Lockup()) {
+                      if (pointing_down_) {
+                        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+                      } else {
+                        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+                      }
+                      SaberBase::DoBeginLockup();
+                      return false;//to keep track off button released
+                    }
+                    break;
+
+                case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+                    if (!SaberBase::Lockup()) {
+                        SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+                        SaberBase::DoBeginLockup();
+                    return false; //break??
+                    }
+                    break;
+
+                case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON | BUTTON_POWER):
+                    if (!SaberBase::Lockup()) {
+                        SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+                        SaberBase::DoBeginLockup();
+                    return false; //break??
+                    }
+                    break;
+
+                // Off functions
+                case EVENTID(BUTTON_POWER, EVENT_CLICK_LONG, MODE_OFF):
+                //case EVENTID(BUTTON_POWER, EVENT_CLICK_LONG, MODE_ON): // this is annoying and you will trigger it by accident too much
+                    if (!SaberBase::Lockup()) {
+                       StartOrStopTrack();
+                    }
+                    return true;
+                    
+                case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+                    next_preset();
+                    return true;
+
+                case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF | BUTTON_POWER):
+                    previous_preset();
+                    return true;
+                
+                case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+                    Parse("set_preset", "0");//select 1st preset
+                #ifdef SAVE_PRESET
+                    SaveState(0);//remember we went to preset 0 next time we start up
+                #endif
+                    return true; //break??
+
+                case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
+                    SaberBase::RequestMotion();
+                    return true;
+
+              // Events that needs to be handled regardless of what other buttons
+              // are pressed.
+                case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+                    if (SaberBase::Lockup()) {
+                      SaberBase::DoEndLockup();
+                      SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+                      return true;
+                    }
+                
+            }
+    }
+    else // we are in menu mode
+    {
+       //MENU MODE
+           switch(EVENTID(button, event, modifiers)) {
+
+              case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_ON):
+              case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF):
+                //go to next menu item
+                CfgMenu();
+                return true;
+
+              case EVENTID(BUTTON_POWER, EVENT_HELD_LONG, MODE_OFF):
+              case EVENTID(BUTTON_POWER, EVENT_HELD_LONG, MODE_ON):
+                ExitMenu();         
+                return true;
+
+            }
+        
+    }
+    return false;
+  }
+
+private:
+  RefPtr<BufferedWavPlayer> player;
+  MenuType menu_ = MenuType(MENU_NONE);
+  bool aux_on_ = true;
+  bool pointing_down_ = false;
+  bool mode_menu_ = false;
+  bool mode_volume_ = false;
+  bool mode_dim_ = false;
+  bool mode_color_ = false;
+};
+
+#endif

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -502,6 +502,12 @@ EFFECT(ccbegin);
 EFFECT(ccend);
 EFFECT(ccchange);
 
+#ifdef ENABLE_MENU_DIMBLADE
+// DimBlade menu
+EFFECT(dimbgn);
+EFFECT(dimend);
+#endif
+
 // Blaster effects
 // hum, boot and font are reused from sabers and already defined.
 EFFECT(bgnauto); // Doesn't exist in fonts, but I expect there may be use for autofire transitions

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -423,6 +423,22 @@ public:
           beeper.Beep(0.05, 2000.0);
         }
         break;
+#ifdef ENABLE_MENU_DIMBLADE
+      case SaberBase::ENTER_DIM_CHANGE:
+        if (!PlayPolyphonic(&SFX_dimbgn)) {
+          beeper.Beep(0.20, 1000.0);
+          beeper.Beep(0.20, 1414.2);
+          beeper.Beep(0.20, 2000.0);
+        }
+        break;
+      case SaberBase::EXIT_DIM_CHANGE:
+        if (!PlayPolyphonic(&SFX_dimend)) {
+          beeper.Beep(0.20, 2000.0);
+          beeper.Beep(0.20, 1414.2);
+          beeper.Beep(0.20, 1000.0);
+        }
+        break;
+#endif
     }
   }
 


### PR DESCRIPTION
	modified:   blades/dim_blade.h
	modified:   common/saber_base.h
	modified:   config/default_proffieboard_config.h
	modified:   props/prop_base.h

Permanently embedded DimBlade option in ProffieOS. It will allow for real-time brightness alteration
using a Menu (comparable to colorchange) or serial commands (dim ##, get_dim)

Maybe it woul even be nice to have this with a #define DIMBLADE 100, that would automaticaly wraps the DimBlade(#,) around the BladeConfig? (This would then affect all blades defined, including accent leds and crystal chambers)? 