### PR TITLE
timers added to Stab, Thrust, Twist ignitions

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -416,13 +416,13 @@ SaberFett263Buttons() : PropBase() {}
           Off();
           saber_off_time_ = millis();
         }
-#endif
-#ifndef FETT263_BM_DISABLE_OFF_BUTTON
+#else
          Off();
          saber_off_time_ = millis();
+         battle_mode_ = false;
 #endif
-#ifndef FETT263_BATTLE_MODE_ALWAYS_ON
-          battle_mode_ = false;
+#ifdef FETT263_BATTLE_MODE_ALWAYS_ON
+          battle_mode_ = true;
 #endif
         }
         return true;

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -411,11 +411,15 @@ SaberFett263Buttons() : PropBase() {}
 #endif
         if (!swinging_) {
           swing_blast_ = false;
+#ifdef FETT263_BM_DISABLE_OFF_BUTTON
+        if (!battle_mode_) {
+          Off();
+          saber_off_time_ = millis();
+        }
+#endif
 #ifndef FETT263_BM_DISABLE_OFF_BUTTON
-          if (!battle_mode_) {
-            Off();
-            saber_off_time_ = millis();
-          }
+         Off();
+         saber_off_time_ = millis();
 #endif
 #ifndef FETT263_BATTLE_MODE_ALWAYS_ON
           battle_mode_ = false;

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -260,7 +260,7 @@ SaberFett263Buttons() : PropBase() {}
           mss.y * mss.y + mss.z * mss.z > 70 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > 5) {
+        if (abs(millis() - push_begin_millis_) > 5) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
         } 
@@ -284,7 +284,7 @@ SaberFett263Buttons() : PropBase() {}
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
           mss.x > 14  &&
           fusor.swing_speed() < 150) {
-        if (millis() - thrust_begin_millis_ > 15) {
+        if (abs(millis() - thrust_begin_millis_) > 15) {
           Event(BUTTON_NONE, EVENT_THRUST);
           thrust_begin_millis_ = millis();
         } 
@@ -637,7 +637,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_OFF
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 3000) {
+        if (abs(millis() - last_twist_) > 3000) {
           Off();
           last_twist_ = millis();
           saber_off_time_ = millis();
@@ -651,69 +651,79 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_ON
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 2000) {
+        if (abs(millis() - last_twist_) > 2000 &&
+            abs(millis() - saber_off_time_) > 1000) {
           FastOn();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;
 #endif
+          last_twist_ = millis();
         }
-        last_twist_ = millis();
         return true;
 #endif
 
 #ifdef FETT263_TWIST_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 2000) {
+        if (millis() - last_twist_ > 2000 &&
+            abs(millis() - saber_off_time_) > 1000) {
           On();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;
 #endif
+          last_twist_ = millis();
         }
-        last_twist_ = millis();
         return true;
 #endif
 
 #ifdef FETT263_STAB_ON
       case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        FastOn();
+        if (abs(millis() - saber_off_time_) > 1000) {
+          FastOn();
 #ifndef FETT263_STAB_ON_NO_BM
-        battle_mode_ = true;
+          battle_mode_ = true;
 #endif
+        }
         return true;
 #endif
 
 #ifdef FETT263_STAB_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        On();
+        if (abs(millis() - saber_off_time_) > 1000) {
+          On();
 #ifndef FETT263_STAB_ON_NO_BM
-        battle_mode_ = true;
+          battle_mode_ = true;
 #endif
+        }
         return true;
 #endif
 
 #ifdef FETT263_THRUST_ON
       case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        FastOn();
+        if (abs(millis() - saber_off_time_) > 1000) {
+          FastOn();
 #ifndef FETT263_THRUST_ON_NO_BM
-        battle_mode_ = true;
+          battle_mode_ = true;
 #endif
+        }
         return true;
 #endif
 
 #ifdef FETT263_THRUST_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        On();
+        if (abs(millis() - saber_off_time_) > 1000) {
+          On();
 #ifndef FETT263_THRUST_ON_NO_BM
-        battle_mode_ = true;
+          battle_mode_ = true;
 #endif
+        }
         return true;
 #endif
 
 #ifdef FETT263_FORCE_PUSH
       case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
         if (battle_mode_ &&
-            millis() - last_push_ > 2000) {
+            abs(millis() - last_push_) > 2000) {
           if (SFX_push) {
             hybrid_font.PlayCommon(&SFX_push);
           } else {
@@ -728,7 +738,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_MULTI_PHASE
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON | BUTTON_AUX):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 2000) {
+        if (abs(millis() - last_twist_) > 2000) {
           last_twist_ = millis();
           next_preset();
         }
@@ -736,7 +746,7 @@ SaberFett263Buttons() : PropBase() {}
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON | BUTTON_POWER):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 2000) {
+        if (abs(millis() - last_twist_) > 2000) {
           last_twist_ = millis();
           previous_preset();
         }

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -254,12 +254,12 @@ SaberFett263Buttons() : PropBase() {}
           mss.y * mss.y + mss.z * mss.z > 100 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > 25) {
+        if (millis() - push_begin_millis_ > 10) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
-        } else {
-          push_begin_millis_ = millis();
-        }
+        } 
+      } else {
+        push_begin_millis_ = millis();
       }
 
     } else {
@@ -278,9 +278,9 @@ SaberFett263Buttons() : PropBase() {}
         if (millis() - thrust_begin_millis_ > 50) {
           Event(BUTTON_NONE, EVENT_THRUST);
           thrust_begin_millis_ = millis();
-        } else {
-          thrust_begin_millis_ = millis();
-        }
+        } 
+      } else {
+        thrust_begin_millis_ = millis();
       }
     }
   }

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -110,15 +110,9 @@
 // FETT263_THRUST_ON_NO_BM
 // To enable Thrust On Ignition control but not activate Battle Mode (works with THRUST_ON_PREON only)
 //
