### PR TITLE
motion/mpu6050:    added ASYNC read option, for ProffieOS5.x on Teensy4.0 

### DIFF
--- a/motion/mpu6050.h
+++ b/motion/mpu6050.h
@@ -100,7 +100,7 @@ public:
 
   MPU6050() : I2CDevice(0x68) {}
 
-#ifdef ÀSYNC_READ_MOTION // use Wire.h and ASYNC to read MPU6050
+#ifdef ASYNC_READ_MOTION // use Wire.h and ASYNC to read MPU6050
   void Loop() override {
     STATE_MACHINE_BEGIN();
 

--- a/motion/mpu6050.h
+++ b/motion/mpu6050.h
@@ -100,6 +100,109 @@ public:
 
   MPU6050() : I2CDevice(0x68) {}
 
+#ifdef USE_TEENSY4 //use Wire.h and ASYNC to read MPU6050
+  void Loop() override {
+    STATE_MACHINE_BEGIN();
+
+    while (!i2cbus.inited()) YIELD();
+
+    while (1) {
+      first_motion_ = true;
+      first_accel_ = true;
+
+      STDOUT.print("Motion setup ... ");
+      while (!I2CLock()) YIELD(); 
+
+      I2C_WRITE_BYTE_ASYNC(PWR_MGMT_1, 0); // wake up,
+      I2C_WRITE_BYTE_ASYNC(CONFIG, 1);     // digital filter config ~180Hz, 
+                                           //1khz rate, 2ms delay
+      I2C_WRITE_BYTE_ASYNC(SMPLRT_DIV, 0); // sample rate  0 = 1khz, 1 = 500Hz
+      I2C_WRITE_BYTE_ASYNC(GYRO_CONFIG, 3 << 3);  // 2000 degrees / s
+      I2C_WRITE_BYTE_ASYNC(ACCEL_CONFIG, 1 << 3); // 4g range
+      I2C_WRITE_BYTE_ASYNC(INT_PIN_CFG, 0x30);  // interrupt on data available, 
+                                                //cleared on any read
+      I2C_WRITE_BYTE_ASYNC(INT_ENABLE, 1);      // enable data ready interrupt
+      pinMode(motionSensorInterruptPin, INPUT);
+      I2C_READ_BYTES_ASYNC(WHO_AM_I, databuffer, 1);
+      if (databuffer[0] == 0x68) {
+        STDOUT.println("done.");
+      } else {
+        STDOUT.println("failed.");
+        goto i2c_timeout;
+      }
+
+      I2CUnlock();
+
+      last_event_ = millis();
+      while (true) {
+        YIELD();
+        if (!SaberBase::MotionRequested()) break;
+        if (!digitalRead(motionSensorInterruptPin)) {
+          if (millis() - last_event_ > I2C_TIMEOUT_MILLIS * 2) {
+            goto i2c_timeout;
+          }
+          continue;
+        } else {
+          last_event_ = millis();
+        }
+        while (!I2CLock()) YIELD();
+
+        // Do the accel data first to make clashes as fast as possible.
+        // accel data available
+        I2C_READ_BYTES_ASYNC(ACCEL_XOUT_H, databuffer, 14);
+        prop.DoAccel(
+              MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4 g range
+              Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
+              false);
+        first_accel_ = false;
+
+        // gyroscope data available
+        prop.DoMotion(
+              MotionUtil::FromData(databuffer+8, 2000.0 / 32768.0,  // 2000 dps
+              Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
+              false);
+        first_motion_ = false;
+
+        // Temp data available
+        // TODO: Temp Shutdown
+        int16_t temp_data = (databuffer[6] << 8) + databuffer[7];
+        float temp = temp_data / 340.0 + 36.53;
+        if (monitor.ShouldPrint(Monitoring::MonitorTemp)) {
+          STDOUT.print("TEMP: ");
+          STDOUT.println(temp);
+        }
+        I2CUnlock(); 
+      } //while(true)
+          
+      STDOUT.println("Motion disable.");
+
+      while (!I2CLock()) YIELD();
+      I2C_WRITE_BYTE_ASYNC(PWR_MGMT_1, 0x40); // sleep mode, 5uA idle-current
+      I2CUnlock();
+          
+      while (!SaberBase::MotionRequested()) YIELD();
+      continue;
+
+      i2c_timeout:
+        STDOUT.println("Motion chip timeout, reboot motion chip!");
+        Reset();
+        SLEEP(20);
+        I2CUnlock();
+        SLEEP(20);
+    }
+
+    STATE_MACHINE_END();
+  }
+
+  uint8_t databuffer[14];
+  int status_reg;
+  uint32_t last_temp_;
+  uint32_t last_event_;
+  bool first_motion_;
+  bool first_accel_;
+
+#else //non async, motion interrupt pin is not required for this method of reading mpu6050
+
   void Loop() override {
     STATE_MACHINE_BEGIN();
 
@@ -111,11 +214,11 @@ public:
       STDOUT.print("Motion setup ... ");
       writeByte(PWR_MGMT_1, 0); // wake up
       writeByte(CONFIG, 1);     // digital filter config ~180Hz, 1khz rate, 2ms delay
-      writeByte(SMPLRT_DIV, 0); // sample rate = 1khz / 1
-      writeByte(GYRO_CONFIG, 3 << 3); // 2000 degrees / s
+      writeByte(SMPLRT_DIV, 0);        // sample rate = 1khz / 1
+      writeByte(GYRO_CONFIG, 3 << 3);  // 2000 degrees / s
       writeByte(ACCEL_CONFIG, 1 << 3); // 4g range
-      writeByte(INT_PIN_CFG, 0x20);  // interrupt on data available
-      writeByte(INT_ENABLE, 1); // enable data ready interrupt
+      writeByte(INT_PIN_CFG, 0x20);    // interrupt on data available
+      writeByte(INT_ENABLE, 1);        // enable data ready interrupt
 
       if (readByte(WHO_AM_I) == 0x68) {
         STDOUT.println("done.");
@@ -129,26 +232,26 @@ public:
         if (status_reg == -1) {
           // motion fail, reboot motion chip.
           STDOUT.println("Motion chip timeout, reboot motion chip!");
-          // writeByte(CTRL3_C, 1);
           delay(20);
           break;
         }
+
         if (status_reg & 0x1) {
-	// Do the accel data first to make clashes as fast as possible.
+          // Do the accel data first to make clashes as fast as possible.
           // accel data available
           if (readBytes(ACCEL_XOUT_H, databuffer, 6) == 6) {
-	    prop.DoAccel(
+            prop.DoAccel( 
               MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4 g range
-				   Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
-	      false);
+              Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
+              false);
           }
 
           // gyroscope data available
           if (readBytes(GYRO_XOUT_H, databuffer, 6) == 6) {
-	    prop.DoMotion(
+            prop.DoMotion(
               MotionUtil::FromData(databuffer, 2000.0 / 32768.0,  // 2000 dps
-				   Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
-	      false);
+              Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
+              false);
           }
 
           // Temp data available
@@ -166,6 +269,7 @@ public:
     }
     STATE_MACHINE_END();
   }
+#endif
 };
 
 #endif

--- a/motion/mpu6050.h
+++ b/motion/mpu6050.h
@@ -100,7 +100,7 @@ public:
 
   MPU6050() : I2CDevice(0x68) {}
 
-#ifdef USE_TEENSY4 //use Wire.h and ASYNC to read MPU6050
+#ifdef ÀSYNC_READ_MOTION // use Wire.h and ASYNC to read MPU6050
   void Loop() override {
     STATE_MACHINE_BEGIN();
 
@@ -115,12 +115,12 @@ public:
 
       I2C_WRITE_BYTE_ASYNC(PWR_MGMT_1, 0); // wake up,
       I2C_WRITE_BYTE_ASYNC(CONFIG, 1);     // digital filter config ~180Hz, 
-                                           //1khz rate, 2ms delay
+                                           // 1khz rate, 2ms delay
       I2C_WRITE_BYTE_ASYNC(SMPLRT_DIV, 0); // sample rate  0 = 1khz, 1 = 500Hz
       I2C_WRITE_BYTE_ASYNC(GYRO_CONFIG, 3 << 3);  // 2000 degrees / s
       I2C_WRITE_BYTE_ASYNC(ACCEL_CONFIG, 1 << 3); // 4g range
       I2C_WRITE_BYTE_ASYNC(INT_PIN_CFG, 0x30);  // interrupt on data available, 
-                                                //cleared on any read
+                                                // cleared on any read
       I2C_WRITE_BYTE_ASYNC(INT_ENABLE, 1);      // enable data ready interrupt
       pinMode(motionSensorInterruptPin, INPUT);
       I2C_READ_BYTES_ASYNC(WHO_AM_I, databuffer, 1);
@@ -151,7 +151,7 @@ public:
         // accel data available
         I2C_READ_BYTES_ASYNC(ACCEL_XOUT_H, databuffer, 14);
         prop.DoAccel(
-              MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4 g range
+              MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4g range
               Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
               false);
         first_accel_ = false;
@@ -172,7 +172,7 @@ public:
           STDOUT.println(temp);
         }
         I2CUnlock(); 
-      } //while(true)
+      } // while(true)
           
       STDOUT.println("Motion disable.");
 
@@ -201,7 +201,7 @@ public:
   bool first_motion_;
   bool first_accel_;
 
-#else //non async, motion interrupt pin is not required for this method of reading mpu6050
+#else // non async, motion interrupt pin is not required for this method of reading mpu6050
 
   void Loop() override {
     STATE_MACHINE_BEGIN();
@@ -241,7 +241,7 @@ public:
           // accel data available
           if (readBytes(ACCEL_XOUT_H, databuffer, 6) == 6) {
             prop.DoAccel( 
-              MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4 g range
+              MotionUtil::FromData(databuffer, 4.0 / 32768.0,   // 4g range
               Vec3::BYTEORDER_MSB, Vec3::ORIENTATION),
               false);
           }


### PR DESCRIPTION
As requested, made the modification of the mpu605o a sperate pull-request from the Teensy4.0 integration.

    added ASYNC read option, for ProffieOS5.x on Teensy4.0 
    cleaned up the original read-rouitne a little bit (indentation and non relevant comments deleted)
    modified:   motion/mpu6050.h

Switching between the 2 is now coupled to the #define USE_TEENSY4
Maybe this should be more generic, and use a separate define line #define mpu6050_ASYNC in the hardware config?