### PR TITLE
BC_buttons - faston replace out

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -185,7 +185,7 @@ public:
 #endif
   }
 
-  void FastOn() {
+  virtual void FastOn() {
     if (!CommonIgnition()) return;
     SaberBase::TurnOn();
     SaberBase::DoEffect(EFFECT_FAST_ON, 0);

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -590,6 +590,13 @@ public:
     }
   }
 
+  void FastOn() override {
+    if (SFX_faston) SFX_out.Select(-2);
+    SaberBase::TurnOn();
+    SaberBase::DoEffect(EFFECT_FAST_ON, 0);
+    SFX_out.Select(-1);
+  }
+
   RefPtr<BufferedWavPlayer> wav_player;
 
   bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {


### PR DESCRIPTION
What's a better way to skip playing out.wav than this?
Currently, this assigns an invalid wav file to play and results in something like:
"File Dooku/out/out.wav not found." 

While it works audio-wise, I feel it doesn't make sense to hack a workaround like this.