### PR TITLE
Update saber_BC_buttons - prevent melt during lock/lb

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -850,10 +850,12 @@ public:
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON):
       clash_impact_millis_ = millis();
       swing_blast_ = false;
-      if (!swinging_) {
-        SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-        auto_melt_on_ = true;
-        SaberBase::DoBeginLockup();
+      if (!SaberBase::Lockup()) {
+        if (!swinging_) {
+          SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+          auto_melt_on_ = true;
+          SaberBase::DoBeginLockup();
+        }
       }
       return true;
 


### PR DESCRIPTION
Melt was triggering and interrupting lockup or lightning block with false clashes from loud volume.
Besides, not likely you'd be melting a door in the middle of a force lightning attack  ¯\_(ツ)_/¯