### PR TITLE
New Config Options for Disabling Preset Changing Props

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -182,7 +182,7 @@ public:
 #else
     // No sound means no preon.
     FastOn();
-#endif    
+#endif
   }
 
   void FastOn() {
@@ -360,15 +360,15 @@ public:
   void SaveVolumeIfNeeded() {
     if (0
 #ifdef SAVE_VOLUME
-      || dynamic_mixer.get_volume() != saved_global_state.volume
+        || dynamic_mixer.get_volume() != saved_global_state.volume
 #endif
 #ifdef SAVE_BLADE_DIMMING
-      || SaberBase::GetCurrentDimming() != saved_global_state.dimming
+        || SaberBase::GetCurrentDimming() != saved_global_state.dimming
 #endif
 #ifdef SAVE_CLASH_THRESHOLD
-      || GetCurrentClashThreshold() != saved_global_state.clash_threshold
-#endif	
-      ) {
+        || GetCurrentClashThreshold() != saved_global_state.clash_threshold
+#endif
+    ) {
       SaveGlobalState();
     }
   }
@@ -490,7 +490,7 @@ public:
     if (on) On();
     TRACE(PROP, "end");
   }
-	
+
   // Go to the next Preset.
   virtual void next_preset() {
 #ifdef SAVE_PRESET
@@ -565,7 +565,7 @@ public:
 
   size_t FindBestConfig() {
     static_assert(NELEM(blades) > 0, "blades array cannot be empty");
-    
+
     size_t best_config = 0;
     if (NELEM(blades) > 1) {
       float resistor = id();
@@ -602,7 +602,7 @@ public:
     }
     return false;
   }
-    
+
   // Must be called from loop()
   void PollScanId() {
     if (find_blade_again_pending_) {
@@ -612,7 +612,7 @@ public:
   }
 #else
   void PollScanId() {}
-#endif  
+#endif
 
   // Called from setup to identify the blade and select the right
   // Blade driver, style and sound font.
@@ -769,11 +769,11 @@ public:
     } else {
 #ifndef PROFFIEOS_DONT_USE_GYRO_FOR_CLASH
       v = (diff.len() + fusor.gyro_clash_value()) / 2.0;
-#else      
+#else
       v = diff.len();
-#endif      
+#endif
     }
-#if 0    
+#if 0
     static uint32_t last_printout=0;
     if (millis() - last_printout > 1000) {
       last_printout = millis();
@@ -783,13 +783,13 @@ public:
 	     << " v = " << v << "\n";
     }
 #endif
-    // If we're spinning the saber or if loud sounds are playing, 
+    // If we're spinning the saber or if loud sounds are playing,
     // require a stronger acceleration to activate the clash.
     if (v > (CLASH_THRESHOLD_G + fusor.gyro().len() / 200.0)
 #if defined(ENABLE_AUDIO) && defined(AUDIO_CLASH_SUPPRESSION_LEVEL)
-	+ (dynamic_mixer.audio_volume() * (AUDIO_CLASH_SUPPRESSION_LEVEL * 0.000001))
-#endif	
-      ) {    
+                + (dynamic_mixer.audio_volume() * (AUDIO_CLASH_SUPPRESSION_LEVEL * 0.000001))
+#endif
+    ) {
       if ( (accel_ - fusor.down()).len2() > (accel - fusor.down()).len2() ) {
         diff = -diff;
       }
@@ -1589,7 +1589,7 @@ public:
       SetClashThreshold(parsefloat(arg));
       return true;
     }
-#endif    
+#endif
 
     if (!strcmp(cmd, "get_preset")) {
       STDOUT.println(current_preset_.preset_num);

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -504,7 +504,10 @@ public:
 #ifdef SAVE_PRESET
     SaveState(current_preset_.preset_num + 1);
 #endif
+
+#ifndef DISABLE_FAST_PRESET_CHANGE
     SetPresetFast(current_preset_.preset_num + 1);
+#endif
   }
 
   // Go to the previous Preset.
@@ -520,7 +523,10 @@ public:
 #ifdef SAVE_PRESET
     SaveState(current_preset_.preset_num - 1);
 #endif
+
+#ifndef DISABLE_FAST_PRESET_CHANGE
     SetPresetFast(current_preset_.preset_num - 1);
+#endif
   }
 
   // Rotates presets backwards and saves.

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -29,15 +29,15 @@ Features:
 - No blade inserted = no gestures option if Blade Detect is used.
 - Optional On-the-fly volume controls with Quick MIN and MAX levels.
 - Bypass preon and/or postoff based on blade angle.
