### PR TITLE
delay say() 200ms

### DIFF
--- a/modes/stepped_mode.h
+++ b/modes/stepped_mode.h
@@ -43,7 +43,7 @@ struct SteppedMode : public SPEC::SelectCancelMode {
   }
   void mode_Loop() override {
     SaberBase::RequestMotion();
-    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_{
+    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_) {
       say_time_ = Cyclint<uint32_t>(0);
       say();
     }

--- a/modes/stepped_mode.h
+++ b/modes/stepped_mode.h
@@ -43,8 +43,7 @@ struct SteppedMode : public SPEC::SelectCancelMode {
   }
   void mode_Loop() override {
     SaberBase::RequestMotion();
-    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_ 
-        && Cyclint<uint32_t>(millis() - say_time_ >= 200)) {
+    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_{
       say_time_ = Cyclint<uint32_t>(0);
       say();
     }

--- a/modes/stepped_mode.h
+++ b/modes/stepped_mode.h
@@ -43,7 +43,8 @@ struct SteppedMode : public SPEC::SelectCancelMode {
   }
   void mode_Loop() override {
     SaberBase::RequestMotion();
-    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_) {
+    if (say_time_ && Cyclint<uint32_t>(millis()) > say_time_ 
+        && Cyclint<uint32_t>(millis() - say_time_ >= 200)) {
       say_time_ = Cyclint<uint32_t>(0);
       say();
     }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -614,6 +614,7 @@ public:
       default: return;
       case EFFECT_MENU_CHANGE:
         if (!PlayPolyphonic(&SFX_ccchange)) {
+          SaberBase::sound_length = 0.2;
           beeper.Beep(0.05, 2000.0);
         }
 	return;


### PR DESCRIPTION
This allows some breathing space so when turning you don't get "ninety two...nine...ninet...nin...nine...ninety...ninety eight" for example. It lets the change settle for a beat, then speaks.  Working well in testing.