-// FETT263_THRUST_LENGTH 50
-// Length of time the thrust gesture needs to continue to prevent false detection, defaults to 50 ms
-//
 // FETT263_FORCE_PUSH
 // To enable gesture controlled Force Push during Battle Mode
 // (will use push.wav or force.wav if not present)
-//
-// FETT263_PUSH_LENGTH 25
-// Length of time the push gesture needs to continue to prevent false detection, defaults to 25 ms
 //
 // FETT263_MULTI_PHASE
 // This will enable a preset change while ON to create a "Multi-Phase" saber effect
@@ -152,14 +146,6 @@
 
 #ifndef FETT263_LOCKUP_DELAY
 #define FETT263_LOCKUP_DELAY 200
-#endif
-
-#ifndef FETT263_THRUST_LENGTH
-#define FETT263_THRUST_LENGTH 50
-#endif
-
-#ifndef FETT263_PUSH_LENGTH
-#define FETT263_PUSH_LENGTH 25
 #endif
 
 #if defined(FETT263_BATTLE_MODE_ALWAYS_ON) && defined(FETT263_BATTLE_MODE_START_ON)
@@ -268,15 +254,12 @@ SaberFett263Buttons() : PropBase() {}
           mss.y * mss.y + mss.z * mss.z > 100 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-          if (!push_begin_) {
-            push_gesture_ = millis();
-            push_begin_ = true;
-          } else {
-            if(millis() - push_gesture_ > FETT263_PUSH_LENGTH) {
-              Event(BUTTON_NONE, EVENT_PUSH);
-              push_begin_ = false;
-            }
-          }
+        if (millis() - push_begin_millis_ > 25) {
+          Event(BUTTON_NONE, EVENT_PUSH);
+          push_begin_millis_ = millis();
+        } else {
+          push_begin_millis_ = millis();
+        }
       }
 
     } else {
@@ -290,16 +273,13 @@ SaberFett263Buttons() : PropBase() {}
       }
       // EVENT_THRUST
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
-        mss.x > 14  &&
-        fusor.swing_speed() < 150) {
-        if (!thrust_begin_) {
-          thrust_gesture_ = millis();
-          thrust_begin_ = true;
+          mss.x > 14  &&
+          fusor.swing_speed() < 150) {
+        if (millis() - thrust_begin_millis_ > 50) {
+          Event(BUTTON_NONE, EVENT_THRUST);
+          thrust_begin_millis_ = millis();
         } else {
-          if (millis() - thrust_gesture_ > FETT263_THRUST_LENGTH) {
-            Event(BUTTON_NONE, EVENT_THRUST);
-            thrust_begin_ = false;
-          }
+          thrust_begin_millis_ = millis();
         }
       }
     }
@@ -798,10 +778,8 @@ private:
   bool auto_lockup_on_ = false;
   bool auto_melt_on_ = false;
   bool battle_mode_ = false;
