### PR TITLE
Add missing include guard

### DIFF
--- a/sound/filter.h
+++ b/sound/filter.h
@@ -1,4 +1,5 @@
 #ifndef SOUND_FILTER_H
+#define SOUND_FILTER_H
 #include <complex>
 
 namespace Filter {


### PR DESCRIPTION
One of the files had only half of a include guard, this trivial patch adds the missing define.

