### PR TITLE
Option for OLED time out

### DIFF
--- a/display/ssd1306.h
+++ b/display/ssd1306.h
@@ -340,7 +340,7 @@ public:
         return font_config.ProffieOSFontImageDuration;
 
       case SCREEN_PLI:
-        if (!IMG_idle && !SaberBase::IsOn() && t_ > OLED_OFF_TIME) {
+        if (!SaberBase::IsOn() && t_ > OLED_OFF_TIME) {
           screen_ = SCREEN_OFF;
           return FillFrameBuffer2(advance);
         }

--- a/display/ssd1306.h
+++ b/display/ssd1306.h
@@ -1,8 +1,8 @@
 #ifndef DISPLAY_SSD1306_H
 #define DISPLAY_SSD1306_H
 
-#ifndef OLED_OFF_TIME
-#define OLED_OFF_TIME font_config.ProffieOSFontImageDuration
+#ifndef PLI_OFF_TIME
+#define PLI_OFF_TIME font_config.ProffieOSFontImageDuration
 #endif
 
 #include "monoframe.h"
@@ -340,7 +340,7 @@ public:
         return font_config.ProffieOSFontImageDuration;
 
       case SCREEN_PLI:
-        if (!SaberBase::IsOn() && t_ > OLED_OFF_TIME) {
+        if (!SaberBase::IsOn() && t_ > PLI_OFF_TIME) {
           screen_ = SCREEN_OFF;
           return FillFrameBuffer2(advance);
         }

--- a/display/ssd1306.h
+++ b/display/ssd1306.h
@@ -1,6 +1,10 @@
 #ifndef DISPLAY_SSD1306_H
 #define DISPLAY_SSD1306_H
 
+#ifndef OLED_OFF_TIME
+#define OLED_OFF_TIME font_config.ProffieOSFontImageDuration
+#endif
+
 #include "monoframe.h"
 
 // Images/animations
@@ -336,10 +340,10 @@ public:
         return font_config.ProffieOSFontImageDuration;
 
       case SCREEN_PLI:
-	if (!SaberBase::IsOn() && t_ > font_config.ProffieOSFontImageDuration) {
-	  screen_ = SCREEN_OFF;
-	  return FillFrameBuffer2(advance);
-	}
+        if (!IMG_idle && !SaberBase::IsOn() && t_ > OLED_OFF_TIME) {
+          screen_ = SCREEN_OFF;
+          return FillFrameBuffer2(advance);
+        }
 	Clear();
 	display_->DrawBatteryBar(BatteryBar16, battery_monitor.battery_percent());
 	if (HEIGHT > 32) {


### PR DESCRIPTION
Turning screen off after font_config.ProffieOSFontImageDuration sort of defeats the purpose if there's an idle image, as it wouldn't be shown for very long.
This edit would allow idle.bmp to display (if it exists) until IDLE_OFF_TIME expires.
If no idle image exists, it gives the user a discrete, configurable OLED_OFF_TIME option, with the original font_config.ProffieOSFontImageDuration as default if not specified.