### PR TITLE
add easy preon check

### DIFF
--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -258,6 +258,10 @@ public:
     return true;
   }
 
+  bool isDoingPreon() {
+    return state_ == STATE_WAIT_FOR_ON;
+  }
+
   void Deactivate() {
     lock_player_.Free();
     hum_player_.Free();


### PR DESCRIPTION
Sometimes just checking if (!SaberBase::IsOn()) doesn't cut it.