### PR TITLE
fix DUAL_PROP_CONDITION

### DIFF
--- a/props/dual_prop.h
+++ b/props/dual_prop.h
@@ -26,7 +26,7 @@ Give the BladeConfig 2 sets of descriptions, and
 */
 
 
-#define DUAL_PROP_CONDITION blade_present()
+#define DUAL_PROP_CONDITION this->blade_present()
 
 #ifdef PROP_INHERIT_PREFIX
 #error dual_prop.h must be included first


### PR DESCRIPTION
Avoid error: there are no arguments to 'blade_present' that depend on a template parameter, so a declaration of 'blade_present' must be available [-fpermissive]