### PR TITLE
RawHID support for Teensy based sabers

### DIFF
--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -20,7 +20,6 @@
 
 // You can have multiple configuration files, and specify which one
 // to use here.
-#define CONFIG_FILE "config/aat_teensy_singleblade_config.h"
 // #define CONFIG_FILE "config/default_proffieboard_config.h"
 // #define CONFIG_FILE "config/default_v3_config.h"
 // #define CONFIG_FILE "config/crossguard_config.h"
@@ -29,7 +28,7 @@
 // #define CONFIG_FILE "config/owk_v2_config.h"
 // #define CONFIG_FILE "config/test_bench_config.h"
 // #define CONFIG_FILE "config/toy_saber_config.h"
-// #define CONFIG_FILE "config/proffieboard_v1_test_bench_config.h"
+#define CONFIG_FILE "config/proffieboard_v1_test_bench_config.h"
 // #define CONFIG_FILE "config/td_proffieboard_config.h"
 // #define CONFIG_FILE "config/teensy_audio_shield_micom.h"
 // #define CONFIG_FILE "config/proffieboard_v2_ob4.h"
@@ -1905,4 +1904,3 @@ void loop() {
 #define CONFIG_BOTTOM
 #include CONFIG_FILE
 #undef CONFIG_BOTTOM
-

--- a/common/_usb_rawhid.h
+++ b/common/_usb_rawhid.h
@@ -1,0 +1,129 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _USBrawhid_h_
+#define _USBrawhid_h_
+
+#include "usb_desc.h"
+#include "usb_rawhid.h"
+
+#if defined(RAWHID_INTERFACE)
+
+#include <inttypes.h>
+
+// C language implementation
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Stream
+int _usb_rawhid_read(void);
+int _usb_rawhid_peek(void);
+// Print
+size_t _usb_rawhid_writeval(uint8_t val);
+size_t _usb_rawhid_writebuf(const uint8_t *buf, size_t size);
+#ifdef __cplusplus
+}
+#endif
+
+//Stream
+int _usb_rawhid_read() {
+    return -1;
+}
+
+int _usb_rawhid_peek() {
+    return -1;
+}
+
+// extension of usb_rawhid
+size_t _usb_rawhid_writeval(uint8_t val) {
+	uint8_t sendbuf[64];
+    memset(sendbuf,0, sizeof(sendbuf));
+	sendbuf[0] = val;
+    usb_rawhid_send(sendbuf, 100);
+    return (size_t) 1;
+}
+
+size_t _usb_rawhid_writebuf(const uint8_t *buf, size_t size) {
+    uint8_t sendbuf[64];
+	uint8_t _offset = 0;
+	while(size > 64){
+		memcpy(sendbuf, buf + _offset, 64);
+		usb_rawhid_send(sendbuf, 100);
+		_offset += 64;
+		size -= 64;
+	}
+    memset(sendbuf,0, sizeof(sendbuf)); //clear buffer to flush unwanted characters
+    memcpy(sendbuf, buf + _offset, size);
+    usb_rawhid_send(sendbuf, 100);
+    return (size_t) 64;
+}
+
+
+
+// C++ interface
+#ifdef __cplusplus
+#include "Stream.h"
+#include "Print.h"
+
+class _usb_rawhid_class : public Stream
+{
+public:
+    constexpr _usb_rawhid_class() {}
+	int available(void) {return usb_rawhid_available(); }
+	int recv(void *buffer, uint16_t timeout) { return usb_rawhid_recv(buffer, timeout); }
+	int send(const void *buffer, uint16_t timeout) { return usb_rawhid_send(buffer, timeout); }
+
+    // Stream implementation
+    int read(){ return _usb_rawhid_read(); };
+    int peek(){ return _usb_rawhid_peek(); };
+
+    // Print implementation
+    using Print::write; // pull in write(str) and write(buf, size) from Print
+    size_t write(uint8_t val) { _usb_rawhid_writeval(val); return 1;};
+	size_t write(const uint8_t *buf, size_t size)
+				{ _usb_rawhid_writebuf(buf, size); return size; }
+
+	int availableForWrite() { return 64; }
+    virtual void flush();
+
+private:
+	//size_t printFloat(double n, uint8_t digits);
+	//size_t printNumber(unsigned long n, uint8_t base, uint8_t sign);
+
+
+};
+
+extern _usb_rawhid_class SerialHID;
+
+#endif // __cplusplus
+
+#endif // RAWHID_INTERFACE
+
+#endif // USBrawhid_h_

--- a/common/stdout.h
+++ b/common/stdout.h
@@ -2,7 +2,9 @@
 #define COMMON_STDOUT_H
 
 #include "monitoring.h"
-
+#ifdef TEENSYDUINO
+#include "_usb_rawhid.h"
+#endif
 extern Print* default_output;
 extern Print* stdout_output;
 
@@ -23,12 +25,38 @@ public:
       stdout_output != default_output;
   }
   size_t write(uint8_t b) override {
+#ifdef TEENSYDUINO
+#if defined(RAWHID_INTERFACE)	
+	size_t ret = 1;
+    if (stdout_output) {
+		ret = stdout_output->write(b);
+	} else {
+		SerialHID.write(b);   
+	}
+#else
+	size_t	ret = stdout_output->write(b);
+#endif
+#else
     size_t ret = stdout_output->write(b);
+#endif
     if (debug_is_on()) default_output->write(b);
     return ret;
   }
   size_t write(const uint8_t *buffer, size_t size) override {
+#ifdef TEENSYDUINO
+#if defined(RAWHID_INTERFACE)	
+	size_t ret = 1;
+    if (stdout_output) {
+		ret = stdout_output->write(buffer, size);
+	} else {
+		SerialHID.write(buffer, size);   
+	}
+#else
+	size_t	ret = stdout_output->write(buffer, size);
+#endif
+#else
     size_t ret = stdout_output->write(buffer, size);
+#endif
     if (debug_is_on()) default_output->write(buffer, size);
     return ret;
   }


### PR DESCRIPTION
Extended the usb_rawhid class provided by Teensyduino an made  a SerialHID object /common/_usb_rawhid.h

Could not get it to be an actual Print*, therefore had to add an dedicated serial Parser in ProffieOS.ino and modified common/stdout.h to switch between serialHID and stream objects.

Only when Serial type: raw HID is selected, will the dode be actual used by the compiler.

Any suggestions are welcome to implement it better, before integrating this into ProffieOS
