### PR TITLE
Fix blaster jam check so that 0 percent actually is 0 percent

### DIFF
--- a/props/blaster.h
+++ b/props/blaster.h
@@ -108,7 +108,7 @@ public:
   }
 
   virtual bool CheckJam(int percent) {
-    int random = rand() % 100;
+    int random = rand() % 100 + 1;
     return random <= percent ? true : false;
   }
 

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -109,7 +109,7 @@ public:
 
   virtual bool CheckJam(int percent) {
     int random = rand() % 100;
-    return random < percent ? true : false;
+    return random < percent;
   }
 
   virtual void Fire() {

--- a/props/blaster.h
+++ b/props/blaster.h
@@ -108,8 +108,8 @@ public:
   }
 
   virtual bool CheckJam(int percent) {
-    int random = rand() % 100 + 1;
-    return random <= percent ? true : false;
+    int random = rand() % 100;
+    return random < percent ? true : false;
   }
 
   virtual void Fire() {


### PR DESCRIPTION
rand mod check on blaster jam percentage was incorrectly comparing in range 0-99 instead of 1-100. 0 percent chance should never jam.