### PR TITLE
Add 'preamble' sound slot that plays before preon

### DIFF
--- a/sound/effect.h
+++ b/sound/effect.h
@@ -501,6 +501,7 @@ private:
 #define EFFECT2(X, Y) Effect SFX_##X(#X, &SFX_##Y)
 #define IMAGE_FILESET(X) Effect IMG_##X(#X, nullptr, Effect::FileType::IMAGE)
 
+EFFECT(preamble);
 EFFECT(preon);
 EFFECT(pstoff);
 


### PR DESCRIPTION
Feature Request: Play a 'preamble' sound file if found (example preamble01.wav). This will play before a preon (if there is a preon), or if there is no preon then the preamble will play before out.wav. The piece of code that I am unsure of is the monophonic_hum part, originally it was contained within the "if (SFX_preon)" code block, but instead I relocated that code to outside of that code block where it will now always execute regardless of if there is a preon or not (<--- again, I'm not sure of this part).

Use cases tested (each with polyphonic sound fonts):
(a) NO Preon, NO Preamble
(b) Preon only
(c) Preon + Preamble
(d) Preamble only

The changes are just for sound, and no corresponding blade functions. The intended use is for dialogue quotes before the saber turns on, but since this just creates a sound slot it could be used for any sound purpose that is desired in that spot  (music, positive affirmations, lightsaber creeds, fart noises).