### PR TITLE
Fix CAIWYN_SAVE_TRACKS by saving after track change instead of before

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1080,11 +1080,13 @@ public:
     return clash_pending1_;
   }
 
+#ifdef ENABLE_AUDIO
   virtual void PollTrackPlayer() {
     if (track_player_ && !track_player_->isPlaying()) {
       track_player_.Free();
     }
   }
+#endif
 
   void Loop() override {
     CallMotion();

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1080,6 +1080,12 @@ public:
     return clash_pending1_;
   }
 
+  virtual void PollTrackPlayer() {
+    if (track_player_ && !track_player_->isPlaying()) {
+      track_player_.Free();
+    }
+  }
+
   void Loop() override {
     CallMotion();
     if (clash_pending1_) {
@@ -1093,11 +1099,8 @@ public:
     PollScanId();
     CheckLowBattery();
 #ifdef ENABLE_AUDIO
-    if (track_player_ && !track_player_->isPlaying()) {
-      track_player_.Free();
-    }
+    PollTrackPlayer();
 #endif
-
 #ifndef DISABLE_COLOR_CHANGE
 #define TICK_ANGLE (M_PI * 2 / 12)
     switch (SaberBase::GetColorChangeMode()) {

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1080,13 +1080,11 @@ public:
     return clash_pending1_;
   }
 
-#ifdef ENABLE_AUDIO
   virtual void PollTrackPlayer() {
     if (track_player_ && !track_player_->isPlaying()) {
       track_player_.Free();
     }
   }
-#endif
 
   void Loop() override {
     CallMotion();

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1080,12 +1080,6 @@ public:
     return clash_pending1_;
   }
 
-  virtual void PollTrackPlayer() {
-    if (track_player_ && !track_player_->isPlaying()) {
-      track_player_.Free();
-    }
-  }
-
   void Loop() override {
     CallMotion();
     if (clash_pending1_) {
@@ -1099,8 +1093,11 @@ public:
     PollScanId();
     CheckLowBattery();
 #ifdef ENABLE_AUDIO
-    PollTrackPlayer();
+    if (track_player_ && !track_player_->isPlaying()) {
+      track_player_.Free();
+    }
 #endif
+
 #ifndef DISABLE_COLOR_CHANGE
 #define TICK_ANGLE (M_PI * 2 / 12)
     switch (SaberBase::GetColorChangeMode()) {

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -92,6 +92,16 @@
 //                                  fonts, but if it sounds weird you can
 //                                  disable the clash sound and just use the
 //                                  lockup by itself.
+// #define CAIWYN_SAVE_TRACKS     - Automatically saves the selected track for
+//                                  each preset. Any time the user holds the
+//                                  Aux button for one second to change the
+//                                  active track, the preset is updated to
+//                                  default to that track. This ONLY happens
+//                                  when the user selects the track directly;
+//                                  if the Track Player Mode is set to repeat
+//                                  all tracks, the saved track is not updated
+//                                  when the next track is automatically
+//                                  played.
 
 #ifndef PROPS_CAIWYN_BUTTONS_H
 #define PROPS_CAIWYN_BUTTONS_H
@@ -327,10 +337,6 @@ public:
         RunCommandAndFindNextSortedLine<128>("list_current_tracks", nullptr, nullptr, next_track, false);
       }
       strcpy(current_track_, next_track);
-#ifdef SAVE_TRACK
-      current_preset_.track = mkstr(current_track_);
-      current_preset_.Save();
-#endif
       PlayTrack();
     } else {
       StartOrStopTrack();
@@ -460,6 +466,10 @@ public:
 #endif
         if (track_player_) {
           NextTrack();
+#ifdef CAIWYN_SAVE_TRACKS
+          current_preset_.track = mkstr(current_track_);
+          current_preset_.Save();
+#endif
         } else {
           next_preset();
           strcpy(current_track_,current_preset_.track.get());

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -68,8 +68,7 @@
 // monce.wav                - Set Track Player to play a single track one time
 // mloop.wav                - Set Track Player to repeat a single track
 // mrotate.wav              - Set Track Player to repeat all tracks
-// mselect.wav              - Next Track (omit if you don't want a confirmation
-//                                        sound when the track is changed)
+// mselect.wav              - Next Track (can be omitted if you prefer)
 // ccbegin.wav              - Enter Color Change Mode
 // ccend01.wav              - Save Color and Exit Color Change Mode
 // ccend02.wav              - Reset Color and Exit Color Change Mode
@@ -82,17 +81,17 @@
 // https://drive.google.com/file/d/1cSBirX5STOVPanOkOlIeb0eofjx-qFmj/view
 //
 // Options you can add to your config file:
-// #define CAIWYN_BUTTON_LOCKUP   - Enables a lockup to be triggered without
-//                                  impact to the blade by pressing and holding
-//                                  the power button.  This effect replaces
-//                                  lightning blocks for two-button sabers, but
-//                                  if a saber has three buttons, the lightning
+// #define CAIWYN_BUTTON_CLASH    - Enables a clash to be triggered without
+//                                  impact to the blade by pressing the power
+//                                  button.  This effect replaces lightning
+//                                  blocks for two-button sabers, but if a
+//                                  saber has three buttons, the lightning
 //                                  block can be triggered by holding AUX2 and
 //                                  pressing AUX.
 //
-// #define CAIWYN_BUTTON_CLASH    - Enables a clash to be triggered without
-//                                  impact to the blade by pressing the power
-//                                  button.
+// #define CAIWYN_BUTTON_LOCKUP   - Enables a lockup to be triggered without
+//                                  impact to the blade by pressing and holding
+//                                  the power button.
 //                                  If both CAIWYN_BUTTON_LOCKUP and
 //                                  CAIWYN_BUTTON_CLASH are defined, pressing
 //                                  the power button triggers a lockup, but a

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -12,14 +12,14 @@
 //                            track is not playing
 //          Start/Stop Track: Click Aux
 //                Next Track: Hold Aux for 1 second while track is playing
+//                            | Tracks must be stored in <font>/tracks/*.wav
+//                            | and will be selected in alphabetical order.
 //         Track Player Mode: Double-click and hold Aux for 1 second while
 //                            track is playing
 //                            | This cycles through three playback modes:
 //                            | 1. Play a single track and stop (default)
 //                            | 2. Repeat a single track in a loop
 //                            | 3. Repeat all tracks in a loop
-//                            | Tracks must be in <font>/tracks/*.wav, and will
-//                            | be selected in alphabetical order.
 //             Turn Saber On: Press Power
 //     Turn On & Start Track: Hold Aux or Aux2 and press Power
 //
@@ -115,7 +115,7 @@
 //
 // #define CAIWYN_SAVE_TRACK_MODE - Saves the selected track mode to a config
 //                                  file so that the setting is restored when
-//                                  Proffieboad boots up after the battery is
+//                                  Proffieboard boots up after the battery is
 //                                  recharged or replaced.
 //                                  If SAVE_STATE is defined, then this will
 //                                  automatically be defined as well.

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -308,7 +308,7 @@ public:
   }
 
   void PlayTrack(const char* track) {
-    track_player_ = GetFreeWavPlayer();
+    if (!track_player_) track_player_ = GetFreeWavPlayer();
     if (track_player_) {
       track_player_->Play(track);
       track_player_on_ = true;

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -51,7 +51,7 @@
 //
 //            Turn Saber Off: Hold Aux or Aux2 and press Power
 //
-// If CAIWYN_BUTTON_LOCKUP is defined:
+// If CAIWYN_BUTTON_LOCKUP and/or CAIWYN_BUTTON_CLASH is defined:
 //   Non-impact Clash/Lockup: Click/Hold Power
 //                            | This generates a clash/lockup effect with no
 //                            | impact to the blade; quick press for a short

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -67,15 +67,15 @@
 // monce.wav                - Set Track Player to play a single track one time
 // mloop.wav                - Set Track Player to repeat a single track
 // mrotate.wav              - Set Track Player to repeat all tracks
-// mselect.wav              - Next Track (can be omitted if you prefer)
 // ccbegin.wav              - Enter Color Change Mode
 // ccend01.wav              - Save Color and Exit Color Change Mode
 // ccend02.wav              - Reset Color and Exit Color Change Mode
-// mbatt.wav                - Announce Current Battery Level
+// battlevl.wav             - Announce Current Battery Level
 // mnum1.wav to mnum20.wav  - Individually Spoken Numbers
 // thirty.wav to ninety.wav
 // hundred.wav              - "Hundred"
 // mpercent.wav             - "Percent"
+// mselect.wav              - Beep to confirm menu selections (can be omitted)
 // You can download a package containing all of these files here:
 // https://drive.google.com/file/d/1cSBirX5STOVPanOkOlIeb0eofjx-qFmj/view
 //
@@ -160,13 +160,6 @@
 #define CAIWYN_SAVE_TRACK_MODE
 #endif
 
-EFFECT(vmbegin);
-EFFECT(vmend);
-EFFECT(volmax);
-EFFECT(monce);
-EFFECT(mloop);
-EFFECT(mrotate);
-
 #ifdef CAIWYN_SAVE_TRACK_MODE
 class SaveCaiwynStateFile : public ConfigFile {
 public:
@@ -190,7 +183,7 @@ public:
     sound_library_.Poll(wav_player_);
   }
 
-  virtual void SetPreset(int preset_num, bool announce) override {
+  void SetPreset(int preset_num, bool announce) override {
     PropBase::SetPreset(preset_num, announce);
     strcpy(current_track_,current_preset_.track.get());
   }
@@ -212,13 +205,8 @@ public:
   void VolumeMenu() {
     current_menu_angle_ = fusor.angle2();
     mode_volume_ = true;
-    if (SFX_vmbegin) {
-      hybrid_font.PlayPolyphonic(&SFX_vmbegin);
-    } else {
-      beeper.Beep(0.20,1000.0);
-      beeper.Beep(0.20,1414.2);
-      beeper.Beep(0.20,2000.0);
-    }
+    sound_library_.SaySelect();
+    sound_library_.SayEnterVolumeMenu();
     STDOUT.println("Enter Volume Menu");
   }
 
@@ -242,28 +230,16 @@ public:
 
   void VolumeSave() {
     mode_volume_ = false;
-    if (SFX_vmend) {
-      hybrid_font.PlayPolyphonic(&SFX_vmend);
-    } else {
-      beeper.Beep(0.20,2000.0);
-      beeper.Beep(0.20,1414.2);
-      beeper.Beep(0.20,1000.0);
-    }
+    sound_library_.SaySelect();
+    sound_library_.SayVolumeMenuEnd();
     STDOUT.println("Exit Volume Menu");
   }
 
   void VolumeReset() {
     dynamic_mixer.set_volume(VOLUME);
     mode_volume_ = false;
-    if (SFX_volmax) {
-      hybrid_font.PlayPolyphonic(&SFX_volmax);
-    } else if (SFX_vmend) {
-      hybrid_font.PlayPolyphonic(&SFX_vmend);
-    } else {
-      beeper.Beep(0.20,2000.0);
-      beeper.Beep(0.20,1414.2);
-      beeper.Beep(0.20,1000.0);
-    }
+    sound_library_.SaySelect();
+    sound_library_.SayMaximumVolume();
     STDOUT.println("Volume Reset");
     STDOUT.print("Current Volume: ");
     STDOUT.println(dynamic_mixer.get_volume());
@@ -321,8 +297,6 @@ public:
           NextTrack(false);
           break;
       }
-    } else if (track_player_ && !track_player_->isPlaying()) {
-        track_player_.Free();
     }
   }
 
@@ -337,30 +311,34 @@ public:
     track_player_ = GetFreeWavPlayer();
     if (track_player_) {
       track_player_->Play(track);
+      track_player_on_ = true;
     } else {
       STDOUT.println("No available WAV players.");
+      track_player_on_ = false;
+      STDOUT.println("Track player stopped.");
     }
   }
 
   void StartTrackPlayer() {
     num_tracks_ = RunCommandAndGetSingleLine("list_current_tracks", nullptr, 0, 0, 0);
-    STDOUT.println("Track player started.");
     if (!current_track_) strcpy(current_track_,current_preset_.track.get());
     if (!TrackExists(current_track_)) {
       STDOUT.print(current_track_);
       STDOUT.println(" not found.");
-      RunCommandAndFindNextSortedLine<128>("list_current_tracks", nullptr, nullptr, current_track_, false);
+      if (num_tracks_ > 0) {
+        RunCommandAndFindNextSortedLine<128>("list_current_tracks", nullptr, nullptr, current_track_, false);
+      } else {
+        STDOUT.println("No tracks found.");
+        return;
+      }
     }
+    STDOUT.println("Track player started.");
     PlayTrack(current_track_);
-    track_player_on_ = true;
   }
 
   void StopTrackPlayer() {
     track_player_on_ = false;
-    if (track_player_) {
-      track_player_->Stop();
-      track_player_.Free();
-    }
+    if (track_player_ && track_player_->isPlaying()) track_player_->Stop();
     STDOUT.println("Track player stopped.");
 #ifdef CAIWYN_SAVE_TRACK_MODE
     SaveCaiwynState();
@@ -368,8 +346,7 @@ public:
   }
 
   void NextTrack(bool manually_selected) {
-    if (track_player_->isPlaying()) track_player_->Stop();
-    if (track_player_) track_player_.Free();
+    if (track_player_ && track_player_->isPlaying()) track_player_->Stop();
     if (num_tracks_ > 0) {
       char next_track[128];
       next_track[0] = 0;
@@ -389,38 +366,21 @@ public:
   }
 
   void ChangeTrackMode() {
+    sound_library_.SaySelect();
     switch (track_mode_) {
       case PLAYBACK_ONCE:
         track_mode_ = PLAYBACK_LOOP;
-        if (SFX_mloop) {
-          hybrid_font.PlayPolyphonic(&SFX_mloop);
-        } else {
-          beeper.Beep(0.20,1000);
-          beeper.Beep(0.20,2000);
-          beeper.Beep(0.20,1000);
-        }
+        sound_library_.SayLoop();
         STDOUT.println("Track player set to repeat single track.");
         break;
       case PLAYBACK_LOOP:
         track_mode_ = PLAYBACK_ROTATE;
-        if (SFX_mrotate) {
-          hybrid_font.PlayPolyphonic(&SFX_mrotate);
-        } else {
-          beeper.Beep(0.20,1000);
-          beeper.Beep(0.20,2000);
-          beeper.Beep(0.20,1000);
-        }
+        sound_library_.SayRotate();
         STDOUT.println("Track player set to repeat all tracks.");
         break;
       case PLAYBACK_ROTATE:
         track_mode_ = PLAYBACK_ONCE;
-        if (SFX_monce) {
-          hybrid_font.PlayPolyphonic(&SFX_monce);
-        } else {
-          beeper.Beep(0.20,1000);
-          beeper.Beep(0.20,2000);
-          beeper.Beep(0.20,1000);
-        }
+        sound_library_.Play("monce.wav");
         STDOUT.println("Track player set to play single track.");
         break;
     }
@@ -429,7 +389,8 @@ public:
   void CheckBattery() {
     SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
     if (SFX_mnum) {
-      sound_library_.SayBatteryLevel();
+      sound_library_.SaySelect();
+      sound_library_.SayTheBatteryLevelIs();
       sound_library_.SayNumber(battery_monitor.battery_percent(), SAY_WHOLE);
       sound_library_.SayPercent();
     } else {
@@ -445,6 +406,7 @@ public:
     if (!current_style()) return;
     if (SFX_ccend) {
       SFX_ccend.Select(1);
+      sound_library_.SaySelect();
     }
     STDOUT << "Reset Color Variation" << "\n";
     SetVariation(0);
@@ -545,6 +507,7 @@ public:
         } else if (SaberBase::GetColorChangeMode() == SaberBase::COLOR_CHANGE_MODE_STEPPED) {
           if (SFX_ccend) {
             SFX_ccend.Select(0);
+            sound_library_.SaySelect();
           }
           ToggleColorChangeMode();
           return true;
@@ -557,6 +520,7 @@ public:
         if (SaberBase::GetColorChangeMode() == SaberBase::COLOR_CHANGE_MODE_ZOOMED) {
           if (SFX_ccend) {
             SFX_ccend.Select(0);
+            sound_library_.SaySelect();
           }
           ToggleColorChangeMode();
           return true;
@@ -617,6 +581,7 @@ public:
 #ifndef DISABLE_COLOR_CHANGE
       case EVENTID(BUTTON_AUX, EVENT_THIRD_HELD_MEDIUM, MODE_ON):
         if (!mode_volume_) {
+          sound_library_.SaySelect();
           ToggleColorChangeMode();
           return true;
         }

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -113,6 +113,8 @@
 //                                  all tracks, the saved track is not updated
 //                                  when the next track is automatically
 //                                  played.
+//                                  If SAVE_STATE is defined, then this will
+//                                  automatically be defined as well.
 //
 // #define CAIWYN_SAVE_TRACK_MODE - Saves the selected track mode to a config
 //                                  file so that the setting is restored when
@@ -158,6 +160,7 @@
 #endif
 
 #ifdef SAVE_STATE
+#define CAIWYN_SAVE_TRACKS
 #define CAIWYN_SAVE_TRACK_MODE
 #endif
 

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -68,6 +68,8 @@
 // monce.wav                - Set Track Player to play a single track one time
 // mloop.wav                - Set Track Player to repeat a single track
 // mrotate.wav              - Set Track Player to repeat all tracks
+// mselect.wav              - Next Track (omit if you don't want a confirmation
+//                                        sound when the track is changed)
 // ccbegin.wav              - Enter Color Change Mode
 // ccend01.wav              - Save Color and Exit Color Change Mode
 // ccend02.wav              - Reset Color and Exit Color Change Mode

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -500,16 +500,14 @@ public:
 // Next Preset/Track
       case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_MEDIUM, MODE_OFF):
         if (track_player_on_) {
-          if (SFX_mselect) {
-            hybrid_font.PlayPolyphonic(&SFX_mselect);
-          } else {
-            beeper.Beep(0.1,2000);
-          }
           NextTrack();
 #ifdef CAIWYN_SAVE_TRACKS
           current_preset_.track = mkstr(current_track_);
           current_preset_.Save();
 #endif
+          if (SFX_mselect) {
+            hybrid_font.PlayPolyphonic(&SFX_mselect);
+          }
         } else {
           next_preset();
           strcpy(current_track_,current_preset_.track.get());

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -82,26 +82,24 @@
 // https://drive.google.com/file/d/1cSBirX5STOVPanOkOlIeb0eofjx-qFmj/view
 //
 // Options you can add to your config file:
-// #define CAIWYN_BUTTON_LOCKUP   - Enables clashes and lockups to be triggered
-//                                  without impact to the blade by pressing and
-//                                  holding the power button.  This effect
-//                                  replaces lightning blocks for two-button
-//                                  sabers, but if a saber has three buttons,
-//                                  the lightning block can be triggered by
-//                                  holding AUX2 and pressing AUX.
+// #define CAIWYN_BUTTON_LOCKUP   - Enables a lockup to be triggered without
+//                                  impact to the blade by pressing and holding
+//                                  the power button.  This effect replaces
+//                                  lightning blocks for two-button sabers, but
+//                                  if a saber has three buttons, the lightning
+//                                  block can be triggered by holding AUX2 and
+//                                  pressing AUX.
 //
-// #define CAIWYN_BUTTON_CLASH    - If CAIWYN_BUTTON_LOCKUP is defined, holding
-//                                  the power button triggers a lockup.  In
-//                                  practice, you can quickly press and release
-//                                  the power button to simulate a clash.
-//                                  However, this plays the bgnlock and endlock
-//                                  sounds in quick succession, which I have
-//                                  found usually sounds like multiple clashes
-//                                  rather than a single clash.
-//                                  If CAIWYN_BUTTON_CLASH is also defined, a
-//                                  a clash sound will be overlayed on top of
-//                                  the lockup sounds, which smooths out the
-//                                  result.
+// #define CAIWYN_BUTTON_CLASH    - Enables a clash to be triggered without
+//                                  impact to the blade by pressing the power
+//                                  button.
+//                                  If both CAIWYN_BUTTON_LOCKUP and
+//                                  CAIWYN_BUTTON_CLASH are defined, pressing
+//                                  the power button triggers a lockup, but a
+//                                  clash sound is overlayed on top of the
+//                                  lockup sounds to smooth out the transition
+//                                  from bgnlock and endlock sounds for quick
+//                                  clashes.  I recommend this configuration.
 //
 // #define CAIWYN_SAVE_TRACKS     - Automatically saves the selected track for
 //                                  each preset. Any time the user holds the
@@ -539,6 +537,8 @@ public:
 #ifdef CAIWYN_BUTTON_CLASH
           hybrid_font.PlayPolyphonic(&SFX_clsh);
 #endif
+#elif defined(CAIWYN_BUTTON_CLASH)
+          SaberBase::DoClash();
 #else
           SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
           SaberBase::DoBeginLockup();
@@ -640,7 +640,7 @@ public:
 #endif
 
 // Lightning Block
-#if NUM_BUTTONS > 2 && defined CAIWYN_BUTTON_LOCKUP
+#if NUM_BUTTONS > 2 && defined(CAIWYN_BUTTON_LOCKUP)
       case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON | BUTTON_AUX2):
       case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON | BUTTON_AUX):
         SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -166,7 +166,6 @@ EFFECT(volmax);
 EFFECT(monce);
 EFFECT(mloop);
 EFFECT(mrotate);
-EFFECT(mselect);
 
 #ifdef CAIWYN_SAVE_TRACK_MODE
 class SaveCaiwynStateFile : public ConfigFile {
@@ -369,17 +368,8 @@ public:
   }
 
   void NextTrack(bool manually_selected) {
-    if (manually_selected) {
-      track_player_->Stop();
-      track_player_.Free();
-#ifdef CAIWYN_SAVE_TRACKS
-      current_preset_.track = mkstr(current_track_);
-      current_preset_.Save();
-#endif
-      if (SFX_mselect) {
-        hybrid_font.PlayPolyphonic(&SFX_mselect);
-      }
-    }
+    if (track_player_->isPlaying()) track_player_->Stop();
+    if (track_player_) track_player_.Free();
     if (num_tracks_ > 0) {
       char next_track[128];
       next_track[0] = 0;
@@ -387,6 +377,13 @@ public:
         RunCommandAndFindNextSortedLine<128>("list_current_tracks", nullptr, nullptr, next_track, false);
       }
       strcpy(current_track_, next_track);
+      if (manually_selected) {
+#ifdef CAIWYN_SAVE_TRACKS
+        current_preset_.track = mkstr(current_track_);
+        current_preset_.Save();
+#endif
+        sound_library_.SaySelect();
+      }
     }
     PlayTrack(current_track_);
   }

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -24,16 +24,12 @@
 //     Turn On & Start Track: Hold Aux or Aux2 and press Power
 //
 // While saber is ON:
-//   Non-impact Clash/Lockup: Click/Hold Power
-//                            | This generates a clash/lockup effect with no
-//                            | impact to the blade; quick press for a short
-//                            | clash, hold for a lockup.
 //             Blaster Block: Click Aux
 //                    Lockup: Hold Aux or Aux2 during impact
 //                      Drag: Hold Aux or Aux2 during impact with blade pointed
 //                            down.
 //                      Melt: Hold Aux or Aux2 and stab
-//           Lightning Block: Hold Aux2 and Press Aux (3 buttons required)
+//           Lightning Block: Click/Hold Power
 //
 //         Enter Volume Menu: Double-click and hold Aux for 1 second
 //                            | Be aware that the first click will trigger a
@@ -55,6 +51,15 @@
 //
 //            Turn Saber Off: Hold Aux or Aux2 and press Power
 //
+// If CAIWYN_BUTTON_LOCKUP is defined:
+//   Non-impact Clash/Lockup: Click/Hold Power
+//                            | This generates a clash/lockup effect with no
+//                            | impact to the blade; quick press for a short
+//                            | clash, hold for a lockup.  This effect
+//                            | replaces the Lightning Block for sabers with
+//                            | only 2 buttons.
+//           Lightning Block: Hold Aux2 and press Aux (requires 3 buttons)
+//
 // You will need the following sound files in order for menus to work properly:
 // (missing sound files will be replaced with simple beeps)
 // vmbegin.wav              - Enter Volume Change Menu
@@ -75,23 +80,30 @@
 // https://drive.google.com/file/d/1cSBirX5STOVPanOkOlIeb0eofjx-qFmj/view
 //
 // Options you can add to your config file:
-// #define DISABLE_COLOR_CHANGE   - Disables the color change menu.
+// #define CAIWYN_BUTTON_LOCKUP   - Enables clashes and lockups to be triggered
+//                                  without impact to the blade by pressing and
+//                                  holding the power button.  This effect
+//                                  replaces lightning blocks for two-button
+//                                  sabers, but if a saber has three buttons,
+//                                  the lightning block can be triggered by
+//                                  holding AUX2 and pressing AUX.
+// #define CAIWYN_BUTTON_NOCLASH  - If CAIWYN_BUTTON_LOCKUP is defined, when
+//                                  you click the power button, both a clash
+//                                  sound and a lockup are simultaneously
+//                                  played.  This is because I have found that
+//                                  quickly starting and ending a lockup often
+//                                  sounds like multiple clashes rather than a
+//                                  single clash.
+//                                  To smooth everything out, a clash sound is
+//                                  mixed in as well.  This works for most
+//                                  fonts, but if it sounds weird you can
+//                                  define CAIWYN_BUTTON_NOCLASH and only the
+//                                  lockup sounds will be played.
 // #define CAIWYN_DISABLE_BEEPS   - Disables the single beep that occurs when
 //                                  selecting fonts, tracks, or entering or
 //                                  exiting the volume and color change menus.
 //                                  Note that beeps will still play if any
 //                                  sound file listed above is missing.
-// #define CAIWYN_NOCLASH_LOCKUP  - When you click the power button, both a
-//                                  clash sound and a lockup are simultaneously
-//                                  triggered.  This is because I have found
-//                                  that quickly starting and ending a lockup
-//                                  often sounds like multiple clashes rather
-//                                  than a single clash.
-//                                  To smooth everything out, a clash sound is
-//                                  mixed in as well.  This works for most
-//                                  fonts, but if it sounds weird you can
-//                                  disable the clash sound and just use the
-//                                  lockup by itself.
 // #define CAIWYN_SAVE_TRACKS     - Automatically saves the selected track for
 //                                  each preset. Any time the user holds the
 //                                  Aux button for one second to change the
@@ -102,6 +114,7 @@
 //                                  all tracks, the saved track is not updated
 //                                  when the next track is automatically
 //                                  played.
+// #define DISABLE_COLOR_CHANGE   - Disables the color change menu.
 
 #ifndef PROPS_CAIWYN_BUTTONS_H
 #define PROPS_CAIWYN_BUTTONS_H
@@ -488,13 +501,18 @@ public:
         }
         break;
 
-// Non-Impact Clash and Lockup / Zoom Color
+// Lightning Block / Non-Impact Clash and Lockup / Zoom Color
       case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ON):
         if (!SaberBase::Lockup() && !mode_volume_ && (SaberBase::GetColorChangeMode() == SaberBase::COLOR_CHANGE_MODE_NONE)) {
+#ifdef CAIWYN_BUTTON_LOCKUP
           SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
           SaberBase::DoBeginLockup();
-#ifndef CAIWYN_NOCLASH_LOCKUP
+#ifndef CAIWYN_BUTTON_NOCLASH
           hybrid_font.PlayPolyphonic(&SFX_clsh);
+#endif
+#else
+          SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+          SaberBase::DoBeginLockup();
 #endif
           return true;
 #ifndef DISABLE_COLOR_CHANGE
@@ -606,10 +624,10 @@ public:
 #endif
 
 // Lightning Block
-#if NUM_BUTTONS > 2
+#if NUM_BUTTONS > 2 && defined CAIWYN_BUTTON_LOCKUP
       case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON | BUTTON_AUX2):
       case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON | BUTTON_AUX):
-        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+        SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
         SaberBase::DoBeginLockup();
         return true;
 #endif

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -88,18 +88,18 @@
 //                                  the lightning block can be triggered by
 //                                  holding AUX2 and pressing AUX.
 //
-// #define CAIWYN_BUTTON_NOCLASH  - If CAIWYN_BUTTON_LOCKUP is defined, when
-//                                  you click the power button, both a clash
-//                                  sound and a lockup are simultaneously
-//                                  played.  This is because I have found that
-//                                  quickly starting and ending a lockup often
-//                                  sounds like multiple clashes rather than a
-//                                  single clash.
-//                                  To smooth everything out, a clash sound is
-//                                  mixed in as well.  This works for most
-//                                  fonts, but if it sounds weird you can
-//                                  define CAIWYN_BUTTON_NOCLASH and only the
-//                                  lockup sounds will be played.
+// #define CAIWYN_BUTTON_CLASH    - If CAIWYN_BUTTON_LOCKUP is defined, holding
+//                                  the power button triggers a lockup.  In
+//                                  practice, you can quickly press and release
+//                                  the power button to simulate a clash.
+//                                  However, this plays the bgnlock and endlock
+//                                  sounds in quick succession, which I have
+//                                  found usually sounds like multiple clashes
+//                                  rather than a single clash.
+//                                  If CAIWYN_BUTTON_CLASH is also defined, a
+//                                  a clash sound will be overlayed on top of
+//                                  the lockup sounds, which smooths out the
+//                                  result.
 //
 // #define CAIWYN_DISABLE_BEEPS   - Disables the single beep that occurs when
 //                                  selecting fonts, tracks, or entering or
@@ -563,7 +563,7 @@ public:
 #ifdef CAIWYN_BUTTON_LOCKUP
           SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
           SaberBase::DoBeginLockup();
-#ifndef CAIWYN_BUTTON_NOCLASH
+#ifdef CAIWYN_BUTTON_CLASH
           hybrid_font.PlayPolyphonic(&SFX_clsh);
 #endif
 #else

--- a/props/saber_caiwyn_buttons.h
+++ b/props/saber_caiwyn_buttons.h
@@ -291,12 +291,13 @@ public:
       switch (track_mode_) {
         case PLAYBACK_ONCE:
           track_player_on_ = false;
+          if (num_tracks_ > 0) STDOUT.println("Track player stopped.");
           break;
         case PLAYBACK_LOOP:
-          if (num_tracks_ <= 0) {
-            StartOrStopTrack();
-          } else {
+          if (num_tracks_ > 0) {
             PlayTrack();
+          } else {
+            StartOrStopTrack();
           }
           break;
         case PLAYBACK_ROTATE:
@@ -307,13 +308,18 @@ public:
   }
 
   void PlayTrack() {
-    if (!current_track_) {
-      strcpy(current_track_,current_preset_.track.get());
+    if (!current_track_) strcpy(current_track_,current_preset_.track.get());
+    if (!LSFS::Exists(current_track_)) {
+      STDOUT.print(current_track_);
+      STDOUT.println(" not found.");
+      RunCommandAndFindNextSortedLine<128>("list_current_tracks", nullptr, nullptr, current_track_, false);
     }
     MountSDCard();
     EnableAmplifier();
     track_player_ = GetFreeWavPlayer();
     if (track_player_) {
+      STDOUT.print("Now playing ");
+      STDOUT.println(current_track_);
       track_player_->Play(current_track_);
     } else {
       STDOUT.println("No available WAV players.");
@@ -323,6 +329,7 @@ public:
   void StartTrackPlayer() {
     num_tracks_ = RunCommandAndGetSingleLine("list_current_tracks", nullptr, 0, 0, 0);
     if (num_tracks_ > 0) {
+      STDOUT.println("Track player started.");
       PlayTrack();
     } else {
       StartOrStopTrack();
@@ -335,6 +342,7 @@ public:
     if (track_player_) {
       track_player_->Stop();
       track_player_.Free();
+      STDOUT.println("Track player stopped.");
     } else {
       StartOrStopTrack();
     }
@@ -371,6 +379,7 @@ public:
           beeper.Beep(0.20,2000);
           beeper.Beep(0.20,1000);
         }
+        STDOUT.println("Track player set to repeat single track.");
         break;
       case PLAYBACK_LOOP:
         track_mode_ = PLAYBACK_ROTATE;
@@ -384,6 +393,7 @@ public:
           beeper.Beep(0.20,2000);
           beeper.Beep(0.20,1000);
         }
+        STDOUT.println("Track player set to repeat all tracks.");
         break;
       case PLAYBACK_ROTATE:
         track_mode_ = PLAYBACK_ONCE;
@@ -397,6 +407,8 @@ public:
           beeper.Beep(0.20,2000);
           beeper.Beep(0.20,1000);
         }
+        STDOUT.println("Track player set to play single track.");
+        break;
     }
   }
 


### PR DESCRIPTION
This fixes a bug in CAIWYN_SAVE_TRACKS.  The save is meant to occur whenever a new track is manually selected, but it was happening before the new track was in memory, causing it to save the previous track instead of the newly-selected track.