### PR TITLE
Diagnostic Delay at boot

### DIFF
--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -1633,6 +1633,10 @@ void setup() {
 #endif
 
   Looper::DoSetup();
+#ifdef DIAGNOSTIC_STARTUP_DELAY_FOR_SERIAL_MONITOR
+  delay(3000);
+#endif
+  PVLOG_DEBUG << "***************** Booting up! *******************\n";
   // Time to identify the blade.
   prop.FindBlade(true);
   SaberBase::DoBoot();

--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -1633,9 +1633,6 @@ void setup() {
 #endif
 
   Looper::DoSetup();
-#ifdef DIAGNOSTIC_STARTUP_DELAY_FOR_SERIAL_MONITOR
-  delay(3000);
-#endif
   PVLOG_DEBUG << "***************** Booting up! *******************\n";
   // Time to identify the blade.
   prop.FindBlade(true);


### PR DESCRIPTION
This allows for the absolute beginning of messages to be monitored with Serial Monitor. Normally, messages prior to the Welcome are not shown.