### PR TITLE
Added controls

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -11,9 +11,8 @@
 // Retract (OFF) - click PWR while ON (disabled during swinging, Twist Off available with define)
 // Play/Stop Music Track - hold and release PWR while OFF or hold and release PWR while ON and pointing blade straight up
 // Blast - click AUX while ON
-// Multi-Blast Mode - hold and release AUX while ON or in Battle Mode, click AUX and swing within 3 seconds to enter Mode,
-//                    while in Multi-Blast Mode every swing will trigger a Blast effect.
-//                    click AUX or lockup, clash, stab, melt, drag or any button presses automatically exits Mode
+// Multi-Blast Mode - hold and release AUX while ON to enter mode, Swing to initiate Blasts, click Aux to exit mode
+//                    lockup, clash, stab, melt, drag or any button presses automatically exits mode
 // Clash - clash blade while ON
 //         in Battle Mode clash and pull away quickly for "Clash" (requires BEGIN_LOCKUP and END_LOCKUP styles)
 // Lockup - hold AUX and clash while ON
@@ -324,12 +323,6 @@ SaberFett263Buttons() : PropBase() {}
         push_begin_millis_ = millis();
       }
       
-      // Multi-Blast detection
-      if (!swing_blast_ && battle_mode_ && millis() - last_blast_ < 3000 && fusor.swing_speed() > 250) {
-        SaberBase::DoBlast();
-        swing_blast_ = true;
-      }
-      
     } else {
       // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
       if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
@@ -530,9 +523,6 @@ SaberFett263Buttons() : PropBase() {}
           return true;
         } else {
           SaberBase::DoBlast();
-          if (battle_mode_) {
-            last_blast_ = millis();
-          }
         }
         return true;
 
@@ -869,7 +859,6 @@ private:
   uint32_t thrust_begin_millis_ = millis();
   uint32_t push_begin_millis_ = millis();
   uint32_t clash_impact_millis_ = millis();
-  uint32_t last_blast_ = millis();
   uint32_t last_twist_ = millis();
   uint32_t last_push_ = millis();
   uint32_t saber_off_time_ = millis();

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -206,6 +206,54 @@
 #error You cannot define both FETT263_FORCE_PUSH_ALWAYS_ON and FETT263_FORCE_PUSH
 #endif
 
+#ifdef FETT263_SWING_ON
+#define SWING_GESTURE
+#endif
+
+#ifdef FETT263_SWING_ON_PREON
+#define SWING_GESTURE
+#endif
+
+#if defined(FETT263_SWING_ON_NO_BM) && !defined(SWING_GESTURE)
+#error FETT263_SWING_ON_NO_BM requires either FETT263_SWING_ON or FETT263_SWING_ON_PREON
+#endif
+
+#ifdef FETT263_STAB_ON
+#define STAB_GESTURE
+#endif
+
+#ifdef FETT263_STAB_ON_PREON
+#define STAB_GESTURE
+#endif
+
+#if defined(FETT263_STAB_ON_NO_BM) && !defined(STAB_GESTURE)
+#error FETT263_STAB_ON_NO_BM requires either FETT263_STAB_ON or FETT263_STAB_ON_PREON
+#endif
+
+#ifdef FETT263_TWIST_ON
+#define TWIST_GESTURE
+#endif
+
+#ifdef FETT263_TWIST_ON_PREON
+#define TWIST_GESTURE
+#endif
+
+#if defined(FETT263_TWIST_ON_NO_BM) && !defined(TWIST_GESTURE)
+#error FETT263_TWIST_ON_NO_BM requires either FETT263_TWIST_ON or FETT263_TWIST_ON_PREON
+#endif
+
+#ifdef FETT263_THRUST_ON
+#define THRUST_GESTURE
+#endif
+
+#ifdef FETT263_THRUST_ON_PREON
+#define THRUST_GESTURE
+#endif
+
+#if defined(FETT263_THRUST_ON_NO_BM) && !defined(THRUST_GESTURE)
+#error FETT263_THRUST_ON_NO_BM requires either FETT263_THRUST_ON or FETT263_THRUST_ON_PREON
+#endif
+
 #ifdef FETT263_FORCE_PUSH_ALWAYS_ON
 #define FORCE_PUSH_CONDITION true
 #define FETT263_FORCE_PUSH

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -186,24 +186,16 @@
 #error You cannot define both FETT263_BATTLE_MODE_START_ON and FETT263_STAB_ON_NO_BM
 #endif
 