-  bool thrust_begin_ = false;
-  bool push_begin_ = false;
-  uint32_t thrust_gesture_ = millis();
-  uint32_t push_gesture_ = millis();
+  uint32_t thrust_begin_millis_ = millis();
+  uint32_t push_begin_millis_ = millis();
   uint32_t clash_impact_millis_ = millis();
   uint32_t last_twist_ = millis();
   uint32_t last_push_ = millis();

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -110,9 +110,15 @@
 // FETT263_THRUST_ON_NO_BM
 // To enable Thrust On Ignition control but not activate Battle Mode (works with THRUST_ON_PREON only)
 //
+// FETT263_THRUST_LENGTH 50
+// Length of time the thrust gesture needs to continue to prevent false detection, defaults to 50 ms
+//
 // FETT263_FORCE_PUSH
 // To enable gesture controlled Force Push during Battle Mode
 // (will use push.wav or force.wav if not present)
+//
+// FETT263_PUSH_LENGTH 25
+// Length of time the push gesture needs to continue to prevent false detection, defaults to 25 ms
 //
 // FETT263_MULTI_PHASE
 // This will enable a preset change while ON to create a "Multi-Phase" saber effect
@@ -146,6 +152,14 @@
 
 #ifndef FETT263_LOCKUP_DELAY
 #define FETT263_LOCKUP_DELAY 200
+#endif
+
+#ifndef FETT263_THRUST_LENGTH
+#define FETT263_THRUST_LENGTH 50
+#endif
+
+#ifndef FETT263_PUSH_LENGTH
+#define FETT263_PUSH_LENGTH 25
 #endif
 
 #if defined(FETT263_BATTLE_MODE_ALWAYS_ON) && defined(FETT263_BATTLE_MODE_START_ON)
@@ -251,10 +265,18 @@ SaberFett263Buttons() : PropBase() {}
 
       // EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
-          mss.y * mss.y + mss.z * mss.z > 120 &&
+          mss.y * mss.y + mss.z * mss.z > 100 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        Event(BUTTON_NONE, EVENT_PUSH);
+          if (!push_begin_) {
+            push_gesture_ = millis();
+            push_begin_ = true;
+          } else {
+            if(millis() - push_gesture_ > FETT263_PUSH_LENGTH) {
+              Event(BUTTON_NONE, EVENT_PUSH);
+              push_begin_ = false;
+            }
+          }
       }
 
     } else {
@@ -270,7 +292,15 @@ SaberFett263Buttons() : PropBase() {}
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
         mss.x > 14  &&
         fusor.swing_speed() < 150) {
-        Event(BUTTON_NONE, EVENT_THRUST);
+        if (!thrust_begin_) {
+          thrust_gesture_ = millis();
+          thrust_begin_ = true;
+        } else {
+          if (millis() - thrust_gesture_ > FETT263_THRUST_LENGTH) {
+            Event(BUTTON_NONE, EVENT_THRUST);
+            thrust_begin_ = false;
+          }
+        }
       }
     }
   }
@@ -768,6 +798,10 @@ private:
   bool auto_lockup_on_ = false;
   bool auto_melt_on_ = false;
   bool battle_mode_ = false;
+  bool thrust_begin_ = false;
+  bool push_begin_ = false;
+  uint32_t thrust_gesture_ = millis();
+  uint32_t push_gesture_ = millis();
   uint32_t clash_impact_millis_ = millis();
   uint32_t last_twist_ = millis();
   uint32_t last_push_ = millis();

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -271,6 +271,9 @@ SaberFett263Buttons() : PropBase() {}
       // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
       if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
         SaberBase::RequestMotion();
