### PR TITLE
fontName " Font directory not found" message is helpful

### DIFF
--- a/sound/effect.h
+++ b/sound/effect.h
@@ -419,29 +419,30 @@ class Effect {
             ScanAll(dir, iter.name());
           }
         }
-
-      }
-
+      } else {
 #ifdef ENABLE_AUDIO
 #if VERSION_MAJOR < 4
-      else if (strlen(dir) > 8) { // TODO: Check individual path segments
-        STDOUT << "\nFont directory not found\n";
-        STDOUT << " and name exceeds 8 characters: " << dir << "\n";
-        talkie.Say(talkie_font_directory_15, 15);
-        talkie.Say(talkie_too_long_15, 15);
-      } else if (strlen(dir)) {
-        STDOUT << "\nFont directory not found: " << dir << "\n";
-        talkie.Say(talkie_font_directory_15, 15);
-        talkie.Say(talkie_not_found_15, 15);
-      } 
+        if (strlen(dir) > 8) { // TODO: Check individual path segments
+          STDOUT.println(" done");
+          STDOUT << "Font directory not found,\n";
+          STDOUT << "and name exceeds 8 characters: " << dir << "\n";
+          talkie.Say(talkie_font_directory_15, 15);
+          talkie.Say(talkie_too_long_15, 15);
+        } else if (strlen(dir)) {
+          STDOUT.println(" done");
+          STDOUT << "Font directory not found: " << dir << "\n";
+          talkie.Say(talkie_font_directory_15, 15);
+          talkie.Say(talkie_not_found_15, 15);
+        } 
 #else
-      else if (strlen(dir)) {
-        STDOUT << "\nFont directory not found: " << dir << "\n";
-        talkie.Say(talkie_font_directory_15, 15);
-        talkie.Say(talkie_not_found_15, 15);
-      }
+        if (strlen(dir)) {
+          STDOUT << "Font directory not found: " << dir << "\n";
+          talkie.Say(talkie_font_directory_15, 15);
+          talkie.Say(talkie_not_found_15, 15);
+        }
 #endif   // VERSION_MAJOR < 4
 #endif   // ENABLE_AUDIO
+      }
 #endif   // ENABLE_SD
       STDOUT.println(" done");
     }

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -427,6 +427,7 @@ class Effect {
         talkie.Say(talkie_font_directory_15, 15);
         talkie.Say(talkie_too_long_15, 15);
       } else if (strlen(dir)) {
+	STDOUT.println(" Font directory not found.");
         talkie.Say(talkie_font_directory_15, 15);
         talkie.Say(talkie_not_found_15, 15);
       }

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -423,14 +423,24 @@ class Effect {
       }
 
 #ifdef ENABLE_AUDIO
+#if VERSION_MAJOR < 4
       else if (strlen(dir) > 8) { // TODO: Check individual path segments
+        STDOUT << "\nFont directory not found\n";
+        STDOUT << " and name exceeds 8 characters: " << dir << "\n";
         talkie.Say(talkie_font_directory_15, 15);
         talkie.Say(talkie_too_long_15, 15);
       } else if (strlen(dir)) {
-	STDOUT.println(" Font directory not found.");
+        STDOUT << "\nFont directory not found: " << dir << "\n";
+        talkie.Say(talkie_font_directory_15, 15);
+        talkie.Say(talkie_not_found_15, 15);
+      } 
+#else
+      else if (strlen(dir)) {
+        STDOUT << "\nFont directory not found: " << dir << "\n";
         talkie.Say(talkie_font_directory_15, 15);
         talkie.Say(talkie_not_found_15, 15);
       }
+#endif   // VERSION_MAJOR < 4
 #endif   // ENABLE_AUDIO
 #endif   // ENABLE_SD
       STDOUT.println(" done");


### PR DESCRIPTION
...especially with additional fonts in the path, this clarifies which one(s).
Also useful for when no speaker is hooked up.
I found myself in both situations tonight and this was great small addition.