### PR TITLE
Update smooth_swing_config.h

### DIFF
--- a/sound/smooth_swing_config.h
+++ b/sound/smooth_swing_config.h
@@ -12,8 +12,11 @@ public:
     CONFIG_VARIABLE(Transition1Degrees, 45.0f);
     CONFIG_VARIABLE(Transition2Degrees, 160.0f);
     CONFIG_VARIABLE(MaxSwingVolume, 3.0f);
+  #ifdef NO_ACCENT_SWINGS
     CONFIG_VARIABLE(AccentSwingSpeedThreshold, 0.0f);
-    CONFIG_VARIABLE(AccentSlashAccelerationThreshold, 260.0f);
+  #endif
+    CONFIG_VARIABLE(AccentSwingSpeedThreshold, 450.0f);
+    CONFIG_VARIABLE(AccentSlashAccelerationThreshold, 100.0f);
   };
 
   int  Version;


### PR DESCRIPTION
As per TRA discussion, the Wiki could also be edited to reflect this option of defaulting accent swings to ON