### PR TITLE
vol mode no start at 0

### DIFF
--- a/modes/settings_menues.h
+++ b/modes/settings_menues.h
@@ -24,7 +24,8 @@ struct SmoothVolumeMode : public SPEC::SmoothMode {
   virtual float revolutions() { return 1.0f; }
   // x = 0-32767
   virtual int get() override {
-    float ret = dynamic_mixer.get_volume() / VOLUME;
+    float volume = dynamic_mixer.get_volume();
+    float ret = volume / VOLUME;
     ret = powf(ret, 1.0 / VOLUME_MENU_GAMMA);
     return ret * 32767.0;
   }


### PR DESCRIPTION
VOLUME divide needs float, otherwise it's always zero.
This way the menu starts at saber's current volume.