### PR TITLE
Revert calls to bmbegin bmend

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -844,7 +844,7 @@ public:
         STDOUT.println("Entering Battle Mode");
         battle_mode_ = true;
         if (SFX_bmbegin) {
-          sound_library_.SayBattleModeBegin();
+          hybrid_font.PlayCommon(&SFX_bmbegin);
           STDOUT.println("-----------------playing bmbegin.wav");
         } else {
           hybrid_font.DoEffect(EFFECT_FORCE, 0);
@@ -854,7 +854,7 @@ public:
         STDOUT.println("Exiting Battle Mode");
         battle_mode_ = false;
         if (SFX_bmend) {
-          sound_library_.SayBattleModeEnd();
+          hybrid_font.PlayCommon(&SFX_bmbegin);
           STDOUT.println("-----------------playing bmend.wav");
         } else {
           beeper.Beep(0.5, 3000);


### PR DESCRIPTION
This was a premature change. 
bmbegin and bmend do not and should not exist in sound_library.
Going back to back to being SFX items played via hybrid_font.