### PR TITLE
Updated ColorCycle variable names

### DIFF
--- a/styles/color_cycle.h
+++ b/styles/color_cycle.h
@@ -5,19 +5,27 @@
 #include "rgb.h"
 
 // Usage: ColorCycle<COLOR, PERCENT, RPM>
-// or: ColorCycle<COLOR, PERCENT, RPM, ON_COLOR, ON_PERCENT, ON_RPM, FADE_TIME_MILLIS, OFF_COLOR>
-// COLOR, ON_COLOR, OFF_COLOR: COLOR
-// RPM, PERCENT, ON_PERCENT, ON_RPM, FADE_TIME_MILLIS: a number
+// or: ColorCycle<OFF_COLOR, OFF_PERCENT, OFF_RPM, ON_COLOR, ON_PERCENT, ON_RPM, FADE_TIME_MILLIS, BASE_COLOR>
+// OFF_COLOR, ON_COLOR, BASE_COLOR: COLOR
+// OFF_RPM, OFF_PERCENT, ON_PERCENT, ON_RPM, FADE_TIME_MILLIS: a number
 // return value: COLOR
 // This is intended for a small ring of neopixels
 // A section of the ring is lit at the specified color
 // and rotates at the specified speed. The size of the
 // lit up section is defined by "percentage".
+// The arguments for this style are divided into two groups of
+// { COLOR, PERCENT, RPM }, one for while the blade is OFF, and the other
+// while it's ON.
+// BASE_COLOR is the color of pixels not part of the lit section, so if PERCENT
+// is 0, the entire blade will be BASE_COLOR, and if PERCENT is 100, the entire blade
+// will be OFF_COLOR or ON_COLOR (depending on blade state).
+// FADE_TIME_MILLIS is the time taken to transition between the OFF and ON groups
+// of values.
 class BladeBase;
 
 class ColorCycleBase {
 public:
-  bool run(BladeBase* base, int percentage, int rpm, int on_percentage, int on_rpm, int fade_time_millis,
+  bool run(BladeBase* base, int off_percentage, int off_rpm, int on_percentage, int on_rpm, int fade_time_millis,
     bool off_color_is_black) {
     bool keep_running = true;
 
@@ -30,9 +38,9 @@ public:
     if (!base->is_on()) fade_delta = - fade_delta;
     fade_ = std::max<float>(0.0f, std::min(1.0f, fade_ + fade_delta));
 
-    float current_rpm = rpm * (1 - fade_) + on_rpm * fade_;
+    float current_rpm = off_rpm * (1 - fade_) + on_rpm * fade_;
     float current_percentage =
-       percentage * (1 - fade_) + on_percentage * fade_;
+       off_percentage * (1 - fade_) + on_percentage * fade_;
     fade_int_ = (int)(16384 * fade_);
     pos_ = fract(pos_ + delta / 60000000.0 * current_rpm);
     num_leds_ = base->num_leds() * 16384;
@@ -72,34 +80,34 @@ protected:
 };
 
 
-template<class COLOR, int percentage, int rpm,
-         class ON_COLOR = COLOR,
-         int on_percentage = percentage,
-         int on_rpm = rpm,
+template<class OFF_COLOR, int off_percentage, int off_rpm,
+         class ON_COLOR = OFF_COLOR,
+         int on_percentage = off_percentage,
+         int on_rpm = off_rpm,
          int fade_time_millis = 1,
-         class OFF_COLOR = Rgb<0,0,0> >
+         class BASE_COLOR = Rgb<0,0,0> >
 class ColorCycle : public ColorCycleBase {
 public:
   bool run(BladeBase* base) {
-    c_.run(base);
-    on_c_.run(base);
     off_c_.run(base);
-    return ColorCycleBase::run(base, percentage, rpm, on_percentage, on_rpm, fade_time_millis,
-			       is_same_type<OFF_COLOR, Rgb<0,0,0> >::value);
+    on_c_.run(base);
+    base_c_.run(base);
+    return ColorCycleBase::run(base, off_percentage, off_rpm, on_percentage, on_rpm, fade_time_millis,
+			       is_same_type<BASE_COLOR, Rgb<0,0,0> >::value);
   }
 
 private:
-  COLOR c_;
-  ON_COLOR on_c_;
   OFF_COLOR off_c_;
+  ON_COLOR on_c_;
+  BASE_COLOR base_c_;
 public:
 
-  auto getColor(int led) -> decltype(MixColors(off_c_.getColor(0), MixColors(c_.getColor(0), on_c_.getColor(0), 1, 15), 1, 15)) {
+  auto getColor(int led) -> decltype(MixColors(base_c_.getColor(0), MixColors(off_c_.getColor(0), on_c_.getColor(0), 1, 15), 1, 15)) {
     int black_mix = getMix(led);
-    auto c = c_.getColor(led);
-    auto on_c = on_c_.getColor(led);
     auto off_c = off_c_.getColor(led);
-    return MixColors(off_c, MixColors(c, on_c, fade_int_, 14), black_mix, 14);
+    auto on_c = on_c_.getColor(led);
+    auto base_c = base_c_.getColor(led);
+    return MixColors(base_c, MixColors(off_c, on_c, fade_int_, 14), black_mix, 14);
   }
 };
 


### PR DESCRIPTION
Changed `COLOR` to `OFF_COLOR` and `OFF_COLOR` to `BASE_COLOR` to better represent their purpose. 

Changed all associated variable names accordingly.

Updated comment and added additional description for behavior.