### PR TITLE
BC buttons. clean small redundancy

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -721,8 +721,6 @@ public:
       // Delay twist events to prevent false trigger from over twisting
       if (millis() - last_twist_ > 3000) {
         last_twist_ = millis();
-        saber_off_time_ = millis();
-        battle_mode_ = false;
         TurnOffHelper();
       }
       return true;


### PR DESCRIPTION
These are now handled more globally in the TurnOffHelper() function.