### PR TITLE
Update prop_base.h

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -628,8 +628,6 @@ public:
       bool blade_present_after = blade_present();
       if (blade_present_before != blade_present_after) {
         SaberBase::DoBladeDetect(blade_present_after);
-      } else {
-	SaberBase::DoNewFont();
       }
     }
   }


### PR DESCRIPTION
In testing, this causes the board to play font.wav "for no reason". Although the board may have detected a change, if the result after averaging reads is the same state as before, it should just be quiet. Serial monitor still reports activity.