### PR TITLE
blaster.h fix for dual_prop use.

### DIFF
--- a/props/blaster.h
+++ b/props/blaster.h
@@ -275,7 +275,7 @@ public:
 
   // Make swings do nothing
   void DoMotion(const Vec3& motion, bool clear) override {
-    PropBase::DoMotion(motion, clear);
+    PropBase::DoMotion(Vec3(0), clear);
   }
 
   bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -273,6 +273,7 @@ public:
     }
   }
 
+  // Make swings do nothing
   void DoMotion(const Vec3& motion, bool clear) override {
     PropBase::DoMotion(Vec3(), clear);
   }

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -275,7 +275,7 @@ public:
 
   // Make swings do nothing
   void DoMotion(const Vec3& motion, bool clear) override {
-    PropBase::DoMotion(Vec3(), clear);
+    PropBase::DoMotion(motion, clear);
   }
 
   bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -273,8 +273,10 @@ public:
     }
   }
 
+#ifndef PROPS_DUAL_PROP_H
   // Make swings do nothing
   void DoMotion(const Vec3& motion, bool clear) override {}
+#endif
 
   bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     switch (EVENTID(button, event, modifiers)) {

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -273,10 +273,9 @@ public:
     }
   }
 
-#ifndef PROPS_DUAL_PROP_H
-  // Make swings do nothing
-  void DoMotion(const Vec3& motion, bool clear) override {}
-#endif
+  void DoMotion(const Vec3& motion, bool clear) override {
+    PropBase::DoMotion(Vec3(), clear);
+  }
 
   bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     switch (EVENTID(button, event, modifiers)) {


### PR DESCRIPTION
Smoothswings play when blaster mode is invoked by blade removal without this condition.