-#if defined(FETT263_SWING_ON) && defined(FETT263_SWING_ON_NO_BM)
-#error You cannot define both FETT263_SWING_ON and FETT263_SWING_ON_NO_BM
+#if defined(FETT263_BATTLE_MODE_START_ON) && defined(FETT263_THRUST_ON_NO_BM)
+#error You cannot define both FETT263_BATTLE_MODE_START_ON and FETT263_STAB_ON_NO_BM
 #endif
 
 #if defined(FETT263_SWING_ON) && defined(FETT263_SWING_ON_PREON)
 #error You cannot define both FETT263_SWING_ON and FETT263_SWING_ON_PREON
 #endif
 
-#if defined(FETT263_TWIST_ON) && defined(FETT263_TWIST_ON_NO_BM)
-#error You cannot define both FETT263_TWIST_ON and FETT263_TWIST_ON_NO_BM
-#endif
-
 #if defined(FETT263_TWIST_ON) && defined(FETT263_TWIST_PREON)
 #error You cannot define both FETT263_TWIST_ON and FETT263_TWIST_ON_PREON
-#endif
-
-#if defined(FETT263_STAB_ON) && defined(FETT263_STAB_ON_NO_BM)
-#error You cannot define both FETT263_STAB_ON and FETT263_STAB_ON_NO_BM
 #endif
 
 #if defined(FETT263_STAB_ON) && defined(FETT263_STAB_PREON)

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -119,6 +119,10 @@
 // To enable gesture controlled Force Push during Battle Mode
 // (will use push.wav or force.wav if not present)
 //
+// FETT263_FORCE_PUSH_ALWAYS_ON
+// To enable gesture controlled Force Push full time
+// (will use push.wav or force.wav if not present)
+//
 // FETT263_MULTI_PHASE
 // This will enable a preset change while ON to create a "Multi-Phase" saber effect
 //
@@ -204,6 +208,10 @@
 
 #if defined(FETT263_STAB_ON) && defined(FETT263_STAB_PREON)
 #error You cannot define both FETT263_STAB_ON and FETT263_STAB_ON_PREON
+#endif
+
+#if defined(FETT263_FORCE_PUSH_ALWAYS_ON) && defined(FETT263_FORCE_PUSH)
+#error You cannot define both FETT263_FORCE_PUSH_ALWAYS_ON and FETT263_FORCE_PUSH
 #endif
 
 #include "prop_base.h"
@@ -724,6 +732,20 @@ SaberFett263Buttons() : PropBase() {}
       case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
         if (battle_mode_ &&
             millis() - last_push_ > 2000) {
+          if (SFX_push) {
+            hybrid_font.PlayCommon(&SFX_push);
+          } else {
+            hybrid_font.DoEffect(EFFECT_FORCE, 0);
+          }
+          last_push_ = millis();
+        }
+        return true;
+
+#endif
+        
+#ifdef FETT263_FORCE_PUSH_ALWAYS_ON
+      case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
+        if (millis() - last_push_ > 2000) {
           if (SFX_push) {
             hybrid_font.PlayCommon(&SFX_push);
           } else {

--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -206,6 +206,13 @@
 #error You cannot define both FETT263_FORCE_PUSH_ALWAYS_ON and FETT263_FORCE_PUSH
 #endif
 
+#ifdef FETT263_FORCE_PUSH_ALWAYS_ON
+#define FORCE_PUSH_CONDITION true
+#define FETT263_FORCE_PUSH
+#else
+#define FORCE_PUSH_CONDITION battle_mode_
+#endif
+
 #include "prop_base.h"
 #include "../sound/hybrid_font.h"
 
@@ -722,22 +729,8 @@ SaberFett263Buttons() : PropBase() {}
 
 #ifdef FETT263_FORCE_PUSH
       case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
-        if (battle_mode_ &&
+        if (FORCE_PUSH_CONDITION &&
             millis() - last_push_ > 2000) {
-          if (SFX_push) {
-            hybrid_font.PlayCommon(&SFX_push);
-          } else {
-            hybrid_font.DoEffect(EFFECT_FORCE, 0);
-          }
-          last_push_ = millis();
-        }
-        return true;
-
-#endif
-        
-#ifdef FETT263_FORCE_PUSH_ALWAYS_ON
-      case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
-        if (millis() - last_push_ > 2000) {
           if (SFX_push) {
             hybrid_font.PlayCommon(&SFX_push);
           } else {


### PR DESCRIPTION
I've added an additional Multi-Blast mode control per user idea, in Battle Mode if you do a Blast with Aux button and swing within 3 seconds it will automatically enter Multi-Blast mode. 
And I've added control for Start or Stop Track while blade is on per user request using hold PWR with blade pointing straight up, this enables users to control tracks while blade is on.