### PR TITLE
Fix warnings

### DIFF
--- a/modes/style_argument_helpers.h
+++ b/modes/style_argument_helpers.h
@@ -16,6 +16,8 @@ bool isTimeArg(int arg) {
     case RETRACTION_TIME_ARG:
     case RETRACTION_DELAY_ARG:
       return true;
+    default:
+      return false;
   }
 }
 

--- a/modes/style_option_modes.h
+++ b/modes/style_option_modes.h
@@ -7,7 +7,7 @@ template<class SPEC>
 class SelectArgSmoothMode : public SPEC::SmoothMode {
 public:
   int get() override { return GetIntArg(menu_current_blade, menu_current_arg); }
-  int set(int x) {
+  void set(int x) {
     value_ = x;
     if (!getSL<SPEC>()->busy()) {
       getSL<SPEC>()->SayWhole(x * 100 / 32768);
@@ -30,7 +30,7 @@ class SelectArgTime : public SPEC::SmoothMode {
 public:
   int get() override { return GetIntArg(menu_current_blade, menu_current_arg); }
   float t(int x) { return powf(x / 32768.0f, 2.0) * 30.0; }
-  int set(int x) {
+  void set(int x) {
     value_ = x;
     if (!getSL<SPEC>()->busy()) {
       getSL<SPEC>()->SayNumber(t(x), SAY_DECIMAL);


### PR DESCRIPTION
style_option_modes.h:16:3: warning: no return statement in function returning non-void [-Wreturn-type]
and
style_argument_helpers.h:20:1: warning: control reaches end of non-void function [-Wreturn-type]