### PR TITLE
Update saber_base.h. add SWAP and MONOFORCE

### DIFF
--- a/common/saber_base.h
+++ b/common/saber_base.h
@@ -36,6 +36,8 @@ extern SaberBase* saberbases;
     DEFINE_EFFECT(POWERSAVE)                    \
     DEFINE_EFFECT(BATTERY_LEVEL)                \
     DEFINE_EFFECT(FAST_ON)                      \
+    DEFINE_EFFECT(SWAP)            		\
+    DEFINE_EFFECT(MONOFORCE)       		\
     /* Blaster effects */                       \
     DEFINE_EFFECT(STUN)				\
     DEFINE_EFFECT(FIRE)				\
@@ -194,6 +196,7 @@ public:                                                         \
   static void DoClash() { DoEffectR(EFFECT_CLASH); }
   static void DoBlast() { DoEffectR(EFFECT_BLAST); }
   static void DoForce() { DoEffectR(EFFECT_FORCE); }
+  static void DoMonoForce() { DoEffectR(EFFECT_MONOFORCE); }
   static void DoStab() { DoEffect(EFFECT_STAB, 1.0f); }
   static void DoBoot() { DoEffect(EFFECT_BOOT, 0); }
   static void DoBeginLockup() { DoEffectR(EFFECT_LOCKUP_BEGIN); }


### PR DESCRIPTION
Add SWAP and MONOFORCE - just extra features that can be used with BC prop file. 
SWAP - just another EFFECT to use to trigger EffectSequence to avoid being locked into using an existing effect like blast, clash, or tying up colorchange mode to do the swap, nulling access to the color wheel.
Used with BC prop file to "swap" blade styles within the same preset, or anything within EffectSequence really. Uses custom swap.wavs.
MONOFORCE is simply force effect that intentionally triggers a monophonic wav for sounds where the hum is silenced (seismic charge, iceblade, open for future conceptual use) Currently does not trigger a blade animation as invoking DoForce would collide with regular force sound. 
