### PR TITLE
Bug fix for Special Abilities

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -5788,7 +5788,7 @@ SaberFett263Buttons() : PropBase() {}
 #endif
 // Gesture Controls (not button specific)
       case EVENTID(BUTTON_NONE, EVENT_TWIST_RIGHT, MODE_ON):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }
@@ -5809,7 +5809,7 @@ SaberFett263Buttons() : PropBase() {}
         return false;
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST_LEFT, MODE_ON):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }
@@ -5831,7 +5831,7 @@ SaberFett263Buttons() : PropBase() {}
         return false;
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST_RIGHT, MODE_OFF):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }
@@ -5842,7 +5842,7 @@ SaberFett263Buttons() : PropBase() {}
         return false;
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST_LEFT, MODE_OFF):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }
@@ -5921,7 +5921,7 @@ SaberFett263Buttons() : PropBase() {}
         return false;
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST_RIGHT, MODE_OFF | BUTTON_POWER):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }
@@ -5954,7 +5954,7 @@ SaberFett263Buttons() : PropBase() {}
         return false;
 
       case EVENTID(BUTTON_NONE, EVENT_TWIST_LEFT, MODE_OFF | BUTTON_POWER):
-        if (wav_player && wav_player->isPlaying()) {
+        if (menu_ && wav_player && wav_player->isPlaying()) {
           current_menu_angle_ = fusor.angle2();
           return false;
         }


### PR DESCRIPTION
Fix wav_player bug for Special Abilities in certain use cases.  Check for wav_player.Playing() should only apply when a menu is active otherwise it blocks certain effects from triggering.