### PR TITLE
Add Blade ID Scan Millis Timeout

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -584,31 +584,27 @@ public:
 #ifndef SHARED_POWER_PINS
 #warning SHARED_POWER_PINS is recommended when using BLADE_ID_SCAN_MILLIS
 #endif
-    
 #ifdef BLADE_ID_SCAN_TIMEOUT
-    int scan_timeout = BLADE_ID_SCAN_TIMEOUT;
-#else
-    int scan_timeout = 60 * 10 * 1000;
+#define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
 #endif
-
-#ifdef BLADE_ID_STOP_SCAN_WHILE_IGNITED
-    bool scan_while_ignited = false;
-#else
-    bool scan_while_ignited = true;
-#endif
-
-  bool find_blade_again_pending_ = false;
-  uint32_t last_scan_id_ = 0;
+    
+    bool find_blade_again_pending_ = false;
+    uint32_t last_scan_id_ = 0;
     bool ScanBladeIdNow() {
         uint32_t now = millis();
-        bool scan;
-        if (scan_while_ignited == false && IsOn() == true){
+        
+        bool scan = true;
+        #ifdef BLADE_ID_STOP_SCAN_WHILE_IGNITED
+        if (IsOn()) {
             scan = false;
         }
-        else {
-            scan = true;
+        #endif
+        
+        if ((now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
+            scan = false;
         }
-        if (scan == true && (now - blade_id_scan_start_) < scan_timeout) {
+        
+        if (scan == true) {
             if (now - last_scan_id_ > BLADE_ID_SCAN_MILLIS) {
                 last_scan_id_ = now;
                 size_t best_config = FindBestConfig(PROFFIEOS_LOG_LEVEL >= 500);

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -584,24 +584,31 @@ public:
 #ifndef SHARED_POWER_PINS
 #warning SHARED_POWER_PINS is recommended when using BLADE_ID_SCAN_MILLIS
 #endif
-#ifndef BLADE_ID_SCAN_TIMEOUT
-#define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
+    
+#ifdef BLADE_ID_SCAN_TIMEOUT
+    int scan_timeout = BLADE_ID_SCAN_TIMEOUT;
+#else
+    int scan_timeout = 60 * 10 * 1000;
 #endif
-#ifndef BLADE_ID_SCAN_WHILE_IGNITED
-#define BLADE_ID_SCAN_WHILE_IGNITED true
+
+#ifdef BLADE_ID_STOP_SCAN_WHILE_IGNITED
+    bool scan_while_ignited = false;
+#else
+    bool scan_while_ignited = true;
 #endif
+
   bool find_blade_again_pending_ = false;
   uint32_t last_scan_id_ = 0;
     bool ScanBladeIdNow() {
         uint32_t now = millis();
         bool scan;
-        if (BLADE_ID_SCAN_WHILE_IGNITED == false && IsOn() == true){
+        if (scan_while_ignited == false && IsOn() == true){
             scan = false;
         }
         else {
             scan = true;
         }
-        if (scan == true && (now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
+        if (scan == true && (now - blade_id_scan_start_) < scan_timeout) {
             if (now - last_scan_id_ > BLADE_ID_SCAN_MILLIS) {
                 last_scan_id_ = now;
                 size_t best_config = FindBestConfig(PROFFIEOS_LOG_LEVEL >= 500);

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -584,40 +584,38 @@ public:
 #ifndef SHARED_POWER_PINS
 #warning SHARED_POWER_PINS is recommended when using BLADE_ID_SCAN_MILLIS
 #endif
-#ifdef BLADE_ID_SCAN_TIMEOUT
-#define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
-#endif
     
     bool find_blade_again_pending_ = false;
     uint32_t last_scan_id_ = 0;
     bool ScanBladeIdNow() {
         uint32_t now = millis();
         
-        bool scan = true;
-        #ifdef BLADE_ID_STOP_SCAN_WHILE_IGNITED
+        bool scan = (now - last_scan_id_) > BLADE_ID_SCAN_MILLIS;
+        
+#ifdef BLADE_ID_STOP_SCAN_WHILE_IGNITED
         if (IsOn()) {
             scan = false;
         }
-        #endif
+#endif
         
+#ifdef BLADE_ID_SCAN_TIMEOUT
+#define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
+
         if ((now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
             scan = false;
         }
+#endif
         
-        if (scan == true) {
-            if (now - last_scan_id_ > BLADE_ID_SCAN_MILLIS) {
-                last_scan_id_ = now;
-                size_t best_config = FindBestConfig(PROFFIEOS_LOG_LEVEL >= 500);
-                if (current_config != blades + best_config) {
-                    // We can't call FindBladeAgain right away because
-                    // we're called from the blade. Wait until next loop() call.
-                    find_blade_again_pending_ = true;
-                }
-                return true;
+        if (scan) {
+            last_scan_id_ = now;
+            size_t best_config = FindBestConfig(PROFFIEOS_LOG_LEVEL >= 500);
+            if (current_config != blades + best_config) {
+                // We can't call FindBladeAgain right away because
+                // we're called from the blade. Wait until next loop() call.
+                find_blade_again_pending_ = true;
             }
-            return false;
-        }
-        else{
+            return true;
+        } else {
             return false;
         }
     }

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -599,8 +599,6 @@ public:
 #endif
         
 #ifdef BLADE_ID_SCAN_TIMEOUT
-#define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
-
         if ((now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
             scan = false;
         }

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -587,11 +587,21 @@ public:
 #ifndef BLADE_ID_SCAN_TIMEOUT
 #define BLADE_ID_SCAN_TIMEOUT 60 * 10 * 1000
 #endif
+#ifndef BLADE_ID_SCAN_WHILE_IGNITED
+#define BLADE_ID_SCAN_WHILE_IGNITED true
+#endif
   bool find_blade_again_pending_ = false;
   uint32_t last_scan_id_ = 0;
     bool ScanBladeIdNow() {
         uint32_t now = millis();
-        if (IsOn() == false && (now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
+        bool scan;
+        if (BLADE_ID_SCAN_WHILE_IGNITED == false && IsOn() == true){
+            scan = false;
+        }
+        else {
+            scan = true;
+        }
+        if (scan == true && (now - blade_id_scan_start_) < BLADE_ID_SCAN_TIMEOUT) {
             if (now - last_scan_id_ > BLADE_ID_SCAN_MILLIS) {
                 last_scan_id_ = now;
                 size_t best_config = FindBestConfig(PROFFIEOS_LOG_LEVEL >= 500);

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -357,7 +357,7 @@ public:
 #ifdef IDLE_OFF_TIME
     last_on_time_ = millis();
 #endif
-#ifdef BLADE_ID_SCAN_MILLIS
+#ifdef BLADE_ID_SCAN_TIMEOUT
     blade_id_scan_start_ = millis();
 #endif
     bool on = IsOn();
@@ -1140,7 +1140,7 @@ public:
 
     current_mode->mode_Loop();
 
-#ifdef BLADE_ID_SCAN_MILLIS
+#ifdef BLADE_ID_SCAN_TIMEOUT
     if (SaberBase::IsOn() ||
         (current_style() && current_style()->Charging())) {
       blade_id_scan_start_ = millis();
@@ -1168,7 +1168,7 @@ public:
   uint32_t last_on_time_;
 #endif
     
-#ifdef BLADE_ID_SCAN_MILLIS
+#ifdef BLADE_ID_SCAN_TIMEOUT
   uint32_t blade_id_scan_start_;
 #endif
 


### PR DESCRIPTION
This pull request adds a timeout to the BLADE_ID_SCAN_MILLIS option. Currently if BLADE_ID_SCAN_MILLIS is enabled it will constantly check for a blade configuration even when the lightsaber is not in use. A side effect of BLADE_ID_SCAN_MILLIS is a blinking light. The blinking light can be observed long after the lightsaber has been in use. The timeout allows the lightsaber to stop searching for a blade if it hasn't been turned on in a certain amount of time. The default time is 10 minutes. The value can be changed via a config file. 

The logic: 
If the blade is off and the blade has been off for longer than the timeout, then the proffie board can stop searching for a blade. BLADE_ID_SCAN_MILLIS can be resumed by turning the lightsaber on and off. Once the lightsaber is turned off the board will restart the countdown. 