### PR TITLE
Fixed TrLoopUntil not using OUT transition

### DIFF
--- a/transitions/loop.h
+++ b/transitions/loop.h
@@ -88,7 +88,7 @@ private:
   bool pulsed_ = false;
   PONUA SVFWrapper<PULSE> pulse_;
   PONUA TR transition_;
-  PONUA TR out_;
+  PONUA OUT out_;
 public:
   template<class X, class Y>
   auto getColor(const X& a, const Y& b, int led) ->


### PR DESCRIPTION
Previously TR was used for both normal transition and out, which seems incorrect...