### PR TITLE
Add Option for Disabling Fast Preset Change

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -504,7 +504,10 @@ public:
 #ifdef SAVE_PRESET
     SaveState(current_preset_.preset_num + 1);
 #endif
+
+#ifndef DISABLE_FAST_PRESET_CHANGE
     SetPresetFast(current_preset_.preset_num + 1);
+#endif // DISABLE_FAST_PRESET_CHANGE
   }
 
   // Go to the previous Preset.
@@ -520,7 +523,10 @@ public:
 #ifdef SAVE_PRESET
     SaveState(current_preset_.preset_num - 1);
 #endif
+
+#ifndef DISABLE_FAST_PRESET_CHANGE
     SetPresetFast(current_preset_.preset_num - 1);
+#endif // DISABLE_FAST_PRESET_CHANGE
   }
 
   // Rotates presets backwards and saves.


### PR DESCRIPTION
Have you ever been incredibly annoyed that you changed your blade style while trying to retract it because of your hold angle? `DISABLE_FAST_PRESET_CHANGE` is a new define that allows you to disable changing presets quickly while the blade is on, which in my experience is a completely undesirable feature.