-- Spam Blast - Enter this mode to make the button super sensitive for                      
+- Spam Blast - Enter this mode to make the button super sensitive for
                             multiple blaster blocks. Presses are prioritized over
                             other features. No limits, no lag when "rapid firing".
 - Swap feature with sound - Just an additional EFFECT that can be used to trigger
                             blade animations. See below.
 ---------------------------------------------------------------------------
 Optional Blade style elements:
-On-Demand battery level - A layer built into the blade styles that reacts 
-                          as the battery gets weaker, changing blade color 
+On-Demand battery level - A layer built into the blade styles that reacts
+                          as the battery gets weaker, changing blade color
                           from Green to Red, and the blade length shortens.
 EFFECT_USER1            - Swap feature: Use as a standalone trigger for EffectSequence<>,
                           for example as a way to have multiple blade styles in one preset.
@@ -70,7 +70,12 @@ Gesture Controls:
 #define BC_TWIST_OFF
 #define NO_BLADE_NO_GEST_ONOFF
 - If using blade detect, Gesture ignitions or retractions are disabled.
-  **NOTE** Only works when a BLADE_DETECT_PIN is defined. 
+  **NOTE** Only works when a BLADE_DETECT_PIN is defined.
+
+#define BC_NO_TWIST_PRESET_CHANGE
+- Used to disable the ability to change presets while performing a twist gesture
+  when pointing the blade up or down. This is useful if you like to perform
+  twist gestures to turn the saber on or off at extreme angles.
 
 #define BC_FORCE_PUSH
 - This mode plays a force sound (or force push sound if the font contains it) with
@@ -86,7 +91,7 @@ Gesture Controls:
 
 #define BC_GESTURE_AUTO_BATTLE_MODE
 - Makes gesture ignition ALSO enter battle mode automatically on ignition.
-- *Note* - Cannot be used if #define BC_NO_BM is active. 
+- *Note* - Cannot be used if #define BC_NO_BM is active.
 
 "Battle Mode 1.0" by fett263, BC modified version:
 - Once you enter battle mode, buttons are not used for lockup.
@@ -112,7 +117,7 @@ Gesture Controls:
   stab something, and end when you pull away or push any button.
 
 - Stab will trigger with no buttons and thrusting forward.