+        if (swinging_ && fusor.swing_speed() < 90) {
+          swinging_ = false;
+        }
         if (!swinging_ && fusor.swing_speed() > FETT263_SWING_ON_SPEED) {
           swinging_ = true;
           Event(BUTTON_NONE, EVENT_SWING);

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -412,8 +412,10 @@ SaberFett263Buttons() : PropBase() {}
         if (!swinging_) {
           swing_blast_ = false;
 #ifndef FETT263_BM_DISABLE_OFF_BUTTON
-          Off();
-          saber_off_time_ = millis();
+          if (!battle_mode_) {
+            Off();
+            saber_off_time_ = millis();
+          }
 #endif
 #ifndef FETT263_BATTLE_MODE_ALWAYS_ON
           battle_mode_ = false;
@@ -626,7 +628,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_ON
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 3000) {
+        if (millis() - last_twist_ > 2000) {
           FastOn();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;
@@ -639,7 +641,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
-        if (millis() - last_twist_ > 3000) {
+        if (millis() - last_twist_ > 2000) {
           On();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -260,7 +260,7 @@ SaberFett263Buttons() : PropBase() {}
           mss.y * mss.y + mss.z * mss.z > 70 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (abs(millis() - push_begin_millis_) > 5) {
+        if (millis() - push_begin_millis_ > 5) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
         } 
@@ -284,7 +284,7 @@ SaberFett263Buttons() : PropBase() {}
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
           mss.x > 14  &&
           fusor.swing_speed() < 150) {
-        if (abs(millis() - thrust_begin_millis_) > 15) {
+        if (millis() - thrust_begin_millis_ > 15) {
           Event(BUTTON_NONE, EVENT_THRUST);
           thrust_begin_millis_ = millis();
         } 
@@ -637,7 +637,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_OFF
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
         // Delay twist events to prevent false trigger from over twisting
-        if (abs(millis() - last_twist_) > 3000) {
+        if (millis() - last_twist_ > 3000) {
           Off();
           last_twist_ = millis();
           saber_off_time_ = millis();
@@ -651,8 +651,8 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_TWIST_ON
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
-        if (abs(millis() - last_twist_) > 2000 &&
-            abs(millis() - saber_off_time_) > 1000) {
+        if (millis() - last_twist_ > 2000 &&
+            millis() - saber_off_time_ > 1000) {
           FastOn();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;
@@ -666,7 +666,7 @@ SaberFett263Buttons() : PropBase() {}
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
         // Delay twist events to prevent false trigger from over twisting
         if (millis() - last_twist_ > 2000 &&
-            abs(millis() - saber_off_time_) > 1000) {
+            millis() - saber_off_time_ > 1000) {
           On();
 #ifndef FETT263_TWIST_ON_NO_BM
           battle_mode_ = true;
@@ -678,7 +678,7 @@ SaberFett263Buttons() : PropBase() {}
 
 #ifdef FETT263_STAB_ON
       case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        if (abs(millis() - saber_off_time_) > 1000) {
+        if (millis() - saber_off_time_ > 1000) {
           FastOn();
 #ifndef FETT263_STAB_ON_NO_BM
           battle_mode_ = true;
@@ -689,7 +689,7 @@ SaberFett263Buttons() : PropBase() {}
 
 #ifdef FETT263_STAB_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        if (abs(millis() - saber_off_time_) > 1000) {
+        if (millis() - saber_off_time_ > 1000) {
           On();
 #ifndef FETT263_STAB_ON_NO_BM
           battle_mode_ = true;
@@ -700,7 +700,7 @@ SaberFett263Buttons() : PropBase() {}
 
 #ifdef FETT263_THRUST_ON
       case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        if (abs(millis() - saber_off_time_) > 1000) {
+        if (millis() - saber_off_time_ > 1000) {
           FastOn();
 #ifndef FETT263_THRUST_ON_NO_BM
           battle_mode_ = true;
@@ -711,7 +711,7 @@ SaberFett263Buttons() : PropBase() {}
 
 #ifdef FETT263_THRUST_ON_PREON
       case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        if (abs(millis() - saber_off_time_) > 1000) {
+        if (millis() - saber_off_time_ > 1000) {
           On();
 #ifndef FETT263_THRUST_ON_NO_BM
           battle_mode_ = true;
@@ -723,7 +723,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_FORCE_PUSH
       case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
         if (battle_mode_ &&
-            abs(millis() - last_push_) > 2000) {
+            millis() - last_push_ > 2000) {
           if (SFX_push) {
             hybrid_font.PlayCommon(&SFX_push);
           } else {
@@ -738,7 +738,7 @@ SaberFett263Buttons() : PropBase() {}
 #ifdef FETT263_MULTI_PHASE
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON | BUTTON_AUX):
         // Delay twist events to prevent false trigger from over twisting
-        if (abs(millis() - last_twist_) > 2000) {
+        if (millis() - last_twist_ > 2000) {
           last_twist_ = millis();
           next_preset();
         }
@@ -746,7 +746,7 @@ SaberFett263Buttons() : PropBase() {}
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON | BUTTON_POWER):
         // Delay twist events to prevent false trigger from over twisting
-        if (abs(millis() - last_twist_) > 2000) {
+        if (millis() - last_twist_ > 2000) {
           last_twist_ = millis();
           previous_preset();
         }

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -422,14 +422,14 @@ SaberFett263Buttons() : PropBase() {}
         if (!swinging_) {
           swing_blast_ = false;
 #ifdef FETT263_BM_DISABLE_OFF_BUTTON
-        if (!battle_mode_) {
+          if (!battle_mode_) {
+            Off();
+            saber_off_time_ = millis();
+          }
+#else
           Off();
           saber_off_time_ = millis();
-        }
-#else
-         Off();
-         saber_off_time_ = millis();
-         battle_mode_ = false;
+          battle_mode_ = false;
 #endif
 #ifdef FETT263_BATTLE_MODE_ALWAYS_ON
           battle_mode_ = true;

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -67,7 +67,8 @@
 //
 // FETT263_SWING_ON_NO_BM
 // To enable Swing On Ignition control but not activate Battle Mode
-// (Cannot be used with FETT263_SWING_ON, FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
+// (Combine with FETT263_SWING_ON or FETT263_SWING_ON_PREON, 
+// cannot be used with FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
 //
 // FETT263_SWING_ON_SPEED 250
 // Adjust Swing Speed required for Ignition 250 ~ 500 recommended
@@ -85,7 +86,8 @@
 //
 // FETT263_TWIST_ON_NO_BM
 // To enable Twist On Ignition control but not activate Battle Mode
-// (Cannot be used with FETT263_TWIST_ON, FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
+// (Combine with FETT263_TWIST_ON or FETT263_TWIST_ON_PREON, 
+// cannot be used with FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
 //
 // FETT263_STAB_ON
 // To enable Stab On Ignition control (automatically enters Battle Mode, uses Fast On)
@@ -97,7 +99,8 @@
 //
 // FETT263_STAB_ON_NO_BM
 // To enable Stab On Ignition control but not activate Battle Mode
-// (Cannot be used with FETT263_STAB_ON, FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
+// (Combine with FETT263_STAB_ON or FETT263_STAB_ON_PREON, 
+// cannot be used with FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
 //
 // FETT263_THRUST_ON
 // To enable Thrust On Ignition control (automatically enters Battle Mode, uses Fast On)
@@ -108,7 +111,9 @@
 // Disables Fast On ignition for Thrust On so Preon is used (cannot be used with FETT263_THRUST_ON)
 //
 // FETT263_THRUST_ON_NO_BM
-// To enable Thrust On Ignition control but not activate Battle Mode (works with THRUST_ON_PREON only)
+// To enable Thrust On Ignition control but not activate Battle Mode 
+// (Combine with FETT263_THRUST_ON or FETT263_THRUST_ON_PREON, 
+// cannot be used with FETT263_BATTLE_MODE_ALWAYS_ON or FETT263_BATTLE_MODE_START_ON)
 //
 // FETT263_FORCE_PUSH
 // To enable gesture controlled Force Push during Battle Mode

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -134,6 +134,7 @@
 // Battle Mode Off (on toggle) - bmend.wav
 // Enter Volume Menu - vmbegin.wav
 // Exit Volume Menu - vmend.wav
+// Force Push - push.wav
 // Fast On (optional) - faston.wav
 // Multi-Blast Mode On - blstbgn.wav
 // Multi-Blast Mode Off - blstend.wav
@@ -283,7 +284,7 @@ SaberFett263Buttons() : PropBase() {}
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
           mss.x > 14  &&
           fusor.swing_speed() < 150) {
-        if (millis() - thrust_begin_millis_ > 50) {
+        if (millis() - thrust_begin_millis_ > 15) {
           Event(BUTTON_NONE, EVENT_THRUST);
           thrust_begin_millis_ = millis();
         } 

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -257,10 +257,10 @@ SaberFett263Buttons() : PropBase() {}
 
       // EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
-          mss.y * mss.y + mss.z * mss.z > 100 &&
+          mss.y * mss.y + mss.z * mss.z > 70 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > 10) {
+        if (millis() - push_begin_millis_ > 5) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
         } 


### PR DESCRIPTION
Added timers to reduce false gesture ignition from in.wav during retraction, will need some users to test once it's merged.  Also, per TRA PM I set the timers to abs() to account for millis() reset.  If there's a better way I am open, but I "think" the reset on millis() for a few timers was the inconsistency that was hard to replicate.