### PR TITLE
add missing return

### DIFF
--- a/modes/mode.h
+++ b/modes/mode.h
@@ -5,7 +5,9 @@
 // allows you to temporarily override buttons and other types of events.
 struct ModeInterface {
   virtual void mode_activate(bool onreturn) {}
-  virtual bool mode_Event2(enum BUTTON button, EVENT event, uint32_t modifiers) {}
+  virtual bool mode_Event2(enum BUTTON button, EVENT event, uint32_t modifiers) {
+    return true;
+  }
   virtual void mode_Loop() {}
   virtual bool mode_Parse(const char *cmd, const char* arg) { return false; }
 

--- a/modes/mode.h
+++ b/modes/mode.h
@@ -6,7 +6,7 @@
 struct ModeInterface {
   virtual void mode_activate(bool onreturn) {}
   virtual bool mode_Event2(enum BUTTON button, EVENT event, uint32_t modifiers) {
-    return true;
+    return false;
   }
   virtual void mode_Loop() {}
   virtual bool mode_Parse(const char *cmd, const char* arg) { return false; }


### PR DESCRIPTION
Appeazes Arduino warning
"ProffieOS/modes/mode.h:8:82: warning: no return statement in function returning non-void [-Wreturn-type]
8 | virtual bool mode_Event2(enum BUTTON button, EVENT event, uint32_t modifiers) {}"