-  
+
 ====================== 1 BUTTON CONTROLS ========================
 | Sorted by ON or OFF state: (what it's like while using saber) |
 =================================================================
@@ -127,13 +132,13 @@ Prev Preset           - Double click and hold POW, release after a second (click
                         or TWIST while pointing down.
 Play/Stop Track       - 4x click POW.
 Volume Menu:
-                      * NOTE * Tilting blade too high or low in Volume Menu will give a warning tone to 
+                      * NOTE * Tilting blade too high or low in Volume Menu will give a warning tone to
                         tilt up or down to avoid erratic rotational volume changes at extreme blade angles.
         Enter/Exit    - Hold POW + Clash.
-        Volume UP     - Rotate Right 
-                      - or - 
+        Volume UP     - Rotate Right
+                      - or -
                       - Long click and release POW while in Volume Menu. (just like next preset)
-        Volume DOWN   - Rotate Left 
+        Volume DOWN   - Rotate Left
                       - or -
                       - Double click and hold POW, release after a second while in Volume Menu.
                         (click then long click, just like next preset)
@@ -163,7 +168,7 @@ Spam Blaster Blocks   - 3x click and hold while pointing up. This toggles SPAM B
                         * Note * This gets in the way of normal features,
                         so turn off when you're done spamming.  Plays mzoom.wav.
 Auto Swing Blast      - if #define ENABLE_AUTO_SWING_BLAST is active,
-                        swinging within 1 second of doing button activated 
+                        swinging within 1 second of doing button activated
                         Blaster Block will start this timed mode.
                         To trigger auto blaster blocks, swing saber
                         within 1 second of last Swing Blast block.
@@ -195,7 +200,7 @@ Color Change Mode     - Hold POW + Twist. (while pointing down)
           next color and exit color change mode. If the style does not use
           ColorChange<>, it has no effect.
 Quote Player          - Triple click POW.
-Toggle sequential or 
+Toggle sequential or
   random quote play   - 4x click and hold POW. (while pointing down)
 Force Push            - Push hilt perpendicularly from a stop.
 Swap (EffectSequence) - 4x click and hold POW. (while NOT pointing up)
@@ -220,13 +225,13 @@ Prev Preset           - Double click and hold POW, release after a second (click
                         or TWIST while pointing down.
 Play/Stop Track       - Hold AUX + Double click POW.
 Volume Menu:
-                      * NOTE * Tilting blade too high or low in Volume Menu will give a warning tone to 
+                      * NOTE * Tilting blade too high or low in Volume Menu will give a warning tone to
                         tilt up or down to avoid erratic rotational volume changes at extreme blade angles.
         Enter/Exit    - Hold POW + Clash.
-        Volume UP     - Rotate Right 
-                      - or - 
+        Volume UP     - Rotate Right
+                      - or -
                       - Long click and release POW while in Volume Menu. (just like next preset)
-        Volume DOWN   - Rotate Left 
+        Volume DOWN   - Rotate Left
                       - or -
                       - Double click and hold POW, release after a second while in Volume Menu.
                         (click then long click, just like next preset)
@@ -256,7 +261,7 @@ Spam Blaster Blocks   - 3x click and hold while pointing up. This toggles SPAM B
                         * Note * This gets in the way of normal features,
                         so turn off when you're done spamming.  Plays mzoom.wav.
 Auto Swing Blast      - if #define ENABLE_AUTO_SWING_BLAST is active,
-                        swinging within 1 second of doing button activated 
+                        swinging within 1 second of doing button activated
                         Blaster Block will start this timed mode.
                         To trigger auto blaster blocks, swing saber
                         within 1 second of last Swing Blast block.
@@ -288,7 +293,7 @@ Color Change Mode     - Hold POW + Twist. (while pointing down)
           next color and exit color change mode. If the style does not use
           ColorChange<>, it has no effect.
 Quote Player          - Triple click POW.
-Toggle sequential or 
+Toggle sequential or
   random quote play   - Hold AUX + Twist. (while pointing down)
 Force Push            - Push hilt perpendicularly from a stop.
 Swap (EffectSequence) - Hold AUX + Twist. (while NOT pointing up)
@@ -363,7 +368,7 @@ Turn OFF without postoff - Turn OFF while pointing up.
 #endif
 
 #if defined(NO_BLADE_NO_GEST_ONOFF) && !defined(BLADE_DETECT_PIN)
-#error Using NO_BLADE_NO_GEST_ONOFF requires a BLADE_DETECT_PIN to be defined 
+#error Using NO_BLADE_NO_GEST_ONOFF requires a BLADE_DETECT_PIN to be defined
 #endif
 
 #if defined(BC_NO_BM) && defined(BC_GESTURE_AUTO_BATTLE_MODE)
@@ -612,7 +617,7 @@ public:
 // Gesture Ignition Controls
 #ifdef BC_SWING_ON
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
-      if (mode_volume_) return false;  
+      if (mode_volume_) return false;
 #ifdef NO_BLADE_NO_GEST_ONOFF
       if (!blade_detected_) return false;
 #endif
@@ -625,16 +630,23 @@ public:
 #endif  // BC_SWING_ON
 
     case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+
+#ifndef BC_NO_TWIST_PRESET_CHANGE
+
       // pointing down
-      if (fusor.angle1() < - M_PI / 4) {
-        previous_preset();
-        return true;
+      if (fusor.angle1() < -M_PI / 4) {
+          previous_preset();
+          return true;
       }
       // pointing up
-      if (fusor.angle1() >  M_PI / 3) {
+      if (fusor.angle1() > M_PI / 3) {
         next_preset();
-      } else {
-       // NOT pointing up OR down
+        return true;
+      }
+
+#endif  // BC_NO_TWIST_PRESET_CHANGE
+
+      // NOT pointing up OR down
 #ifdef BC_TWIST_ON
         if (mode_volume_) return false;
 #ifdef NO_BLADE_NO_GEST_ONOFF
@@ -651,7 +663,7 @@ public:
           last_twist_ = millis();
         }
 #endif  // BC_TWIST_ON
-      }
+
       return true;
 
 #ifdef BC_TWIST_OFF
@@ -726,7 +738,7 @@ public:
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       // No power on without exiting Vol Menu first
       if (!mode_volume_) {
-      // Bypass preon if pointing up         
+        // Bypass preon if pointing up
         if (fusor.angle1() >  M_PI / 3) {
           FastOn();
         } else {


### PR DESCRIPTION
# What's New?
The main purpose of this update is to provide two new defines for personal saber configurations that allow users to easily disable preset changing props that may be found irritable during normal saber operation. The name of each of these configuration options were chosen to match similar naming conventions found in both affected prop implementations.

| Deifne | Affected Prop | Description     |
|------------------|-----------|-----------|
| `BC_NO_QUICK_PRESET_CHANGE` | BC Button Props (`props/saber_BC_buttons.h`) | Disable changing presets by twisting when twist gestures are enabled. |
| `DISABLE_FAST_PRESET_CHANGE` | All Props (`props/prop_base.h`) | Disable changing presets quickly while the blade is on. |

This PR also includes some simple file cleanup based on the Google CPP Format Style for affected prop header files.