### PR TITLE
Proposed additional button prop file for ProffieOS.

### DIFF
--- a/props/saber_chris_buttons.h
+++ b/props/saber_chris_buttons.h
@@ -1,0 +1,1036 @@
+/*
+============================================================
+=================== SABERSENSE PROP FILE ===================
+============================================================
+
+Built on SA22C programming by Matthew McGeary.
+Modified by Chris Carter with help and contributions 
+from Brian Connor and Fredrik Hubinette.
+November 2024.
+SabersensePropV31.
+
+
+============================================================
+=============== MODIFICATION AND LOGIC NOTES =============== 
+
+The Sabersense prop file has been engineered for harmonized 
+controls between one-button and two-button operation without 
+compromising the inevitable increase in user-friendliness 
+of two-button operation.
+Where practicable, the same controls apply to both states, 
+with two-button operation benefitting from some extra 
+features and controls that are more user-friendly.
+Where possible without causing conflicts, some one-button 
+controls are duplicated in two-button mode, despite there 
+also being different two-button controls for the same function. 
+The overall intention is that users need only remember a 
+minimum set of control principles in order to access 
+all functions. As such, the logic is that the same button 
+presses do the same thing within the various states, 
+with obvious variants.
+
+Hence:
+ONE AND TWO BUTTON:
+	Single click MAIN always lights the blade...
+		Short click lights blade with sound
+		Long click lights blade mute
+	
+	Double click MAIN always plays a sound file...
+		Character Quote or Music track with blade OFF
+		Character Quote or Force Effect with blade ON
+		
+	Holding down MAIN (1-button) or AUX (2-button) 
+	and waiting with blade OFF always skips to specific preset...
+		Hilt pointing up - first preset
+		Hilt horizontal - middle preset
+		Hilt pointing down - last preset
+		
+	Triple-clicking MAIN always enters a control menu
+		Colour change with blade ON
+		BladeID with blade OFF
+
+TWO BUTTON ONLY:	
+	Short clicking AUX with blade OFF always moves to a different preset, 
+	forward with hilt pointing up, backwards with hilt pointing down...
+		Single short click - one preset
+		Double short click - five presets
+		Triple short click - ten presets
+	
+	Holding MAIN and short clicking AUX always enters a control menu...
+		Colour change with blade ON
+		Volume menu with blade OFF
+
+
+==========================================================		
+=================== 1 BUTTON CONTROLS ==================== 
+
+MAIN FUNCTIONS
+Activate blade			Short click while OFF.
+Activate blade mute   	Long click while OFF (hold for one second then release). 
+Deactivate blade		Hold and wait until blade is off while ON.
+
+FUNCTIONS WITH BLADE OFF
+Next preset	           Double click and hold while OFF pointing blade tip up.
+Previous preset		   Double click and hold while OFF pointing blade tip down.
+Skip to first preset   Press and hold until it switches, hilt pointing upwards.
+Skip to middle preset  Press and hold until it switches, hilt horizontal.
+Skip to last preset    Press and hold until it switches, hilt pointing downwards.
+Play Character Quote   Fast double-click, hilt pointing up. Quotes play sequentially.
+							To reset sequential quotes, change font or run BladeID.
+Play Music Track	   Fast double-click, hilt pointing down.
+Speak battery voltage  Fast four clicks while OFF.
+Run BladeID Manually   Fast triple-click while OFF. (Applicable installs only, toggles arrays).
+Enter/Exit VOLUME MENU Hold and clash while OFF.
+Volume up               	Click MAIN while in VOLUME MENU, hilt pointing up.
+Volume down					Click MAIN while in VOLUME MENU, hilt pointing down.
+						   	Volume adjusts in increments per click.
+						   	You must exit VOLUME MENU to resume using lightsaber normally.
+
+FUNCTIONS WITH BLADE ON		
+Blade lockup			Hold and hit clash while ON.
+Blade tip drag			Hold and hit clash while ON pointing the blade tip down.
+Force Effect (Quote)	Fast double-click MAIN, hilt pointing down.
+							Plays random Force effect (usually character quote).
+Character Quote			Fast double-click MAIN, hilt pointing up.
+							Plays sequential character quote.
+Lightning block			Double click and hold while ON.
+Melt         		    Hold and thrust forward clash while ON. (Selected fonts only).
+Blaster blocks			Short click/double click/triple click while ON.
+Enter multi-blast mode		Hold while swinging for one second and release.
+							To trigger blaster block, swing saber while in multi-blast mode.
+							To exit, hold while swinging for one second and release.
+
+COLOUR CHANGE FUNCTIONS WITH BLADE ON
+Enter COLOUR MENU		Fast triple-click while ON.
+							Announcement confirms you are in the COLOUR MENU. 
+Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+Exit COLOUR MENU		Fast triple-click or hold and wait. 
+							Announcement confirms you are exiting COLOUR MENU.
+                        	You must exit COLOUR MENU to resume using lightsaber normally.
+
+
+============================================================
+===================== 2 BUTTON CONTROLS ====================
+
+MAIN FUNCTIONS
+Activate blade			Short click MAIN.
+Activate blade mute   	Long click MAIN (hold for one second then release). 
+Deactivate blade		Press and hold MAIN and wait until blade is off.
+
+FUNCTIONS WITH BLADE OFF
+Next preset				Short click AUX, hilt pointing upwards.
+Previous preset			Short click AUX, hilt pointing downwards.
+Previous preset			Hold AUX and short click MAIN.
+							(Duplicate command for backwards compatibility).
+Skip to first preset    Press and hold any button until it switches, hilt upwards.
+Skip to middle preset   Press and hold any button  until it switches, hilt horizontal.
+Skip to last preset     Press and hold any button  until it switches, hilt downwards.
+Skip forward 5 presets	Fast double-click AUX, hilt pointing upwards.
+Skip back 5 presets		Fast double-click AUX, hilt pointing downwards.
+Skip forward 10 presets	Fast triple-click AUX, hilt pointing upwards.
+Skip back 10 presets	Fast triple-click AUX, hilt pointing downwards.
+Play Character Quote	Fast double-click MAIN, pointing up. Quotes play sequentially.
+							To reset sequential quotes, change font or run BladeID.
+Play Music Track	    Fast double-click MAIN, pointing down.
+Speak battery voltage	Fast four clicks MAIN.
+Run/Toggle BladeID		Fast triple-click MAIN. (Applicable installs only).
+Enter/Exit VOLUME MENU 	Hold MAIN then quickly click AUX
+						and release both buttons simultaneously.
+Volume up               	Click MAIN while in VOLUME MENU, hilt pointing up.
+Volume down					Click MAIN while in VOLUME MENU, hilt pointing down, or
+							click AUX while in VOLUME MENU.
+							Volume adjusts in increments per click.
+							You must exit VOLUME MENU to resume using saber normally.
+							
+FUNCTIONS WITH BLADE ON
+Blade lockup			Press and hold AUX.
+Blade tip drag			Press and hold AUX while blade is pointing down.
+Force Effect (Quote)	Fast double-click MAIN, hilt pointing down.
+							Plays random Force effect (usually character quote).
+Character Quote			Fast double-click MAIN, hilt pointing up.
+							Plays sequential character quote.
+Lightning block			Double-click MAIN and hold.
+Melt         			Hold MAIN and push blade tip against wall (clash).
+Blaster blocks			Short click AUX.
+Enter multi-blast mode	Hold MAIN while swinging for one second and release. 
+							Saber will play two quick blasts confirming mode.
+							Swing blade to trigger blaster block.
+							To exit multi-blast mode, fast single click AUX.
+
+COLOUR CHANGE FUNCTIONS WITH BLADE ON
+Enter/Exit COLOUR MENU	Hold MAIN then quickly click AUX and release both
+						buttons simultaneously. Or fast triple-click MAIN.
+							Announcement confirms you are in the COLOUR MENU.
+Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+							Most presets have 12 colour options.
+Alt Exit COLOUR MENU	Hold MAIN and wait. 
+							Announcement confirms you are exiting COLOUR MENU.
+							You must exit COLOUR MENU to resume using lightsaber normally.
+
+							
+===========================================================		
+========================= DEFINES =========================
+#define FAKE_BLADE_ID
+Replaces regular BladeID and allows toggling between two different 
+blade/preset arrays regardless of actual BladeID status.
+
+#define SA22C_NO_LOCKUP_HOLD	
+Applicable to two-button mode only, reverts to lockup being triggered
+by clash while holding aux.
+
+GESTURE CONTROLS
+There are four gesture types: Twist, Stab, Swing and Thrust.
+Gesture controls bypass all preon effects.
+Below are the options to add to the config to enable the various gestures. MM.
+#define SA22C_TWIST_ON
+#define SA22C_TWIST_OFF
+#define SA22C_STAB_ON
+#define SA22C_SWING_ON
+#define SA22C_THRUST_ON
+#define SA22C_FORCE_PUSH
+
+#define SA22C_FORCE_PUSH_LENGTH 5
+Allows for adjustment to Push gesture length in millis needed to trigger Force Push
+Recommended range 1 ~ 10, 1 = shortest, easiest to trigger, 10 = longest. MM.
+
+Tightened click timings
+I've shortened the timeout for short and double click detection from 500ms
+to 300ms.  I think it feels more responsive this way but still gives enough
+timeout to ensure all button actions can be achieved consistently
+I've included all button timings so they can be easily tweaked to suit
+individual tastes. MM.
+
+============================================================
+============================================================
+*/
+#ifndef PROPS_SABER_SENSE_BUTTONS_H
+#define PROPS_SABER_SENSE_BUTTONS_H
+
+
+//  Used instead of BladeID and allows toggle switching 
+//  between two blade/preset arrays manually.
+#ifdef FAKE_BLADE_ID
+struct FakeBladeID {
+   static int return_value;
+   float id() { return return_value; }
+   static void toggle() {
+     return_value = NO_BLADE - return_value;
+   }
+};
+int FakeBladeID::return_value = 0;
+#undef BLADE_ID_CLASS_INTERNAL
+#define BLADE_ID_CLASS_INTERNAL FakeBladeID
+#undef BLADE_ID_CLASS
+#define BLADE_ID_CLASS FakeBladeID
+#endif
+
+
+#include "prop_base.h"
+#include "../sound/hybrid_font.h"
+
+#undef PROP_TYPE
+#define PROP_TYPE SabersensePropV31
+
+#ifndef MOTION_TIMEOUT
+#define MOTION_TIMEOUT 60 * 15 * 1000
+#endif
+
+#ifndef SA22C_SWING_ON_SPEED
+#define SA22C_SWING_ON_SPEED 250
+#endif
+
+#ifndef SA22C_LOCKUP_DELAY
+#define SA22C_LOCKUP_DELAY 200
+#endif
+
+#ifndef SA22C_FORCE_PUSH_LENGTH
+#define SA22C_FORCE_PUSH_LENGTH 5
+#endif
+
+#ifndef BUTTON_DOUBLE_CLICK_TIMEOUT
+#define BUTTON_DOUBLE_CLICK_TIMEOUT 300
+#endif
+
+#ifndef BUTTON_SHORT_CLICK_TIMEOUT
+#define BUTTON_SHORT_CLICK_TIMEOUT 300
+#endif
+
+#ifndef BUTTON_HELD_TIMEOUT
+#define BUTTON_HELD_TIMEOUT 300
+#endif
+
+#ifndef BUTTON_HELD_MEDIUM_TIMEOUT
+#define BUTTON_HELD_MEDIUM_TIMEOUT 1000
+#endif
+
+#ifndef BUTTON_HELD_LONG_TIMEOUT
+#define BUTTON_HELD_LONG_TIMEOUT 2000
+#endif
+
+#ifdef SA22C_SWING_ON
+#define SWING_GESTURE
+#endif
+
+#ifdef SA22C_STAB_ON
+#define STAB_GESTURE
+#endif
+
+#ifdef SA22C_TWIST_ON
+#define TWIST_GESTURE
+#endif
+
+#ifdef SA22C_THRUST_ON
+#define THRUST_GESTURE
+#endif
+
+
+//  #define FORCE_PUSH_CONDITION battle_mode_
+
+EFFECT(dim);      // for EFFECT_POWERSAVE
+EFFECT(battery);  // for EFFECT_BATTERY_LEVEL
+EFFECT(bmbegin);  // for Begin Battle Mode
+EFFECT(bmend);    // for End Battle Mode
+EFFECT(vmbegin);  // for Begin Volume Menu
+EFFECT(vmend);    // for End Volume Menu
+EFFECT(volup);    // for increse volume
+EFFECT(voldown);  // for decrease volume
+EFFECT(volmin);   // for minimum volume reached
+EFFECT(volmax);   // for maximum volume reached
+EFFECT(faston);   // for EFFECT_FAST_ON
+EFFECT(blstbgn);  // for Begin Multi-Blast
+EFFECT(blstend);  // for End Multi-Blast
+EFFECT(push);     // for Force Push gesture in Battle Mode
+EFFECT(quote);    // for playing quotes
+
+
+
+// The Saber class implements the basic states and actions
+// for the saber.
+class SabersensePropV31 : public PROP_INHERIT_PREFIX PropBase {
+public:
+  SabersensePropV31() : PropBase() {}
+  const char* name() override { return "SabersensePropV31"; }
+
+  void Loop() override {
+    PropBase::Loop();
+    DetectTwist();
+    Vec3 mss = fusor.mss();
+    if (SaberBase::IsOn()) {
+      DetectSwing();
+      if (auto_lockup_on_ &&
+          !swinging_ &&
+          fusor.swing_speed() > 120 &&
+          millis() - clash_impact_millis_ > SA22C_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        auto_lockup_on_ = false;
+      }
+      if (auto_melt_on_ &&
+          !swinging_ &&
+          fusor.swing_speed() > 60 &&
+          millis() - clash_impact_millis_ > SA22C_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        auto_melt_on_ = false;
+      }
+
+      // EVENT_PUSH
+      if (fabs(mss.x) < 3.0 &&
+          mss.y * mss.y + mss.z * mss.z > 70 &&
+          fusor.swing_speed() < 30 &&
+          fabs(fusor.gyro().x) < 10) {
+        if (millis() - push_begin_millis_ > SA22C_FORCE_PUSH_LENGTH) {
+          Event(BUTTON_NONE, EVENT_PUSH);
+          push_begin_millis_ = millis();
+        }
+      } else {
+        push_begin_millis_ = millis();
+      }
+
+    } else {
+      // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
+      if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
+        SaberBase::RequestMotion();
+        if (swinging_ && fusor.swing_speed() < 90) {
+          swinging_ = false;
+        }
+        if (!swinging_ && fusor.swing_speed() > SA22C_SWING_ON_SPEED) {
+          swinging_ = true;
+          Event(BUTTON_NONE, EVENT_SWING);
+        }
+      }
+      // EVENT_THRUST
+      if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
+          mss.x > 14  &&
+          fusor.swing_speed() < 150) {
+        if (millis() - thrust_begin_millis_ > 15) {
+          Event(BUTTON_NONE, EVENT_THRUST);
+          thrust_begin_millis_ = millis();
+        }
+      } else {
+        thrust_begin_millis_ = millis();
+      }
+    }
+  }
+
+// Volume Menu
+  void VolumeUp() {
+    STDOUT.println("Volume up");
+    if (dynamic_mixer.get_volume() < VOLUME) {
+      dynamic_mixer.set_volume(std::min<int>(VOLUME + VOLUME * 0.1,
+        dynamic_mixer.get_volume() + VOLUME * 0.10));
+      if (SFX_volup) {
+        hybrid_font.PlayCommon(&SFX_volup);
+      } else {
+        beeper.Beep(0.5, 2000);
+      }
+      STDOUT.print("Volume Up - Current Volume: ");
+      STDOUT.println(dynamic_mixer.get_volume());
+    } else {
+      // Cycle through ends of Volume Menu option
+      #ifdef VOLUME_MENU_CYCLE
+        if (!max_vol_reached_) {
+          if (SFX_volmax) {
+            hybrid_font.PlayCommon(&SFX_volmax);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          STDOUT.print("Maximum Volume: ");
+          max_vol_reached_ = true;
+        } else {
+          dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
+          dynamic_mixer.get_volume() - VOLUME * 0.90));
+          if (SFX_volmin) {
+            hybrid_font.PlayCommon(&SFX_volmin);
+          } else {
+            beeper.Beep(0.5, 1000);
+          }
+          STDOUT.print("Minimum Volume: ");
+          max_vol_reached_ = false;
+        }
+      #else
+        if (SFX_volmax) {
+          hybrid_font.PlayCommon(&SFX_volmax);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.print("Maximum Volume: ");
+      #endif
+    }
+  }
+
+  void VolumeDown() {
+    STDOUT.println("Volume Down");
+    if (dynamic_mixer.get_volume() > (0.10 * VOLUME)) {
+      dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
+        dynamic_mixer.get_volume() - VOLUME * 0.10));
+      if (SFX_voldown) {
+        hybrid_font.PlayCommon(&SFX_voldown);
+      } else {
+        beeper.Beep(0.5, 2000);
+      }
+      STDOUT.print("Volume Down - Current Volume: ");
+      STDOUT.println(dynamic_mixer.get_volume());
+    } else {
+      #ifdef VOLUME_MENU_CYCLE
+        if (!min_vol_reached_) {
+          if (SFX_volmin) {
+            hybrid_font.PlayCommon(&SFX_volmin);
+          } else {
+            beeper.Beep(0.5, 1000);
+          }
+          STDOUT.print("Minimum Volume: ");
+          min_vol_reached_ = true;
+        } else {
+          dynamic_mixer.set_volume(VOLUME);
+          if (SFX_volmax) {
+            hybrid_font.PlayCommon(&SFX_volmax);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          STDOUT.print("Maximum Volume: ");
+          min_vol_reached_ = false;
+        }
+      #else
+        if (SFX_volmin) {
+          hybrid_font.PlayCommon(&SFX_volmin);
+        } else {
+          beeper.Beep(0.5, 1000);
+        }
+        STDOUT.print("Minimum Volume: ");
+      #endif
+      
+    }
+  }
+
+
+//  Button Clicker to play press/release wav files when buttons are pressed.
+//  Intended for Scavenger hilt where wheel makes tactile feel difficult.
+//  Requires press.wav and release.wav files to work.
+    void PlaySound(const char* sound) {
+        RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+        if (player) {
+            if (!player->PlayInCurrentDir(sound)) player->Play(sound);
+        }
+    }            
+ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {      
+    switch (EVENTID(button, event, modifiers)) {
+      case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+        SaberBase::RequestMotion();
+        PlaySound("press.wav");
+        return false;
+      case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+      case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+        PlaySound("release.wav");
+        if (SaberBase::Lockup()) {
+          SaberBase::DoEndLockup();
+          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+          return true;
+        } else {
+          return false;
+        }
+      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
+      case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
+        if (accel_.x < -0.15) {
+          pointing_down_ = true;
+        } else {
+          pointing_down_ = false;
+        }
+        return true;
+   
+
+  // Gesture Controls
+#ifdef SA22C_SWING_ON
+  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
+    // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
+    if (millis() > 3000) {
+    FastOn();
+//      On();
+    }
+    return true;
+#endif
+
+
+#ifdef SA22C_TWIST_ON
+  case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+    // Delay twist events to prevent false trigger from over twisting
+    if (millis() - last_twist_ > 2000 &&
+        millis() - saber_off_time_ > 1000) {
+    FastOn();
+//      On();
+      last_twist_ = millis();
+    }
+    return true;
+#endif
+
+
+#ifdef SA22C_TWIST_OFF
+  case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
+    // Delay twist events to prevent false trigger from over twisting
+    if (millis() - last_twist_ > 3000) {
+      Off();
+      last_twist_ = millis();
+      saber_off_time_ = millis();
+      battle_mode_ = false;
+    }
+    return true;
+#endif
+
+
+#ifdef SA22C_STAB_ON
+      case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
+        if (millis() - saber_off_time_ > 1000) {
+//    FastOn();
+      On();
+        }
+        return true;
+#endif
+
+
+#ifdef SA22C_THRUST_ON
+      case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
+        if (millis() - saber_off_time_ > 1000) {
+    FastOn();
+//      On();
+        }
+        return true;
+#endif
+
+
+#ifdef SA22C_FORCE_PUSH
+      case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
+        if (FORCE_PUSH_CONDITION &&
+            millis() - last_push_ > 2000) {
+          if (SFX_push) {
+            hybrid_font.PlayCommon(&SFX_push);
+          } else {
+            hybrid_font.DoEffect(EFFECT_FORCE, 0);
+          }
+          last_push_ = millis();
+        }
+        return true;
+#endif
+
+
+//  Multiple Skips only available with 2 button installs.
+//  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
+case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+    // backwards if pointing down
+    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+
+ 
+// Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
+case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+    // backwards if pointing down
+    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+
+   
+// Saber ON AND Volume Adjust.
+case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+    if (!mode_volume_) {
+      On();
+    } else {
+     if (fusor.angle1() > 0) {
+      VolumeUp();
+    } else {
+      VolumeDown();
+    }
+    }
+    return true;
+
+
+// Modified 2 and 3 button 'next/previous preset' AND volume down,
+// to align with multiple skips above.
+// Forward one font pointing up, back one font pointing down.
+  case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+    // backwards if pointing down
+    if (!mode_volume_) {
+    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+        } else {
+      VolumeDown();
+    }
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+
+
+// 1 button 'next/previous preset' command.
+// Forward one font pointing up, back one font pointing down.
+#if NUM_BUTTONS == 1 
+      case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
+    // backwards if pointing down
+    if (!mode_volume_) {
+    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+        } else {
+      VolumeDown();
+    }
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+#endif
+
+
+//  1 Button skips to first preset (up) or last preset (down)
+//  or middle preset if horizontal:
+#if NUM_BUTTONS == 2
+case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
+#endif
+case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+#define DEGREES_TO_RADIANS (M_PI / 180)
+ if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+// If pointing up
+SetPreset(0, true);
+ } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+// If pointing down
+SetPreset(-1, true);
+ } else {
+// If horizontal
+  CurrentPreset tmp;
+  tmp.SetPreset(-1);
+  SetPreset(tmp.preset_num / 2, true);
+}
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+
+
+#if NUM_BUTTONS == 2
+// 1 and 2 button: Previous Preset, retained legacy control.
+    case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
+#endif
+    if (!mode_volume_) {
+      previous_preset();
+    }
+    return true;
+
+
+//  Skips to first preset (up) or last (battery or charge) preset (down)
+//  or middle preset if horizontal:
+#if NUM_BUTTONS == 2
+// 2 button: First Preset
+case EVENTID(BUTTON_AUX, EVENT_HELD_LONG, MODE_OFF):
+#endif
+#define DEGREES_TO_RADIANS (M_PI / 180)
+ if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+// If pointing up
+SetPreset(0, true);
+ } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+// If pointing down
+SetPreset(-1, true);
+ } else {
+// If horizontal
+  CurrentPreset tmp;
+  tmp.SetPreset(-1);
+  SetPreset(tmp.preset_num / 2, true);
+}
+#ifdef SAVE_PRESET
+    SaveState(current_preset_.preset_num);
+#endif
+    return true;
+    
+
+//  Manual Blade ID Options
+case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+#ifdef FAKE_BLADE_ID
+//  Toggles between blade arrays regardless of BladeID status.
+//  Cannot use more than two blade/preset arrays.
+      FakeBladeID::toggle();
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
+         return true;
+#else
+//  Runs BladeID Manually to actually check BladeID status.
+//  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
+//  Can use any number of blade/preset arrays.
+    FindBladeAgain();
+    SaberBase::DoBladeDetect(true);
+         return true;
+#endif
+
+ 
+// Activate Muted
+//  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+    if (SetMute(true)) {
+      unmute_on_deactivation_ = true;
+      On();
+    }
+    return true;
+
+
+// Turn Blade OFF
+#if NUM_BUTTONS > 1
+// 2 button
+  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
+#else
+// 1 button
+  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_ON):
+#endif
+    if (!SaberBase::Lockup()) {
+#ifndef DISABLE_COLOR_CHANGE
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        // Just exit color change mode.
+        // Don't turn saber off.
+        ToggleColorChangeMode();
+        return true;
+      }
+#endif
+      if (!battle_mode_) {
+        Off();
+      }
+    }
+    saber_off_time_ = millis();
+    battle_mode_ = false;
+    swing_blast_ = false;
+    return true;
+
+
+// Character Quote and Force Effect, Blade ON.
+// Hilt pointed UP for Character Quote, plays sequentially,
+// Hilt pointed DOWN for Force Effect, plays randomly.
+case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+    if (SFX_quote) {
+     if (fusor.angle1() > 0) {
+            SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();
+        }
+       }
+      return true;
+
+
+//  Character Quote and Music Track, Blade OFF.
+//  Play sequential quote pointing up, play music track pointing down.
+case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
+   if (SFX_quote) {
+     if (fusor.angle1() > 0) {
+            SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+    StartOrStopTrack();
+    }
+    }
+    return true;
+    
+
+//  Colour Change.
+//  1 and 2 button modes.
+#ifndef DISABLE_COLOR_CHANGE
+case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+      ToggleColorChangeMode();
+    return true;
+
+//  2 button mode only.
+#if NUM_BUTTONS == 2
+case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+      ToggleColorChangeMode();
+    return true;
+#endif
+#endif
+
+
+// Blaster Deflection
+#if NUM_BUTTONS == 1
+  // 1 button
+  case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+//  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+//  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+#else
+  // 2 and 3 button
+  case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+  case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+//  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+//  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+#endif
+    swing_blast_ = false;
+    SaberBase::DoBlast();
+    return true;
+
+
+// Multi-Blaster Deflection mode
+  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+    swing_blast_ = !swing_blast_;
+    if (swing_blast_) {
+      if (SFX_blstbgn) {
+        hybrid_font.PlayCommon(&SFX_blstbgn);
+      } else {
+        hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+      }
+    } else {
+      if (SFX_blstend) {
+        hybrid_font.PlayCommon(&SFX_blstend);
+      } else {
+        hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+      }
+    }
+    return true;
+
+  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+    if (swing_blast_) {
+      SaberBase::DoBlast();
+    }
+    return true;
+
+
+// Lockup
+#if NUM_BUTTONS == 1
+  // 1 button lockup
+  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+#else
+#ifndef SA22C_NO_LOCKUP_HOLD
+  // 2 and 3 button lockup
+  case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+#else
+  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+#endif
+#endif
+    if (!SaberBase::Lockup() && !battle_mode_) {
+    if (accel_.x < -0.15) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+      } else {
+        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+      }
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
+    }
+    break;
+
+
+// Lightning Block
+#if NUM_BUTTONS < 3
+  // 1 and 2 button
+  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+#else
+  // 3 button
+  case EVENTID(BUTTON_AUX2, EVENT_FIRST_HELD, MODE_ON):
+#endif
+    if (!battle_mode_) {
+      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
+    }
+    break;
+
+
+// Melt
+  case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+    if (!SaberBase::Lockup() && !battle_mode_) {
+      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
+    }
+    break;
+
+
+//  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
+//   case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
+  case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+    SaberBase::RequestMotion();
+    return true;
+
+
+// Enter Volume MENU
+#if NUM_BUTTONS == 1
+  // 1 button
+  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+#else
+  // 2 and 3 button
+  case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+//  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+#endif
+    if (!mode_volume_) {
+      mode_volume_ = true;
+      if (SFX_vmbegin) {
+        hybrid_font.PlayCommon(&SFX_vmbegin);
+      } else {
+        beeper.Beep(0.5, 3000);
+      }
+      STDOUT.println("Enter Volume Menu");
+    } else {
+      mode_volume_ = false;
+      if (SFX_vmend) {
+        hybrid_font.PlayCommon(&SFX_vmend);
+      } else {
+        beeper.Beep(0.5, 3000);
+      }
+      STDOUT.println("Exit Volume Menu");
+    }
+    return true;
+
+
+// Battery level
+  case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
+//  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+    talkie.SayDigit((int)floorf(battery_monitor.battery()));
+    talkie.Say(spPOINT);
+    talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+    talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+    talkie.Say(spVOLTS);
+    SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);        
+    return true;
+ 
+ 
+#ifdef BLADE_DETECT_PIN
+      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+        // Might need to do something cleaner, but let's try this for now.
+        blade_detected_ = true;
+        FindBladeAgain();
+        SaberBase::DoBladeDetect(true);
+        return true;
+
+      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+        // Might need to do something cleaner, but let's try this for now.
+        blade_detected_ = false;
+        FindBladeAgain();
+        SaberBase::DoBladeDetect(false);
+        return true;
+#endif
+
+
+// Events that needs to be handled regardless of what other buttons
+// are pressed.
+//    case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+//    case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+      if (SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+
+void SB_Effect(EffectType effect, float location) override {
+    switch (effect) {
+      
+      case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
+      
+      case EFFECT_POWERSAVE:
+        if (SFX_dim) {
+          hybrid_font.PlayCommon(&SFX_dim);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_BATTERY_LEVEL:
+        if (SFX_battery) {
+          hybrid_font.PlayCommon(&SFX_battery);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_FAST_ON:
+        if (SFX_faston) {
+          hybrid_font.PlayCommon(&SFX_faston);
+        }
+        return;
+
+      default: break; // avoids compiler warning
+    }
+  }
+
+private:
+  bool pointing_down_ = false;
+  bool swing_blast_ = false;
+  bool mode_volume_ = false;
+  bool auto_lockup_on_ = false;
+  bool auto_melt_on_ = false;
+  bool battle_mode_ = false;
+  bool max_vol_reached_ = false;
+  bool min_vol_reached_ = false;
+  uint32_t thrust_begin_millis_ = millis();
+  uint32_t push_begin_millis_ = millis();
+  uint32_t clash_impact_millis_ = millis();
+  uint32_t last_twist_ = millis();
+  uint32_t last_push_ = millis();
+  uint32_t saber_off_time_ = millis();
+};
+
+#endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -754,54 +754,64 @@ public:
   // Hilt pointed UP for Character Quote, plays sequentially,
   // Hilt pointed DOWN for Force Effect, plays randomly.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  // Reverses UP/DOWN options for respective QUOTE/FORCE audio playing.
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  
+      // Define reverses UP/DOWN options for QUOTE/FORCE/TRACK audio player.
       //  Quote player points upwards.
-      if (SFX_quote) {
-        if (fusor.angle1() > 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();
-        }
-       }
+  if (SFX_quote) {
+    if (fusor.angle1() > 0) {
+      SFX_quote.SelectNext();
+        SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+        SaberBase::DoForce();  // Force effect for hilt pointed DOWN
+    }
+    } else {
+        SaberBase::DoForce();  // Fallback: always play force effect if no quotes are available
+    }
     return true;
 #else
       //  Quote player points downwards.
-      if (SFX_quote) {
-        if (fusor.angle1() < 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();
-        }
-       }
+  if (SFX_quote) {
+    if (fusor.angle1() < 0) {
+      SFX_quote.SelectNext();
+        SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+        SaberBase::DoForce();  // Force effect for hilt pointed DOWN
+    }
+    } else {
+      SaberBase::DoForce();  // Fallback: always play force effect if no quotes are available
+    }
     return true;
 #endif
 
   //  Character Quote and Music Track, Blade OFF.
   //  Play sequential quote pointing up, play music track pointing down.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
-#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  // Reverses UP/DOWN options for respective QUOTE/TRACK audio playing.
-      //  Quote player points upwards.
-      if (SFX_quote) {
-        if (fusor.angle1() > 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          StartOrStopTrack();
-        }
-       }
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
+  // Define reverses UP/DOWN options for QUOTE/FORCE/TRACK audio player.
+  //  Quote player points upwards.
+  if (SFX_quote) {
+    if (fusor.angle1() > 0) {
+      SFX_quote.SelectNext();
+        SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+        StartOrStopTrack();  // Play track for hilt pointed DOWN
+    }
+    } else {
+        StartOrStopTrack();  // Fallback: always play track if no quotes are available
+    }
     return true;
 #else
-      //  Quote player points downwards.
-      if (SFX_quote) {
-        if (fusor.angle1() < 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          StartOrStopTrack();
-        }
-       }
+   //  Quote player points downwards.
+  if (SFX_quote) {
+    if (fusor.angle1() < 0) {
+      SFX_quote.SelectNext();
+        SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+        StartOrStopTrack();  // Play track for hilt pointed DOWN
+    }
+    } else {
+        StartOrStopTrack();  // Fallback: always play track if no quotes are available
+    }
     return true;
 #endif
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -301,8 +301,6 @@ Tightened click timings
 #define SABERSENSE_OS7_LEGACY_SUPPORT
 #endif
 
-//  #define FORCE_PUSH_CONDITION battle_mode_
-
 EFFECT(dim);      // for EFFECT_POWERSAVE
 EFFECT(battery);  // for EFFECT_BATTERY_LEVEL
 EFFECT(bmbegin);  // for Begin Battle Mode
@@ -336,62 +334,61 @@ public:
     if (SaberBase::IsOn()) {
       DetectSwing();
       if (auto_lockup_on_ &&
-          !swinging_ &&
-          fusor.swing_speed() > 120 &&
-          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+        !swinging_ &&
+        fusor.swing_speed() > 120 &&
+        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
           SaberBase::Lockup()) {
-        SaberBase::DoEndLockup();
-        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+          SaberBase::DoEndLockup();
+          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_lockup_on_ = false;
       }
       if (auto_melt_on_ &&
-          !swinging_ &&
-          fusor.swing_speed() > 60 &&
-          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+        !swinging_ &&
+        fusor.swing_speed() > 60 &&
+        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
           SaberBase::Lockup()) {
-        SaberBase::DoEndLockup();
-        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+          SaberBase::DoEndLockup();
+          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_melt_on_ = false;
       }
 
       // EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
-          mss.y * mss.y + mss.z * mss.z > 70 &&
-          fusor.swing_speed() < 30 &&
-          fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
-          Event(BUTTON_NONE, EVENT_PUSH);
-          push_begin_millis_ = millis();
-        }
+        mss.y * mss.y + mss.z * mss.z > 70 &&
+        fusor.swing_speed() < 30 &&
+        fabs(fusor.gyro().x) < 10) {
+          if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
+            Event(BUTTON_NONE, EVENT_PUSH);
+            push_begin_millis_ = millis();
+            }
+          } else {
+            push_begin_millis_ = millis();
+          }
       } else {
-        push_begin_millis_ = millis();
-      }
-
-    } else {
-      // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
-      if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
-        SaberBase::RequestMotion();
-        if (swinging_ && fusor.swing_speed() < 90) {
-          swinging_ = false;
+        // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
+        if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
+          SaberBase::RequestMotion();
+            if (swinging_ && fusor.swing_speed() < 90) {
+              swinging_ = false;
+            }
+            if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
+              swinging_ = true;
+            Event(BUTTON_NONE, EVENT_SWING);
+            }
         }
-        if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
-          swinging_ = true;
-          Event(BUTTON_NONE, EVENT_SWING);
-        }
-      }
       // EVENT_THRUST
-      if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
+        if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
           mss.x > 14  &&
           fusor.swing_speed() < 150) {
-        if (millis() - thrust_begin_millis_ > 15) {
-          Event(BUTTON_NONE, EVENT_THRUST);
+          if (millis() - thrust_begin_millis_ > 15) {
+            Event(BUTTON_NONE, EVENT_THRUST);
+            thrust_begin_millis_ = millis();
+          }
+          } else {
           thrust_begin_millis_ = millis();
         }
-      } else {
-        thrust_begin_millis_ = millis();
       }
     }
-  }
 
   // Volume Menu
   void VolumeUp() {
@@ -490,37 +487,37 @@ public:
       RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
        if (player) {
          if (!player->PlayInCurrentDir(sound)) player->Play(sound);
-        }
-      }            
+       }
+    }            
     bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {      
       switch (EVENTID(button, event, modifiers)) {
-      case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
-      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
-        SaberBase::RequestMotion();
-        PlaySound("press.wav");
-          return false;
-      case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
-      case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
-        PlaySound("release.wav");
-        if (SaberBase::Lockup()) {
-          SaberBase::DoEndLockup();
-          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
-            return true;
-        } else {
+        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+          SaberBase::RequestMotion();
+          PlaySound("press.wav");
             return false;
-        }
-      case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
-      case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
-        if (accel_.x < -0.15) {
-          pointing_down_ = true;
+        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+          PlaySound("release.wav");
+          if (SaberBase::Lockup()) {
+            SaberBase::DoEndLockup();
+            SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+          return true;
         } else {
-          pointing_down_ = false;
-      }
-    return true;
+          return false;
+        }
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
+        case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
+          if (accel_.x < -0.15) {
+            pointing_down_ = true;
+          } else {
+            pointing_down_ = false;
+          }
+          return true;
 
   //  Gesture Controls
 #ifdef SABERSENSE_SWING_ON
@@ -528,9 +525,8 @@ public:
       // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
       if (millis() > 3000) {
         FastOn();
-        //  On();
       }
-    return true;
+      return true;
 #endif
 
 #ifdef SABERSENSE_TWIST_ON
@@ -539,9 +535,8 @@ public:
       if (millis() - last_twist_ > 2000 &&
         millis() - saber_off_time_ > 1000) {
           FastOn();
-          //  On();
-         last_twist_ = millis();
-        }
+        last_twist_ = millis();
+      }
       return true;
 #endif
 
@@ -550,10 +545,10 @@ public:
       // Delay twist events to prevent false trigger from over twisting
       if (millis() - last_twist_ > 3000) {
         Off();
-          last_twist_ = millis();
-          saber_off_time_ = millis();
-          battle_mode_ = false;
-        }
+      last_twist_ = millis();
+        saber_off_time_ = millis();
+        battle_mode_ = false;
+      }
       return true;
 #endif
 
@@ -561,38 +556,36 @@ public:
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
       if (millis() - saber_off_time_ > 1000) {
         FastOn();
-        //  On();
       }
-    return true;
+      return true;
 #endif
 
 #ifdef SABERSENSE_THRUST_ON
     case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
       if (millis() - saber_off_time_ > 1000) {
         FastOn();
-        //  On();
       }
-    return true;
+      return true;
 #endif
 
-  //  Multiple Skips only available with 2 button installs.
-  //  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
+    //  Multiple Skips only available with 2 button installs.
+    //  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
     case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
       SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
-    #ifdef SAVE_PRESET
+#ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
-    #endif
-    return true;
+#endif
+return true;
 
   // Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
     case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
         SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
-      #ifdef SAVE_PRESET
+#ifdef SAVE_PRESET
         SaveState(current_preset_.preset_num);
-      #endif
-    return true;
+#endif
+return true;
 
 // Saber ON AND Volume Adjust.
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
@@ -605,9 +598,9 @@ public:
             VolumeUp();
           } else {
             VolumeDown();
+          }
         }
-      }
-    return true;
+        return true;
 
   // Modified 2 button 'next/previous preset' AND volume down,
   // to align with multiple skips above.
@@ -622,7 +615,7 @@ public:
 #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
 #endif
-    return true;
+return true;
 
   // 1 button 'next/previous preset' command.
   // Forward one font pointing up, back one font pointing down.
@@ -631,13 +624,13 @@ public:
       // backwards if pointing down
       if (!mode_volume_) {
         SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
-     } else {
+      } else {
         VolumeDown();
-     }
+      }
 #ifdef SAVE_PRESET
-      SaveState(current_preset_.preset_num);
+       SaveState(current_preset_.preset_num);
 #endif
-  return true;
+return true;
 #endif
 
   //  1 Button skips to first preset (up) or last preset (down)
@@ -662,7 +655,7 @@ public:
 #ifdef SAVE_PRESET
         SaveState(current_preset_.preset_num);
 #endif
-  return true;
+return true;
 
   // 1 and 2 button: Previous Preset, retained legacy control.
 #if NUM_BUTTONS == 2
@@ -671,7 +664,7 @@ public:
       if (!mode_volume_) {
         previous_preset();
       }
-    return true;
+      return true;
 
   //  Skips to first preset (up) or last (battery or charge) preset (down)
   //  or middle preset if horizontal:
@@ -695,7 +688,7 @@ public:
 #ifdef SAVE_PRESET
         SaveState(current_preset_.preset_num);
 #endif
-    return true;
+return true;
 
   //  Manual Blade ID Options
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
@@ -705,24 +698,23 @@ public:
       SabersenseFakeBladeID::toggle();
       FindBladeAgain();
       SaberBase::DoBladeDetect(true);
-    return true;
+      return true;
 #else
     //  Runs BladeID Manually to actually check BladeID status.
     //  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
     //  Can use any number of blade/preset arrays.
       FindBladeAgain();
       SaberBase::DoBladeDetect(true);
-    return true;
+      return true;
 #endif
 
   // Activate Muted
-  //  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
       if (SetMute(true)) {
         unmute_on_deactivation_ = true;
         On();
       }
-    return true;
+      return true;
 
   // Turn Blade OFF
 #if NUM_BUTTONS > 1
@@ -738,8 +730,8 @@ public:
           // Just exit color change mode.
           // Don't turn saber off.
           ToggleColorChangeMode();
-        return true;
-      }
+          return true;
+        }
 #endif
         if (!battle_mode_) {
           Off();
@@ -750,69 +742,69 @@ public:
         swing_blast_ = false;
       return true;
 
-  // Character Quote and Force Effect, Blade ON.
-  // Hilt pointed UP for Character Quote, plays sequentially,
-  // Hilt pointed DOWN for Force Effect, plays randomly.
+    // Character Quote and Force Effect, Blade ON.
+    // Hilt pointed UP for Character Quote, plays sequentially,
+    // Hilt pointed DOWN for Force Effect, plays randomly.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  
       // Define reverses UP/DOWN options for QUOTE/FORCE/TRACK audio player.
       //  Quote player points upwards.
-  if (SFX_quote) {
-    if (fusor.angle1() > 0) {
-      SFX_quote.SelectNext();
-        SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-        SaberBase::DoForce();  // Force effect for hilt pointed DOWN
-    }
-    } else {
-        SaberBase::DoForce();  // Fallback: always play force effect if no quotes are available
-    }
-    return true;
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
 #else
       //  Quote player points downwards.
-  if (SFX_quote) {
-    if (fusor.angle1() < 0) {
-      SFX_quote.SelectNext();
-        SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-        SaberBase::DoForce();  // Force effect for hilt pointed DOWN
-    }
-    } else {
-      SaberBase::DoForce();  // Fallback: always play force effect if no quotes are available
-    }
-    return true;
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
 #endif
 
-  //  Character Quote and Music Track, Blade OFF.
-  //  Play sequential quote pointing up, play music track pointing down.
+    //  Character Quote and Music Track, Blade OFF.
+    //  Play sequential quote pointing up, play music track pointing down.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
-  // Define reverses UP/DOWN options for QUOTE/FORCE/TRACK audio player.
-  //  Quote player points upwards.
-  if (SFX_quote) {
-    if (fusor.angle1() > 0) {
-      SFX_quote.SelectNext();
-        SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-        StartOrStopTrack();  // Play track for hilt pointed DOWN
-    }
-    } else {
-        StartOrStopTrack();  // Fallback: always play track if no quotes are available
-    }
-    return true;
+    // Define reverses UP/DOWN options for QUOTE/FORCE/TRACK audio players.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
 #else
-   //  Quote player points downwards.
-  if (SFX_quote) {
-    if (fusor.angle1() < 0) {
-      SFX_quote.SelectNext();
-        SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-        StartOrStopTrack();  // Play track for hilt pointed DOWN
-    }
-    } else {
-        StartOrStopTrack();  // Fallback: always play track if no quotes are available
-    }
-    return true;
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
 #endif
 
   //  Colour Change.
@@ -820,12 +812,12 @@ public:
 #ifndef DISABLE_COLOR_CHANGE
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
       ToggleColorChangeMode();
-    return true;
+      return true;
   //  2 button mode only.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
       ToggleColorChangeMode();
-    return true;
+      return true;
 #endif
 #endif
 
@@ -833,14 +825,10 @@ public:
 #if NUM_BUTTONS == 1
     // 1 button
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-    //  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-    //  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
 #else
     // 2 button
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
     case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-    //  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-    //  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
 #endif
       swing_blast_ = false;
       SaberBase::DoBlast();
@@ -862,13 +850,13 @@ public:
           hybrid_font.SB_Effect(EFFECT_BLAST, 0);
         }
       }
-    return true;
+      return true;
 
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
       if (swing_blast_) {
         SaberBase::DoBlast();
       }
-    return true;
+      return true;
 
   // Lockup
 #if NUM_BUTTONS == 1
@@ -890,7 +878,7 @@ public:
         }
           swing_blast_ = false;
           SaberBase::DoBeginLockup();
-        return true;
+          return true;
       }
     break;
 
@@ -901,9 +889,9 @@ public:
         SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
         swing_blast_ = false;
         SaberBase::DoBeginLockup();
-      return true;
-    }
-  break;
+        return true;
+      }
+    break;
 
   // Melt
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
@@ -915,8 +903,6 @@ public:
       }
     break;
 
-    //  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
-    //  case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
     case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
       SaberBase::RequestMotion();
     return true;
@@ -928,7 +914,7 @@ public:
 #else
     // 2 button
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
-    //  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+
 #endif
       if (!mode_volume_) {
         mode_volume_ = true;
@@ -947,7 +933,7 @@ public:
         }
         STDOUT.println("Exit Volume Menu");
       }
-    return true;
+      return true;
 
 // Battery level
     case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
@@ -982,47 +968,44 @@ public:
 
   // Events that needs to be handled regardless of what other buttons
   // are pressed.
-    //  case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-    //  case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
     case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
       if (SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         return true;
+        }
       }
+      return false;
     }
-    return false;
-  }
 
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
   void SB_Effect(EffectType effect, float location) override {  //  Required for ProffieOS 7.x.
 #else
   void SB_Effect(EffectType effect, EffectLocation location) override {  //  Required for ProffieOS 8.x.
 #endif
-      switch (effect) {
-        case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
-      
-        case EFFECT_POWERSAVE:
-          if (SFX_dim) {
-            hybrid_font.PlayCommon(&SFX_dim);
-          } else {
-            beeper.Beep(0.5, 3000);
-          }
-          return;
-        case EFFECT_BATTERY_LEVEL:
-          if (SFX_battery) {
-            hybrid_font.PlayCommon(&SFX_battery);
-          } else {
-            beeper.Beep(0.5, 3000);
-          }
-          return;
-        case EFFECT_FAST_ON:
-          if (SFX_faston) {
-            hybrid_font.PlayCommon(&SFX_faston);
-          }
-          return;
+    switch (effect) {
+      case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;  
+      case EFFECT_POWERSAVE:
+        if (SFX_dim) {
+          hybrid_font.PlayCommon(&SFX_dim);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_BATTERY_LEVEL:
+        if (SFX_battery) {
+          hybrid_font.PlayCommon(&SFX_battery);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_FAST_ON:
+        if (SFX_faston) {
+          hybrid_font.PlayCommon(&SFX_faston);
+        }
+        return;
 
-        default: break; // avoids compiler warning
+      default: break; // avoids compiler warning
       }
     }
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -289,22 +289,8 @@ Tightened click timings
 #define SABERSENSE_THRUST_GESTURE
 #endif
 
-#ifdef SABERSENSE_FAKE_BLADE_ID
-#define SABERSENSE_FAKE_BLADE_ID
-#endif
-
-#ifdef SABERSENSE_FLIP_AUDIO_PLAYERS
-#define SABERSENSE_FLIP_AUDIO_PLAYERS
-#endif
-
-#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-#define SABERSENSE_OS7_LEGACY_SUPPORT
-#endif
-
 EFFECT(dim);      // for EFFECT_POWERSAVE
 EFFECT(battery);  // for EFFECT_BATTERY_LEVEL
-EFFECT(bmbegin);  // for Begin Battle Mode
-EFFECT(bmend);    // for End Battle Mode
 EFFECT(vmbegin);  // for Begin Volume Menu
 EFFECT(vmend);    // for End Volume Menu
 EFFECT(volup);    // for increse volume
@@ -314,9 +300,8 @@ EFFECT(volmax);   // for maximum volume reached
 EFFECT(faston);   // for EFFECT_FAST_ON
 EFFECT(blstbgn);  // for Begin Multi-Blast
 EFFECT(blstend);  // for End Multi-Blast
-EFFECT(push);     // for Force Push gesture in Battle Mode
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-EFFECT(quote);    // for playing quotes    //  Required for ProffieOS 7.x.
+EFFECT(quote);    // for playing quotes. Required for ProffieOS 7.x.
 #endif
 
 
@@ -547,7 +532,6 @@ public:
         Off();
       last_twist_ = millis();
         saber_off_time_ = millis();
-        battle_mode_ = false;
       }
       return true;
 #endif
@@ -730,17 +714,14 @@ return true;
           // Just exit color change mode.
           // Don't turn saber off.
           ToggleColorChangeMode();
-          return true;
-        }
-#endif
-        if (!battle_mode_) {
+        } else {
           Off();
-          }
         }
-        saber_off_time_ = millis();
-        battle_mode_ = false;
-        swing_blast_ = false;
+      }
+      saber_off_time_ = millis();
+      swing_blast_ = false;
       return true;
+#endif
 
     // Character Quote and Force Effect, Blade ON.
     // Hilt pointed UP for Character Quote, plays sequentially,
@@ -870,37 +851,31 @@ return true;
     case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
 #endif
 #endif
-      if (!SaberBase::Lockup() && !battle_mode_) {
-        if (accel_.x < -0.15) {
-          SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
-        } else {
-          SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
-        }
-          swing_blast_ = false;
-          SaberBase::DoBeginLockup();
-          return true;
+      if (accel_.x < -0.15) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+      } else {
+        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
       }
-    break;
+        swing_blast_ = false;
+        SaberBase::DoBeginLockup();
+        return true;
+      break;
 
   // Lightning Block
     // 1 and 2 button
     case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
-      if (!battle_mode_) {
-        SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
-        swing_blast_ = false;
-        SaberBase::DoBeginLockup();
-        return true;
-      }
+      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
     break;
 
   // Melt
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
-      if (!SaberBase::Lockup() && !battle_mode_) {
-        SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-        swing_blast_ = false;
-        SaberBase::DoBeginLockup();
-        return true;
-      }
+      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
     break;
 
     case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
@@ -1015,7 +990,6 @@ return true;
     bool mode_volume_ = false;
     bool auto_lockup_on_ = false;
     bool auto_melt_on_ = false;
-    bool battle_mode_ = false;
     bool max_vol_reached_ = false;
     bool min_vol_reached_ = false;
     uint32_t thrust_begin_millis_ = millis();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -12,21 +12,20 @@ November 2024.
 ============================================================
 ============ BUTTON MODIFICATION AND LOGIC NOTES =========== 
 
-The Sabersense prop file has been engineered for harmonized 
-controls between one-button and two-button operation without 
-compromising the inevitable increase in user-friendliness 
+The Sabersense button prop file has been engineered for 
+harmonized controls between one-button and two-button 
+operation without compromising the greater usability
 of two-button operation.
 Where practicable, the same controls apply to both states, 
 with two-button operation benefitting from some extra 
-features and controls that are more user-friendly.
-Where possible without causing conflicts, some one-button 
-controls are duplicated in two-button mode, despite there 
-also being different two-button controls for the same function. 
+features. Where possible without causing conflicts, some 
+one-button controls also appear in two-button mode, 
+despite two-button having its own controls for the same feature.
 The overall intention is that users need only remember a 
 minimum set of control principles in order to access 
 all functions. As such, the logic is that the same button 
 presses do the same thing within the various states, 
-with obvious variants.
+subject to inevitable and obvious variants.
 
 Hence:
   ONE AND TWO BUTTON:
@@ -80,8 +79,8 @@ FUNCTIONS WITH BLADE OFF
   Speak battery voltage     Fast four clicks while OFF.
   Run BladeID Manually      Fast triple-click while OFF. (Applicable installs only, toggles arrays).
   Enter/Exit VOLUME MENU    Hold and clash while OFF.
-  Volume up                 Click MAIN while in VOLUME MENU, hilt pointing up.
-  Volume down               Click MAIN while in VOLUME MENU, hilt pointing down.
+    Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
+    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down.
                               Volume adjusts in increments per click.
                               You must exit VOLUME MENU to resume using lightsaber normally.
 
@@ -102,8 +101,8 @@ FUNCTIONS WITH BLADE ON
 COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Enter COLOUR MENU         Fast triple-click while ON.
                               Announcement confirms you are in the COLOUR MENU. 
-  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
-  Exit COLOUR MENU          Fast triple-click OR hold and wait. 
+    Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+    Exit COLOUR MENU        Fast triple-click OR hold and wait. 
                               Announcement confirms you are exiting COLOUR MENU.
                               You must exit COLOUR MENU to resume using lightsaber normally.
 
@@ -134,8 +133,8 @@ FUNCTIONS WITH BLADE OFF
   Speak battery voltage     Fast four clicks MAIN or hold hold AUX for one second and let go.
   Run/Toggle BladeID        Fast triple-click MAIN. (Applicable installs only).
   Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
-  Volume up                 Click MAIN while in VOLUME MENU, hilt pointing up.
-  Volume down               Click MAIN while in VOLUME MENU, hilt pointing down, OR click 
+    Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
+    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down, OR click 
                               AUX while in VOLUME MENU.
                               Volume adjusts in increments per click.
                               You must exit VOLUME MENU to resume using saber normally.
@@ -159,9 +158,9 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Enter/Exit COLOUR MENU    Hold MAIN then quickly click AUX and release both
                             buttons simultaneously. Or fast triple-click MAIN.
                               Announcement confirms you are in the COLOUR MENU.
-  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+    Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
                               Most Sabersense presets have 12 colour options.
-  Alt Exit COLOUR MENU      Hold MAIN and wait. 
+    Alt Exit COLOUR MENU    Hold MAIN and wait. 
                               Announcement confirms you are exiting COLOUR MENU.
                               You must exit COLOUR MENU to resume using lightsaber normally.
                               
@@ -700,7 +699,7 @@ public:
 
   //  Manual Blade ID Options
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-#ifdef FAKE_BLADE_ID
+#ifdef SABERSENSE_FAKE_BLADE_ID
       //  Toggles between blade arrays regardless of BladeID status.
       //  Cannot use more than two blade/preset arrays.
       SabersenseFakeBladeID::toggle();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -6,11 +6,11 @@
 Built on SA22C programming by Matthew McGeary.
 Modified by Chris Carter with help and contributions 
 from Brian Connor and Fredrik Hubinette.
-November 2024, first edition.
+November 2024.
 
 
 ============================================================
-=============== MODIFICATION AND LOGIC NOTES =============== 
+============ BUTTON MODIFICATION AND LOGIC NOTES =========== 
 
 The Sabersense prop file has been engineered for harmonized 
 controls between one-button and two-button operation without 
@@ -29,170 +29,182 @@ presses do the same thing within the various states,
 with obvious variants.
 
 Hence:
-ONE AND TWO BUTTON:
-	Single click MAIN always lights the blade...
-		Short click lights blade with sound
-		Long click lights blade mute
-	
-	Double click MAIN always plays a sound file...
-		Character Quote or Music track with blade OFF
-		Character Quote or Force Effect with blade ON
-		
-	Holding down MAIN (1-button) or AUX (2-button) 
-	and waiting with blade OFF always skips to specific preset...
-		Hilt pointing up - first preset
-		Hilt horizontal - middle preset
-		Hilt pointing down - last preset
-		
-	Triple-clicking MAIN always enters a control menu
-		Colour change with blade ON
-		BladeID with blade OFF
+  ONE AND TWO BUTTON:
+    Single click MAIN always lights the blade...
+    Short click lights blade with sound
+    Long click lights blade mute
 
-TWO BUTTON ONLY:	
-	Short clicking AUX with blade OFF always moves to a different preset, 
-	forward with hilt pointing up, backwards with hilt pointing down...
-		Single short click - one preset
-		Double short click - five presets
-		Triple short click - ten presets
-	
-	Holding MAIN and short clicking AUX always enters a control menu...
-		Colour change with blade ON
-		Volume menu with blade OFF
+    Double click MAIN always plays a sound file...
+      Character Quote or Music track with blade OFF
+      Character Quote or Force Effect with blade ON
+
+    Holding down MAIN (1-button) or AUX (2-button) 
+    and waiting with blade OFF always skips to specific preset...
+      Hilt pointing up - first preset
+      Hilt horizontal - middle preset
+      Hilt pointing down - last preset
+
+    Triple-clicking MAIN always enters a control menu
+      Colour change with blade ON
+      BladeID with blade OFF
+
+  TWO BUTTON ONLY:
+    Short clicking AUX with blade OFF always moves to a different preset, 
+    forward with hilt pointing up, backwards with hilt pointing down...
+      Single short click - one preset
+      Double short click - five presets
+      Triple short click - ten presets
+
+    Holding MAIN and short clicking AUX always enters a control menu...
+      Colour change with blade ON
+      Volume menu with blade OFF
 
 
-==========================================================		
+==========================================================
 =================== 1 BUTTON CONTROLS ==================== 
 
 MAIN FUNCTIONS
-Activate blade			Short click while OFF.
-Activate blade mute   	Long click while OFF (hold for one second then release). 
-Deactivate blade		Hold and wait until blade is off while ON.
+  Activate blade            Short click while OFF. *
+  Activate blade mute       Long click while OFF (hold for one second then release). 
+  Deactivate blade          Hold and wait until blade is off while ON.
 
 FUNCTIONS WITH BLADE OFF
-Next preset	           Double click and hold while OFF pointing blade tip up.
-Previous preset		   Double click and hold while OFF pointing blade tip down.
-Skip to first preset   Press and hold until it switches, hilt pointing upwards.
-Skip to middle preset  Press and hold until it switches, hilt horizontal.
-Skip to last preset    Press and hold until it switches, hilt pointing downwards.
-Play Character Quote   Fast double-click, hilt pointing up. Quotes play sequentially.
-							To reset sequential quotes, change font or run BladeID.
-Play Music Track	   Fast double-click, hilt pointing down.
-Speak battery voltage  Fast four clicks while OFF.
-Run BladeID Manually   Fast triple-click while OFF. (Applicable installs only, toggles arrays).
-Enter/Exit VOLUME MENU Hold and clash while OFF.
-Volume up               	Click MAIN while in VOLUME MENU, hilt pointing up.
-Volume down					Click MAIN while in VOLUME MENU, hilt pointing down.
-						   	Volume adjusts in increments per click.
-						   	You must exit VOLUME MENU to resume using lightsaber normally.
+  Next preset               Double click and hold while OFF pointing blade tip up.
+  Previous preset           Double click and hold while OFF pointing blade tip down.
+  Skip to first preset      Press and hold until it switches, hilt pointing upwards.
+  Skip to middle preset     Press and hold until it switches, hilt horizontal.
+  Skip to last preset       Press and hold until it switches, hilt pointing downwards.
+  Play Character Quote      Fast double-click, hilt pointing up. Quotes play sequentially. **
+                              To reset sequential quotes, change font or run BladeID.
+  Play Music Track          Fast double-click, hilt pointing down. **
+  Speak battery voltage     Fast four clicks while OFF.
+  Run BladeID Manually      Fast triple-click while OFF. (Applicable installs only, toggles arrays).
+  Enter/Exit VOLUME MENU    Hold and clash while OFF.
+  Volume up                 Click MAIN while in VOLUME MENU, hilt pointing up.
+  Volume down               Click MAIN while in VOLUME MENU, hilt pointing down.
+                              Volume adjusts in increments per click.
+                              You must exit VOLUME MENU to resume using lightsaber normally.
 
-FUNCTIONS WITH BLADE ON		
-Blade lockup			Hold and hit clash while ON.
-Blade tip drag			Hold and hit clash while ON pointing the blade tip down.
-Force Effect (Quote)	Fast double-click MAIN, hilt pointing down.
-							Plays random Force effect (usually character quote).
-Character Quote			Fast double-click MAIN, hilt pointing up.
-							Plays sequential character quote.
-Lightning block			Double click and hold while ON.
-Melt         		    Hold and thrust forward clash while ON. (Selected fonts only).
-Blaster blocks			Short click/double click/triple click while ON.
-Enter multi-blast mode		Hold while swinging for one second and release.
-							To trigger blaster block, swing saber while in multi-blast mode.
-							To exit, hold while swinging for one second and release.
+FUNCTIONS WITH BLADE ON
+  Blade lockup              Hold and hit clash while ON.
+  Blade tip drag            Hold and hit clash while ON pointing the blade tip down.
+  Force Effect (Quote)      Fast double-click MAIN, hilt pointing down.
+                              Plays random Force effect (usually character quote).
+  Character Quote           Fast double-click MAIN, hilt pointing up.
+                              Plays sequential character quote.
+  Lightning block           Double click and hold while ON.
+  Melt                      Hold and thrust forward clash while ON. (Selected fonts only).
+  Blaster blocks            Short click/double click/triple click while ON.
+  Enter multi-blast mode    Hold while swinging for one second and release.
+                              To trigger blaster block, swing saber while in multi-blast mode.
+                              To exit, hold while swinging for one second and release.
 
 COLOUR CHANGE FUNCTIONS WITH BLADE ON
-Enter COLOUR MENU		Fast triple-click while ON.
-							Announcement confirms you are in the COLOUR MENU. 
-Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
-Exit COLOUR MENU		Fast triple-click or hold and wait. 
-							Announcement confirms you are exiting COLOUR MENU.
-                        	You must exit COLOUR MENU to resume using lightsaber normally.
+  Enter COLOUR MENU         Fast triple-click while ON.
+                              Announcement confirms you are in the COLOUR MENU. 
+  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+  Exit COLOUR MENU          Fast triple-click OR hold and wait. 
+                              Announcement confirms you are exiting COLOUR MENU.
+                              You must exit COLOUR MENU to resume using lightsaber normally.
 
 
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
 
 MAIN FUNCTIONS
-Activate blade			Short click MAIN.
-Activate blade mute   	Long click MAIN (hold for one second then release). 
-Deactivate blade		Press and hold MAIN and wait until blade is off.
+  Activate blade            Short click MAIN. *
+  Activate blade mute       Long click MAIN (hold for one second then release). 
+  Deactivate blade          Press and hold MAIN and wait until blade is off.
 
 FUNCTIONS WITH BLADE OFF
-Next preset				Short click AUX, hilt pointing upwards.
-Previous preset			Short click AUX, hilt pointing downwards.
-Previous preset			Hold AUX and short click MAIN.
-							(Duplicate legacy command).
-Skip to first preset    Press and hold any button until it switches, hilt upwards.
-Skip to middle preset   Press and hold any button  until it switches, hilt horizontal.
-Skip to last preset     Press and hold any button  until it switches, hilt downwards.
-Skip forward 5 presets	Fast double-click AUX, hilt pointing upwards.
-Skip back 5 presets		Fast double-click AUX, hilt pointing downwards.
-Skip forward 10 presets	Fast triple-click AUX, hilt pointing upwards.
-Skip back 10 presets	Fast triple-click AUX, hilt pointing downwards.
-Play Character Quote	Fast double-click MAIN, pointing up. Quotes play sequentially.
-							To reset sequential quotes, change font or run BladeID.
-Play Music Track	    Fast double-click MAIN, pointing down.
-Speak battery voltage	Fast four clicks MAIN or hold hold AUX for one second and let go.
-Run/Toggle BladeID		Fast triple-click MAIN. (Applicable installs only).
-Enter/Exit VOLUME MENU 	Hold MAIN then quickly click AUX
-						and release both buttons simultaneously.
-Volume up               	Click MAIN while in VOLUME MENU, hilt pointing up.
-Volume down					Click MAIN while in VOLUME MENU, hilt pointing down, or
-							click AUX while in VOLUME MENU.
-							Volume adjusts in increments per click.
-							You must exit VOLUME MENU to resume using saber normally.
-							
+  Next preset               Short click AUX, hilt pointing upwards.
+  Previous preset           Short click AUX, hilt pointing downwards.
+  Previous preset           Hold AUX and short click MAIN.
+                              (Duplicate legacy command).
+  Skip to first preset      Press and hold any button until it switches, hilt upwards.
+  Skip to middle preset     Press and hold any button  until it switches, hilt horizontal.
+  Skip to last preset       Press and hold any button  until it switches, hilt downwards.
+  Skip forward 5 presets    Fast double-click AUX, hilt pointing upwards.
+  Skip back 5 presets       Fast double-click AUX, hilt pointing downwards.
+  Skip forward 10 presets   Fast triple-click AUX, hilt pointing upwards.
+  Skip back 10 presets      Fast triple-click AUX, hilt pointing downwards.
+  Play Character Quote      Fast double-click MAIN, pointing up. Quotes play sequentially. **
+                              To reset sequential quotes, change font or run BladeID.
+  Play Music Track          Fast double-click MAIN, pointing down. **
+  Speak battery voltage     Fast four clicks MAIN or hold hold AUX for one second and let go.
+  Run/Toggle BladeID        Fast triple-click MAIN. (Applicable installs only).
+  Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
+  Volume up                 Click MAIN while in VOLUME MENU, hilt pointing up.
+  Volume down               Click MAIN while in VOLUME MENU, hilt pointing down, OR click 
+                              AUX while in VOLUME MENU.
+                              Volume adjusts in increments per click.
+                              You must exit VOLUME MENU to resume using saber normally.
+
 FUNCTIONS WITH BLADE ON
-Blade lockup			Press and hold AUX.
-Blade tip drag			Press and hold AUX while blade is pointing down.
-Force Effect (Quote)	Fast double-click MAIN, hilt pointing down.
-							Plays random Force effect (usually character quote).
-Character Quote			Fast double-click MAIN, hilt pointing up.
-							Plays sequential character quote.
-Lightning block			Double-click MAIN and hold.
-Melt         			Hold MAIN and push blade tip against wall (stab).
-Blaster blocks			Short click AUX.
-Enter multi-blast mode	Hold MAIN while swinging for one second and release. 
-							Saber will play two quick blasts confirming mode.
-							Swing blade to trigger blaster block.
-							To exit multi-blast mode, fast single click AUX.
+  Blade lockup              Press and hold AUX.
+  Blade tip drag            Press and hold AUX while blade is pointing down.
+  Force Effect (Quote)      Fast double-click MAIN, hilt pointing down.
+  Plays random              Force effect (usually character quote).
+  Character Quote           Fast double-click MAIN, hilt pointing up.
+                              Plays sequential character quote.
+  Lightning block           Double-click MAIN and hold.
+  Melt                      Hold MAIN and push blade tip against wall (stab).
+  Blaster blocks            Short click AUX.
+  Enter multi-blast mode    Hold MAIN while swinging for one second and release. 
+                              Saber will play two quick blasts confirming mode.
+                              Swing blade to trigger blaster block.
+                              To exit multi-blast mode, fast single click AUX.
 
 COLOUR CHANGE FUNCTIONS WITH BLADE ON
-Enter/Exit COLOUR MENU	Hold MAIN then quickly click AUX and release both
-						buttons simultaneously. Or fast triple-click MAIN.
-							Announcement confirms you are in the COLOUR MENU.
-Cycle to next colour    Rotate hilt whilst in COLOUR MENU until desired colour is reached.
-							Most presets have 12 colour options.
-Alt Exit COLOUR MENU	Hold MAIN and wait. 
-							Announcement confirms you are exiting COLOUR MENU.
-							You must exit COLOUR MENU to resume using lightsaber normally.
+  Enter/Exit COLOUR MENU    Hold MAIN then quickly click AUX and release both
+                            buttons simultaneously. Or fast triple-click MAIN.
+                              Announcement confirms you are in the COLOUR MENU.
+  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+                              Most Sabersense presets have 12 colour options.
+  Alt Exit COLOUR MENU      Hold MAIN and wait. 
+                              Announcement confirms you are exiting COLOUR MENU.
+                              You must exit COLOUR MENU to resume using lightsaber normally.
+                              
+  *  = Gesture ignitions also available via defines.
+  ** = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
 
-							
-===========================================================		
+
+===========================================================
 ========================= DEFINES =========================
 #define SABERSENSE_FAKE_BLADE_ID
-Replaces regular BladeID and allows toggling between two different 
-blade/preset arrays regardless of actual BladeID status.
+  Replaces regular BladeID and allows toggling between two different 
+  blade/preset arrays regardless of actual BladeID status.
+  
+#define SABERSENSE_FLIP_AUDIO_PLAYERS
+  Reverses UP/DOWN orientation for playing FORCE, QUOTE and TRACK audio files.
+  Default (no define) is UP for sequential QUOTE and 
+  DOWN for FORCE (random, blade ON) and TRACK (blade OFF).
+  Define acts on both ON and OFF states for consistency.
 
-#define SABERSENSE_NO_LOCKUP_HOLD	
-Applicable to two-button mode only, reverts to lockup being 
-triggered by clash while holding aux.
+#define SABERSENSE_OS7_LEGACY_SUPPORT
+  Required when using this prop file with ProffieOS 7.x. 
+  Must NOT be used with ProffieOS 8.x or later.
+  
+#define SABERSENSE_NO_LOCKUP_HOLD
+  Applicable to two-button mode only, reverts to lockup being 
+  triggered by clash while holding aux.
 
 GESTURE CONTROLS
-There are four gesture types: Twist, Stab, Swing and Thrust.
-Gesture controls bypass all preon effects.
-Below are the options to add to the config to enable the various gestures. MM.
-#define SABERSENSE_TWIST_ON
-#define SABERSENSE_TWIST_OFF
-#define SABERSENSE_STAB_ON
-#define SABERSENSE_SWING_ON
-#define SABERSENSE_THRUST_ON
+  There are four gesture types: Twist, Stab, Swing and Thrust.
+  Gesture controls bypass all preon effects.
+  Below are the options to add to the config to enable the various gestures. MM.
+  #define SABERSENSE_TWIST_ON
+  #define SABERSENSE_TWIST_OFF
+  #define SABERSENSE_STAB_ON
+  #define SABERSENSE_SWING_ON
+  #define SABERSENSE_THRUST_ON
 
 Tightened click timings
-I've shortened the timeout for short and double click detection from 500ms
-to 300ms.  I think it feels more responsive this way but still gives enough
-timeout to ensure all button actions can be achieved consistently
-I've included all button timings so they can be easily tweaked to suit
-individual tastes. MM.
+  I've shortened the timeout for short and double click detection from 500ms
+  to 300ms.  I think it feels more responsive this way but still gives enough
+  timeout to ensure all button actions can be achieved consistently
+  I've included all button timings so they can be easily tweaked to suit
+  individual tastes. MM.
 
 ============================================================
 ============================================================
@@ -201,23 +213,23 @@ individual tastes. MM.
 #define PROPS_SABER_SABERSENSE_BUTTONS_H
 
 
-//  Used instead of BladeID and allows toggle switching 
-//  between two blade/preset arrays manually irrespective
-//  of actual BladeID status.
-	#ifdef SABERSENSE_FAKE_BLADE_ID
-		struct SabersenseFakeBladeID {
-   		static int return_value;
-   		float id() { return return_value; }
-   		static void toggle() {
-     return_value = NO_BLADE - return_value;
-   	}
-	};
-		int SabersenseFakeBladeID::return_value = 0;
-		#undef BLADE_ID_CLASS_INTERNAL
-		#define BLADE_ID_CLASS_INTERNAL SabersenseFakeBladeID
-		#undef BLADE_ID_CLASS
-		#define BLADE_ID_CLASS SabersenseFakeBladeID
-	#endif
+  //  Used instead of BladeID and allows toggle switching 
+  //  between two blade/preset arrays manually irrespective
+  //  of actual BladeID status.
+#ifdef SABERSENSE_FAKE_BLADE_ID
+  struct SabersenseFakeBladeID {
+    static int return_value;
+    float id() { return return_value; }
+      static void toggle() {
+    return_value = NO_BLADE - return_value;
+    }
+  };
+  int SabersenseFakeBladeID::return_value = 0;
+  #undef BLADE_ID_CLASS_INTERNAL
+  #define BLADE_ID_CLASS_INTERNAL SabersenseFakeBladeID
+  #undef BLADE_ID_CLASS
+  #define BLADE_ID_CLASS SabersenseFakeBladeID
+#endif
 
 
 #include "prop_base.h"
@@ -282,6 +294,14 @@ individual tastes. MM.
 #define SABERSENSE_FAKE_BLADE_ID
 #endif
 
+#ifdef SABERSENSE_FLIP_AUDIO_PLAYERS
+#define SABERSENSE_FLIP_AUDIO_PLAYERS
+#endif
+
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+#define SABERSENSE_OS7_LEGACY_SUPPORT
+#endif
+
 //  #define FORCE_PUSH_CONDITION battle_mode_
 
 EFFECT(dim);      // for EFFECT_POWERSAVE
@@ -298,12 +318,13 @@ EFFECT(faston);   // for EFFECT_FAST_ON
 EFFECT(blstbgn);  // for Begin Multi-Blast
 EFFECT(blstend);  // for End Multi-Blast
 EFFECT(push);     // for Force Push gesture in Battle Mode
-EFFECT(quote);    // for playing quotes
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+EFFECT(quote);    // for playing quotes    //  Required for ProffieOS 7.x.
+#endif
 
 
-
-// The Saber class implements the basic states and actions
-// for the saber.
+  // The Saber class implements the basic states and actions
+  // for the saber.
 class SabersenseButtons : public PROP_INHERIT_PREFIX PropBase {
 public:
   SabersenseButtons() : PropBase() {}
@@ -373,7 +394,7 @@ public:
     }
   }
 
-// Volume Menu
+  // Volume Menu
   void VolumeUp() {
     STDOUT.println("Volume up");
     if (dynamic_mixer.get_volume() < VOLUME) {
@@ -463,25 +484,24 @@ public:
     }
   }
 
-
-//  Button Clicker to play press/release wav files when buttons are pressed.
-//  Intended for Scavenger hilt where wheel makes tactile feel difficult.
-//  Requires press.wav and release.wav files to work.
+  //  Button Clicker to play press/release wav files when buttons are pressed.
+  //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
+  //  Requires press.wav and release.wav files to work.
     void PlaySound(const char* sound) {
-        RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
-        if (player) {
-            if (!player->PlayInCurrentDir(sound)) player->Play(sound);
+      RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+       if (player) {
+         if (!player->PlayInCurrentDir(sound)) player->Play(sound);
         }
-    }            
- bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {      
-    switch (EVENTID(button, event, modifiers)) {
+      }            
+    bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {      
+      switch (EVENTID(button, event, modifiers)) {
       case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
       case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
       case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
       case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
         SaberBase::RequestMotion();
         PlaySound("press.wav");
-        return false;
+          return false;
       case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
       case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
       case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
@@ -490,9 +510,9 @@ public:
         if (SaberBase::Lockup()) {
           SaberBase::DoEndLockup();
           SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
-          return true;
+            return true;
         } else {
-          return false;
+            return false;
         }
       case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
       case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
@@ -500,518 +520,518 @@ public:
           pointing_down_ = true;
         } else {
           pointing_down_ = false;
+      }
+    return true;
+
+  //  Gesture Controls
+#ifdef SABERSENSE_SWING_ON
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
+      // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
+      if (millis() > 3000) {
+        FastOn();
+        //  On();
+      }
+    return true;
+#endif
+
+#ifdef SABERSENSE_TWIST_ON
+    case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+      // Delay twist events to prevent false trigger from over twisting
+      if (millis() - last_twist_ > 2000 &&
+        millis() - saber_off_time_ > 1000) {
+          FastOn();
+          //  On();
+         last_twist_ = millis();
         }
-    	return true;
-   
+      return true;
+#endif
 
-//  Gesture Controls
-	#ifdef SABERSENSE_SWING_ON
-  		case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
-    		// Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
-   	 		if (millis() > 3000) {
-    			FastOn();
-				//  On();
-    		}
-    	return true;
-	#endif
+#ifdef SABERSENSE_TWIST_OFF
+    case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
+      // Delay twist events to prevent false trigger from over twisting
+      if (millis() - last_twist_ > 3000) {
+        Off();
+          last_twist_ = millis();
+          saber_off_time_ = millis();
+          battle_mode_ = false;
+        }
+      return true;
+#endif
 
+#ifdef SABERSENSE_STAB_ON
+    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
+      if (millis() - saber_off_time_ > 1000) {
+        FastOn();
+        //  On();
+      }
+    return true;
+#endif
 
-	#ifdef SABERSENSE_TWIST_ON
-  		case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
-    		// Delay twist events to prevent false trigger from over twisting
-    		if (millis() - last_twist_ > 2000 &&
-        	millis() - saber_off_time_ > 1000) {
-    			FastOn();
-				//  On();
-      		last_twist_ = millis();
-    		}
-    	return true;
-	#endif
+#ifdef SABERSENSE_THRUST_ON
+    case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
+      if (millis() - saber_off_time_ > 1000) {
+        FastOn();
+        //  On();
+      }
+    return true;
+#endif
 
-
-	#ifdef SABERSENSE_TWIST_OFF
-  		case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
-   			// Delay twist events to prevent false trigger from over twisting
-    		if (millis() - last_twist_ > 3000) {
-      		Off();
-      			last_twist_ = millis();
-      			saber_off_time_ = millis();
-      			battle_mode_ = false;
-    		}
-    	return true;
-	#endif
-
-
-	#ifdef SABERSENSE_STAB_ON
-      	case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        	if (millis() - saber_off_time_ > 1000) {
-				FastOn();
-				//  On();
-        	}
-        return true;
-	#endif
-
-
-	#ifdef SABERSENSE_THRUST_ON
-      case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        	if (millis() - saber_off_time_ > 1000) {
-    			FastOn();
-				//  On();
-        	}
-        return true;
-	#endif
-
-
-//  Multiple Skips only available with 2 button installs.
-//  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
-	case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
-    		// backwards if pointing down
-    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
-		#ifdef SAVE_PRESET
-    		SaveState(current_preset_.preset_num);
-		#endif
+  //  Multiple Skips only available with 2 button installs.
+  //  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
+    case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+      SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
+    #ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+    #endif
     return true;
 
- 
-// Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
-	case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-    		// backwards if pointing down
-    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
-		#ifdef SAVE_PRESET
-    		SaveState(current_preset_.preset_num);
-		#endif
+  // Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
+    case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+        SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
+      #ifdef SAVE_PRESET
+        SaveState(current_preset_.preset_num);
+      #endif
     return true;
 
-   
 // Saber ON AND Volume Adjust.
-	case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
-    	if (!mode_volume_) {
-      		On();
-    	} else {
-     	if (fusor.angle1() > 0) {
-      		VolumeUp();
-    	} else {
-      		VolumeDown();
-    	}
-    	}
-    return true;
-
-
-// Modified 2 button 'next/previous preset' AND volume down,
-// to align with multiple skips above.
-// Forward one font pointing up, back one font pointing down.
-	case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
-    	// backwards if pointing down
-    	if (!mode_volume_) {
-    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+      IgnoreClash(50);  //  Hopefully prevents false clashes due to 'clicky' button.
+                        //  Low threshold so as not to conflict with 1-button lockup or volume menu.
+        if (!mode_volume_) {
+          On();
         } else {
-      		VolumeDown();
-    	}
-		#ifdef SAVE_PRESET
-    		SaveState(current_preset_.preset_num);
-		#endif
-	return true;
+          if (fusor.angle1() > 0) {
+            VolumeUp();
+          } else {
+            VolumeDown();
+        }
+      }
+    return true;
 
+  // Modified 2 button 'next/previous preset' AND volume down,
+  // to align with multiple skips above.
+  // Forward one font pointing up, back one font pointing down.
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+      if (!mode_volume_) {
+        SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+      } else {
+        VolumeDown();
+      }
+#ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+#endif
+    return true;
 
-// 1 button 'next/previous preset' command.
-// Forward one font pointing up, back one font pointing down.
-	#if NUM_BUTTONS == 1 
-      case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
-    	// backwards if pointing down
-    	if (!mode_volume_) {
-    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+  // 1 button 'next/previous preset' command.
+  // Forward one font pointing up, back one font pointing down.
+#if NUM_BUTTONS == 1 
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
+      // backwards if pointing down
+      if (!mode_volume_) {
+        SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+     } else {
+        VolumeDown();
+     }
+#ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+#endif
+  return true;
+#endif
+
+  //  1 Button skips to first preset (up) or last preset (down)
+  //  or middle preset if horizontal:
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
+#endif
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+      #define DEGREES_TO_RADIANS (M_PI / 180)
+        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+          // If pointing up
+          SetPreset(0, true);
+        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+          // If pointing down
+          SetPreset(-1, true);
         } else {
-      		VolumeDown();
-    	}
-		#ifdef SAVE_PRESET
-    		SaveState(current_preset_.preset_num);
-		#endif
-    	return true;
-	#endif
+          // If horizontal
+          CurrentPreset tmp;
+          tmp.SetPreset(-1);
+          SetPreset(tmp.preset_num / 2, true);
+        }
+#ifdef SAVE_PRESET
+        SaveState(current_preset_.preset_num);
+#endif
+  return true;
 
-
-//  1 Button skips to first preset (up) or last preset (down)
-//  or middle preset if horizontal:
-		#if NUM_BUTTONS == 2
-			case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
-		#endif
-			case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
-			#define DEGREES_TO_RADIANS (M_PI / 180)
- 				if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-					// If pointing up
-					SetPreset(0, true);
- 				} else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-					// If pointing down
-				SetPreset(-1, true);
- 				} else {
-					// If horizontal
-					CurrentPreset tmp;
-					tmp.SetPreset(-1);
-					SetPreset(tmp.preset_num / 2, true);
-				}
-			#ifdef SAVE_PRESET
-    				SaveState(current_preset_.preset_num);
-			#endif
+  // 1 and 2 button: Previous Preset, retained legacy control.
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
+#endif
+      if (!mode_volume_) {
+        previous_preset();
+      }
     return true;
 
-
-// 1 and 2 button: Previous Preset, retained legacy control.
-	#if NUM_BUTTONS == 2
-		case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
-	#endif
-    	if (!mode_volume_) {
-      	previous_preset();
-   	 }
+  //  Skips to first preset (up) or last (battery or charge) preset (down)
+  //  or middle preset if horizontal:
+#if NUM_BUTTONS == 2
+  // 2 button: First Preset
+    case EVENTID(BUTTON_AUX, EVENT_HELD_LONG, MODE_OFF):
+#endif
+      #define DEGREES_TO_RADIANS (M_PI / 180)
+        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+          // If pointing up
+          SetPreset(0, true);
+        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+          // If pointing down
+           SetPreset(-1, true);
+        } else {
+          // If horizontal
+          CurrentPreset tmp;
+          tmp.SetPreset(-1);
+          SetPreset(tmp.preset_num / 2, true);
+        }
+#ifdef SAVE_PRESET
+        SaveState(current_preset_.preset_num);
+#endif
     return true;
 
-
-//  Skips to first preset (up) or last (battery or charge) preset (down)
-//  or middle preset if horizontal:
-	#if NUM_BUTTONS == 2
-	// 2 button: First Preset
-		case EVENTID(BUTTON_AUX, EVENT_HELD_LONG, MODE_OFF):
-	#endif
-		#define DEGREES_TO_RADIANS (M_PI / 180)
- 		if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-			// If pointing up
-			SetPreset(0, true);
-		} else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-			// If pointing down
-			SetPreset(-1, true);
- 		} else {
-			// If horizontal
-			CurrentPreset tmp;
-			tmp.SetPreset(-1);
-			SetPreset(tmp.preset_num / 2, true);
-		}
-		#ifdef SAVE_PRESET
-    		SaveState(current_preset_.preset_num);
-		#endif
+  //  Manual Blade ID Options
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+#ifdef FAKE_BLADE_ID
+      //  Toggles between blade arrays regardless of BladeID status.
+      //  Cannot use more than two blade/preset arrays.
+      SabersenseFakeBladeID::toggle();
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
     return true;
-    
+#else
+    //  Runs BladeID Manually to actually check BladeID status.
+    //  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
+    //  Can use any number of blade/preset arrays.
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
+    return true;
+#endif
 
-//  Manual Blade ID Options
-	case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-		#ifdef FAKE_BLADE_ID
-		//  Toggles between blade arrays regardless of BladeID status.
-		//  Cannot use more than two blade/preset arrays.
-      		SabersenseFakeBladeID::toggle();
-      		FindBladeAgain();
-      		SaberBase::DoBladeDetect(true);
-        	return true;
-		#else
-		//  Runs BladeID Manually to actually check BladeID status.
-		//  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
-		//  Can use any number of blade/preset arrays.
-    		FindBladeAgain();
-    		SaberBase::DoBladeDetect(true);
-			return true;
-		#endif
-
- 
-// Activate Muted
-	//  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
+  // Activate Muted
+  //  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-    	if (SetMute(true)) {
-      		unmute_on_deactivation_ = true;
-      	On();
-    	}
+      if (SetMute(true)) {
+        unmute_on_deactivation_ = true;
+        On();
+      }
     return true;
 
-
-// Turn Blade OFF
+  // Turn Blade OFF
 #if NUM_BUTTONS > 1
-	// 2 button
-		case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
- 	#else
-	// 1 button
-  		case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_ON):
-	#endif
-    	if (!SaberBase::Lockup()) {
-		#ifndef DISABLE_COLOR_CHANGE
-      	if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        	// Just exit color change mode.
-        	// Don't turn saber off.
-        	ToggleColorChangeMode();
+    // 2 button
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
+#else
+    // 1 button
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_ON):
+#endif
+      if (!SaberBase::Lockup()) {
+#ifndef DISABLE_COLOR_CHANGE
+        if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+          // Just exit color change mode.
+          // Don't turn saber off.
+          ToggleColorChangeMode();
         return true;
-      	}
-	#endif
-      	if (!battle_mode_) {
-       		Off();
-      		}
-    	}
-    	saber_off_time_ = millis();
-    	battle_mode_ = false;
-    	swing_blast_ = false;
-    return true;
+      }
+#endif
+        if (!battle_mode_) {
+          Off();
+          }
+        }
+        saber_off_time_ = millis();
+        battle_mode_ = false;
+        swing_blast_ = false;
+      return true;
 
-
-// Character Quote and Force Effect, Blade ON.
-// Hilt pointed UP for Character Quote, plays sequentially,
-// Hilt pointed DOWN for Force Effect, plays randomly.
-	case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-    	if (SFX_quote) {
-     		if (fusor.angle1() > 0) {
-            	SFX_quote.SelectNext();
-          		SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        	} else {
-          		SaberBase::DoForce();
-        	}
-       	}
-	return true;
-
-
-//  Character Quote and Music Track, Blade OFF.
-//  Play sequential quote pointing up, play music track pointing down.
-case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
-   if (SFX_quote) {
-     if (fusor.angle1() > 0) {
-            SFX_quote.SelectNext();
+  // Character Quote and Force Effect, Blade ON.
+  // Hilt pointed UP for Character Quote, plays sequentially,
+  // Hilt pointed DOWN for Force Effect, plays randomly.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  // Reverses UP/DOWN options for respective QUOTE/FORCE audio playing.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+          SFX_quote.SelectNext();
           SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-    StartOrStopTrack();
-    }
-    }
+        } else {
+          SaberBase::DoForce();
+        }
+       }
     return true;
-    
+#else
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();
+        }
+       }
+    return true;
+#endif
 
-//  Colour Change.
-	//  1 and 2 button modes.
-	#ifndef DISABLE_COLOR_CHANGE
-		case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-      		ToggleColorChangeMode();
-    	return true;
+  //  Character Quote and Music Track, Blade OFF.
+  //  Play sequential quote pointing up, play music track pointing down.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  // Reverses UP/DOWN options for respective QUOTE/TRACK audio playing.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();
+        }
+       }
+    return true;
+#else
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();
+        }
+       }
+    return true;
+#endif
 
-	//  2 button mode only.
-		#if NUM_BUTTONS == 2
-			case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
-      			ToggleColorChangeMode();
-    		return true;
-		#endif
-	#endif
+  //  Colour Change.
+  //  1 and 2 button modes.
+#ifndef DISABLE_COLOR_CHANGE
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+      ToggleColorChangeMode();
+    return true;
+  //  2 button mode only.
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+      ToggleColorChangeMode();
+    return true;
+#endif
+#endif
 
-
-// Blaster Deflection
-	#if NUM_BUTTONS == 1
-  		// 1 button
-  		case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-		//  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-		//  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
-	#else
-  		// 2 button
-  		case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-  		case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-		//  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-		//  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
-	#endif
-    	swing_blast_ = false;
-    	SaberBase::DoBlast();
+  // Blaster Deflection
+#if NUM_BUTTONS == 1
+    // 1 button
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+    //  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+    //  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+#else
+    // 2 button
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+    //  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+    //  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+#endif
+      swing_blast_ = false;
+      SaberBase::DoBlast();
     return true;
 
-
-// Multi-Blaster Deflection mode
-	case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
-    	swing_blast_ = !swing_blast_;
-    	if (swing_blast_) {
-      		if (SFX_blstbgn) {
-        		hybrid_font.PlayCommon(&SFX_blstbgn);
-      		} else {
-        		hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-      		}
-    	} else {
-      		if (SFX_blstend) {
-        	hybrid_font.PlayCommon(&SFX_blstend);
-      	} else {
-        	hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-      		}
-    	}
+  // Multi-Blaster Deflection mode
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+      swing_blast_ = !swing_blast_;
+      if (swing_blast_) {
+        if (SFX_blstbgn) {
+          hybrid_font.PlayCommon(&SFX_blstbgn);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+          }
+        } else {
+          if (SFX_blstend) {
+          hybrid_font.PlayCommon(&SFX_blstend);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+        }
+      }
     return true;
 
-	case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
-    	if (swing_blast_) {
-      		SaberBase::DoBlast();
-    	}
-  	return true;
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+      if (swing_blast_) {
+        SaberBase::DoBlast();
+      }
+    return true;
 
+  // Lockup
+#if NUM_BUTTONS == 1
+    // 1 button lockup
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+#else
+#ifndef SABERSENSE_NO_LOCKUP_HOLD
+    // 2 button lockup
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+#else
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+#endif
+#endif
+      if (!SaberBase::Lockup() && !battle_mode_) {
+        if (accel_.x < -0.15) {
+          SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+        } else {
+          SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+        }
+          swing_blast_ = false;
+          SaberBase::DoBeginLockup();
+        return true;
+      }
+    break;
 
-// Lockup
-	#if NUM_BUTTONS == 1
-  		// 1 button lockup
-  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
-	#else
-		#ifndef SABERSENSE_NO_LOCKUP_HOLD
-  		// 2 button lockup
-  		case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
-	#else
-  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
-	#endif
-	#endif
-    	if (!SaberBase::Lockup() && !battle_mode_) {
-    	if (accel_.x < -0.15) {
-        	SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
-      	} else {
-        	SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
-      	}
-      		swing_blast_ = false;
-      		SaberBase::DoBeginLockup();
+  // Lightning Block
+    // 1 and 2 button
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+      if (!battle_mode_) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+        swing_blast_ = false;
+        SaberBase::DoBeginLockup();
       return true;
     }
+  break;
+
+  // Melt
+    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+      if (!SaberBase::Lockup() && !battle_mode_) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+        swing_blast_ = false;
+        SaberBase::DoBeginLockup();
+        return true;
+      }
     break;
 
-
-// Lightning Block
-  	// 1 and 2 button
-	case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
-		if (!battle_mode_) {
-      		SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
-      		swing_blast_ = false;
-      		SaberBase::DoBeginLockup();
-      	return true;
-    	}
-  	break;
-
-
-// Melt
-  	case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
-    	if (!SaberBase::Lockup() && !battle_mode_) {
-      		SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-      		swing_blast_ = false;
-      		SaberBase::DoBeginLockup();
-      	return true;
-    	}
-    break;
-
-	//  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
-	//  case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
-  	case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
-    	SaberBase::RequestMotion();
+    //  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
+    //  case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
+    case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+      SaberBase::RequestMotion();
     return true;
 
-
-// Enter Volume MENU
-	#if NUM_BUTTONS == 1
-  		// 1 button
-  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
-	#else
-  		// 2 button
-  		case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
-		//  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-	#endif
-    	if (!mode_volume_) {
-      		mode_volume_ = true;
-      	if (SFX_vmbegin) {
-        	hybrid_font.PlayCommon(&SFX_vmbegin);
-      	} else {
-        	beeper.Beep(0.5, 3000);
-      	}
-      		STDOUT.println("Enter Volume Menu");
-    	} else {
-      		mode_volume_ = false;
-      	if (SFX_vmend) {
-        	hybrid_font.PlayCommon(&SFX_vmend);
-      	} else {
-        	beeper.Beep(0.5, 3000);
-      	}
-      STDOUT.println("Exit Volume Menu");
-    }
+  // Enter Volume MENU
+#if NUM_BUTTONS == 1
+    // 1 button
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+#else
+    // 2 button
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+    //  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+#endif
+      if (!mode_volume_) {
+        mode_volume_ = true;
+        if (SFX_vmbegin) {
+          hybrid_font.PlayCommon(&SFX_vmbegin);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Enter Volume Menu");
+      } else {
+        mode_volume_ = false;
+        if (SFX_vmend) {
+          hybrid_font.PlayCommon(&SFX_vmend);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Exit Volume Menu");
+      }
     return true;
-
 
 // Battery level
-	case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
-	#if NUM_BUTTONS == 2
-	case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-	#endif
-    	talkie.SayDigit((int)floorf(battery_monitor.battery()));
-    	talkie.Say(spPOINT);
-    	talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
-    	talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
-    	talkie.Say(spVOLTS);
-    	SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);        
+    case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+#endif
+      talkie.SayDigit((int)floorf(battery_monitor.battery()));
+      talkie.Say(spPOINT);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+      talkie.Say(spVOLTS);
+      SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);        
     return true;
- 
- 
-	#ifdef BLADE_DETECT_PIN
-      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
-      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
-        	// Might need to do something cleaner, but let's try this for now.
-        	blade_detected_ = true;
-        	FindBladeAgain();
-        	SaberBase::DoBladeDetect(true);
-        return true;
 
-      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
-      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
-        	// Might need to do something cleaner, but let's try this for now.
-        	blade_detected_ = false;
-        	FindBladeAgain();
-        	SaberBase::DoBladeDetect(false);
-        return true;
-	#endif
+#ifdef BLADE_DETECT_PIN
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+      // Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = true;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
+    return true;
 
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+      // Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = false;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(false);
+    return true;
+#endif
 
-// Events that needs to be handled regardless of what other buttons
-// are pressed.
-	//  case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-	//  case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+  // Events that needs to be handled regardless of what other buttons
+  // are pressed.
+    //  case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+    //  case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
     case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-      	if (SaberBase::Lockup()) {
-        	SaberBase::DoEndLockup();
-        	SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+      if (SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         return true;
       }
     }
     return false;
   }
 
-
-
-	void SB_Effect(EffectType effect, float location) override {
-    	switch (effect) {
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+  void SB_Effect(EffectType effect, float location) override {  //  Required for ProffieOS 7.x.
+#else
+  void SB_Effect(EffectType effect, EffectLocation location) override {  //  Required for ProffieOS 8.x.
+#endif
+      switch (effect) {
+        case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
       
-      	case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
-      
-      	case EFFECT_POWERSAVE:
-        	if (SFX_dim) {
-          		hybrid_font.PlayCommon(&SFX_dim);
-        	} else {
-          		beeper.Beep(0.5, 3000);
-        	}
-        	return;
-      	case EFFECT_BATTERY_LEVEL:
-        	if (SFX_battery) {
-          		hybrid_font.PlayCommon(&SFX_battery);
-        	} else {
-          		beeper.Beep(0.5, 3000);
-        	}
-        	return;
-      	case EFFECT_FAST_ON:
-        	if (SFX_faston) {
-          		hybrid_font.PlayCommon(&SFX_faston);
-        	}
-        return;
+        case EFFECT_POWERSAVE:
+          if (SFX_dim) {
+            hybrid_font.PlayCommon(&SFX_dim);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          return;
+        case EFFECT_BATTERY_LEVEL:
+          if (SFX_battery) {
+            hybrid_font.PlayCommon(&SFX_battery);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          return;
+        case EFFECT_FAST_ON:
+          if (SFX_faston) {
+            hybrid_font.PlayCommon(&SFX_faston);
+          }
+          return;
 
-      default: break; // avoids compiler warning
+        default: break; // avoids compiler warning
+      }
     }
-  }
 
-private:
-  	bool pointing_down_ = false;
-  	bool swing_blast_ = false;
-  	bool mode_volume_ = false;
- 	bool auto_lockup_on_ = false;
-  	bool auto_melt_on_ = false;
-  	bool battle_mode_ = false;
-  	bool max_vol_reached_ = false;
-  	bool min_vol_reached_ = false;
-  	uint32_t thrust_begin_millis_ = millis();
-  	uint32_t push_begin_millis_ = millis();
-  	uint32_t clash_impact_millis_ = millis();
-  	uint32_t last_twist_ = millis();
-  	uint32_t last_push_ = millis();
-  	uint32_t saber_off_time_ = millis();
-	};
+  private:
+    bool pointing_down_ = false;
+    bool swing_blast_ = false;
+    bool mode_volume_ = false;
+    bool auto_lockup_on_ = false;
+    bool auto_melt_on_ = false;
+    bool battle_mode_ = false;
+    bool max_vol_reached_ = false;
+    bool min_vol_reached_ = false;
+    uint32_t thrust_begin_millis_ = millis();
+    uint32_t push_begin_millis_ = millis();
+    uint32_t clash_impact_millis_ = millis();
+    uint32_t last_twist_ = millis();
+    uint32_t last_push_ = millis();
+    uint32_t saber_off_time_ = millis();
+  };
 
 #endif
-
-

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -174,8 +174,8 @@ Replaces regular BladeID and allows toggling between two different
 blade/preset arrays regardless of actual BladeID status.
 
 #define SABERSENSE_NO_LOCKUP_HOLD	
-Applicable to two-button mode only, reverts to lockup being triggered
-by clash while holding aux.
+Applicable to two-button mode only, reverts to lockup being 
+triggered by clash while holding aux.
 
 GESTURE CONTROLS
 There are four gesture types: Twist, Stab, Swing and Thrust.
@@ -186,11 +186,6 @@ Below are the options to add to the config to enable the various gestures. MM.
 #define SABERSENSE_STAB_ON
 #define SABERSENSE_SWING_ON
 #define SABERSENSE_THRUST_ON
-#define SABERSENSE_FORCE_PUSH
-
-#define SABERSENSE_FORCE_PUSH_LENGTH 5
-Allows for adjustment to Push gesture length in millis needed to trigger Force Push
-Recommended range 1 ~ 10, 1 = shortest, easiest to trigger, 10 = longest. MM.
 
 Tightened click timings
 I've shortened the timeout for short and double click detection from 500ms
@@ -563,21 +558,6 @@ public:
     			FastOn();
 				//  On();
         	}
-        return true;
-	#endif
-
-
-	#ifdef SABERSENSE_FORCE_PUSH
-      	case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
-          if (FORCE_PUSH_CONDITION &&
-            millis() - last_push_ > 2000) {
-          if (SFX_push) {
-            hybrid_font.PlayCommon(&SFX_push);
-          } else {
-            hybrid_font.DoEffect(EFFECT_FORCE, 0);
-          }
-          	last_push_ = millis();
-          }
         return true;
 	#endif
 
@@ -1033,4 +1013,5 @@ private:
 	};
 
 #endif
+
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -465,9 +465,9 @@ public:
     }
   }
 
-  //  Button Clicker to play press/release wav files when buttons are pressed.
-  //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
-  //  Requires press.wav and release.wav files to work.
+    //  Button Clicker to play press/release wav files when buttons are pressed.
+    //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
+    //  Requires press.wav and release.wav files to work.
     void PlaySound(const char* sound) {
       RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
        if (player) {
@@ -531,7 +531,7 @@ public:
       if (millis() - last_twist_ > 3000) {
         Off();
       last_twist_ = millis();
-        saber_off_time_ = millis();
+      saber_off_time_ = millis();
       }
       return true;
 #endif
@@ -562,16 +562,16 @@ public:
 #endif
 return true;
 
-  // Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
+    // Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
     case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
-        SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
+      SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
 #ifdef SAVE_PRESET
-        SaveState(current_preset_.preset_num);
+      SaveState(current_preset_.preset_num);
 #endif
 return true;
 
-// Saber ON AND Volume Adjust.
+    // Saber ON AND Volume Adjust.
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       IgnoreClash(50);  //  Hopefully prevents false clashes due to 'clicky' button.
                         //  Low threshold so as not to conflict with 1-button lockup or volume menu.
@@ -586,9 +586,9 @@ return true;
         }
         return true;
 
-  // Modified 2 button 'next/previous preset' AND volume down,
-  // to align with multiple skips above.
-  // Forward one font pointing up, back one font pointing down.
+    // Modified 2 button 'next/previous preset' AND volume down,
+    // to align with multiple skips above.
+    // Forward one font pointing up, back one font pointing down.
     case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
       if (!mode_volume_) {
@@ -674,7 +674,7 @@ return true;
 #endif
 return true;
 
-  //  Manual Blade ID Options
+    //  Manual Blade ID Options
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
 #ifdef SABERSENSE_FAKE_BLADE_ID
       //  Toggles between blade arrays regardless of BladeID status.
@@ -684,15 +684,15 @@ return true;
       SaberBase::DoBladeDetect(true);
       return true;
 #else
-    //  Runs BladeID Manually to actually check BladeID status.
-    //  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
-    //  Can use any number of blade/preset arrays.
+      //  Runs BladeID Manually to actually check BladeID status.
+      //  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
+      //  Can use any number of blade/preset arrays.
       FindBladeAgain();
       SaberBase::DoBladeDetect(true);
       return true;
 #endif
 
-  // Activate Muted
+    // Activate Muted
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
       if (SetMute(true)) {
         unmute_on_deactivation_ = true;
@@ -815,7 +815,7 @@ return true;
       SaberBase::DoBlast();
     return true;
 
-  // Multi-Blaster Deflection mode
+    // Multi-Blaster Deflection mode
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
       swing_blast_ = !swing_blast_;
       if (swing_blast_) {
@@ -861,8 +861,7 @@ return true;
         return true;
       break;
 
-  // Lightning Block
-    // 1 and 2 button
+    // Lightning Block, 1 and 2 button.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
       SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
       swing_blast_ = false;
@@ -870,7 +869,7 @@ return true;
       return true;
     break;
 
-  // Melt
+    // Melt
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
       SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
       swing_blast_ = false;
@@ -910,7 +909,7 @@ return true;
       }
       return true;
 
-// Battery level
+    // Battery level
     case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
@@ -941,8 +940,7 @@ return true;
     return true;
 #endif
 
-  // Events that needs to be handled regardless of what other buttons
-  // are pressed.
+    // Events that needs to be handled regardless of what other buttons are pressed.
     case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
       if (SaberBase::Lockup()) {
         SaberBase::DoEndLockup();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -6,8 +6,7 @@
 Built on SA22C programming by Matthew McGeary.
 Modified by Chris Carter with help and contributions 
 from Brian Connor and Fredrik Hubinette.
-November 2024.
-SabersensePropV31.
+November 2024, first edition.
 
 
 ============================================================
@@ -170,11 +169,11 @@ Alt Exit COLOUR MENU	Hold MAIN and wait.
 							
 ===========================================================		
 ========================= DEFINES =========================
-#define FAKE_BLADE_ID
+#define SABERSENSE_FAKE_BLADE_ID
 Replaces regular BladeID and allows toggling between two different 
 blade/preset arrays regardless of actual BladeID status.
 
-#define SA22C_NO_LOCKUP_HOLD	
+#define SABERSENSE_NO_LOCKUP_HOLD	
 Applicable to two-button mode only, reverts to lockup being triggered
 by clash while holding aux.
 
@@ -182,14 +181,14 @@ GESTURE CONTROLS
 There are four gesture types: Twist, Stab, Swing and Thrust.
 Gesture controls bypass all preon effects.
 Below are the options to add to the config to enable the various gestures. MM.
-#define SA22C_TWIST_ON
-#define SA22C_TWIST_OFF
-#define SA22C_STAB_ON
-#define SA22C_SWING_ON
-#define SA22C_THRUST_ON
-#define SA22C_FORCE_PUSH
+#define SABERSENSE_TWIST_ON
+#define SABERSENSE_TWIST_OFF
+#define SABERSENSE_STAB_ON
+#define SABERSENSE_SWING_ON
+#define SABERSENSE_THRUST_ON
+#define SABERSENSE_FORCE_PUSH
 
-#define SA22C_FORCE_PUSH_LENGTH 5
+#define SABERSENSE_FORCE_PUSH_LENGTH 5
 Allows for adjustment to Push gesture length in millis needed to trigger Force Push
 Recommended range 1 ~ 10, 1 = shortest, easiest to trigger, 10 = longest. MM.
 
@@ -203,48 +202,49 @@ individual tastes. MM.
 ============================================================
 ============================================================
 */
-#ifndef PROPS_SABER_SENSE_BUTTONS_H
-#define PROPS_SABER_SENSE_BUTTONS_H
+#ifndef PROPS_SABER_SABERSENSE_BUTTONS_H
+#define PROPS_SABER_SABERSENSE_BUTTONS_H
 
 
 //  Used instead of BladeID and allows toggle switching 
-//  between two blade/preset arrays manually.
-#ifdef FAKE_BLADE_ID
-struct FakeBladeID {
-   static int return_value;
-   float id() { return return_value; }
-   static void toggle() {
+//  between two blade/preset arrays manually irrespective
+//  of actual BladeID status.
+	#ifdef SABERSENSE_FAKE_BLADE_ID
+		struct SabersenseFakeBladeID {
+   		static int return_value;
+   		float id() { return return_value; }
+   		static void toggle() {
      return_value = NO_BLADE - return_value;
-   }
-};
-int FakeBladeID::return_value = 0;
-#undef BLADE_ID_CLASS_INTERNAL
-#define BLADE_ID_CLASS_INTERNAL FakeBladeID
-#undef BLADE_ID_CLASS
-#define BLADE_ID_CLASS FakeBladeID
-#endif
+   	}
+	};
+		int SabersenseFakeBladeID::return_value = 0;
+		#undef BLADE_ID_CLASS_INTERNAL
+		#define BLADE_ID_CLASS_INTERNAL SabersenseFakeBladeID
+		#undef BLADE_ID_CLASS
+		#define BLADE_ID_CLASS SabersenseFakeBladeID
+	#endif
 
 
 #include "prop_base.h"
 #include "../sound/hybrid_font.h"
 
 #undef PROP_TYPE
-#define PROP_TYPE SabersensePropV31
+#define PROP_TYPE SabersenseButtons
 
 #ifndef MOTION_TIMEOUT
 #define MOTION_TIMEOUT 60 * 15 * 1000
 #endif
 
-#ifndef SA22C_SWING_ON_SPEED
-#define SA22C_SWING_ON_SPEED 250
+#ifndef SABERSENSE_SWING_ON_SPEED
+#define SABERSENSE_SWING_ON_SPEED 250
 #endif
 
-#ifndef SA22C_LOCKUP_DELAY
-#define SA22C_LOCKUP_DELAY 200
+#ifndef SABERSENSE_LOCKUP_DELAY
+#define SABERSENSE_LOCKUP_DELAY 200
 #endif
 
-#ifndef SA22C_FORCE_PUSH_LENGTH
-#define SA22C_FORCE_PUSH_LENGTH 5
+#ifndef SABERSENSE_FORCE_PUSH_LENGTH
+#define SABERSENSE_FORCE_PUSH_LENGTH 5
 #endif
 
 #ifndef BUTTON_DOUBLE_CLICK_TIMEOUT
@@ -267,22 +267,25 @@ int FakeBladeID::return_value = 0;
 #define BUTTON_HELD_LONG_TIMEOUT 2000
 #endif
 
-#ifdef SA22C_SWING_ON
-#define SWING_GESTURE
+#ifdef SABERSENSE_SWING_ON
+#define SABERSENSE_SWING_GESTURE
 #endif
 
-#ifdef SA22C_STAB_ON
-#define STAB_GESTURE
+#ifdef SABERSENSE_STAB_ON
+#define SABERSENSE_STAB_GESTURE
 #endif
 
-#ifdef SA22C_TWIST_ON
-#define TWIST_GESTURE
+#ifdef SABERSENSE_TWIST_ON
+#define SABERSENSE_TWIST_GESTURE
 #endif
 
-#ifdef SA22C_THRUST_ON
-#define THRUST_GESTURE
+#ifdef SABERSENSE_THRUST_ON
+#define SABERSENSE_THRUST_GESTURE
 #endif
 
+#ifdef SABERSENSE_FAKE_BLADE_ID
+#define SABERSENSE_FAKE_BLADE_ID
+#endif
 
 //  #define FORCE_PUSH_CONDITION battle_mode_
 
@@ -306,10 +309,10 @@ EFFECT(quote);    // for playing quotes
 
 // The Saber class implements the basic states and actions
 // for the saber.
-class SabersensePropV31 : public PROP_INHERIT_PREFIX PropBase {
+class SabersenseButtons : public PROP_INHERIT_PREFIX PropBase {
 public:
-  SabersensePropV31() : PropBase() {}
-  const char* name() override { return "SabersensePropV31"; }
+  SabersenseButtons() : PropBase() {}
+  const char* name() override { return "SabersenseButtons"; }
 
   void Loop() override {
     PropBase::Loop();
@@ -320,7 +323,7 @@ public:
       if (auto_lockup_on_ &&
           !swinging_ &&
           fusor.swing_speed() > 120 &&
-          millis() - clash_impact_millis_ > SA22C_LOCKUP_DELAY &&
+          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
           SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
@@ -329,7 +332,7 @@ public:
       if (auto_melt_on_ &&
           !swinging_ &&
           fusor.swing_speed() > 60 &&
-          millis() - clash_impact_millis_ > SA22C_LOCKUP_DELAY &&
+          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
           SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
@@ -341,7 +344,7 @@ public:
           mss.y * mss.y + mss.z * mss.z > 70 &&
           fusor.swing_speed() < 30 &&
           fabs(fusor.gyro().x) < 10) {
-        if (millis() - push_begin_millis_ > SA22C_FORCE_PUSH_LENGTH) {
+        if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
         }
@@ -356,7 +359,7 @@ public:
         if (swinging_ && fusor.swing_speed() < 90) {
           swinging_ = false;
         }
-        if (!swinging_ && fusor.swing_speed() > SA22C_SWING_ON_SPEED) {
+        if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
           swinging_ = true;
           Event(BUTTON_NONE, EVENT_SWING);
         }
@@ -503,279 +506,279 @@ public:
         } else {
           pointing_down_ = false;
         }
-        return true;
+    	return true;
    
 
-  // Gesture Controls
-#ifdef SA22C_SWING_ON
-  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
-    // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
-    if (millis() > 3000) {
-    FastOn();
-//      On();
-    }
-    return true;
-#endif
+//  Gesture Controls
+	#ifdef SABERSENSE_SWING_ON
+  		case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
+    		// Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
+   	 		if (millis() > 3000) {
+    			FastOn();
+				//  On();
+    		}
+    	return true;
+	#endif
 
 
-#ifdef SA22C_TWIST_ON
-  case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
-    // Delay twist events to prevent false trigger from over twisting
-    if (millis() - last_twist_ > 2000 &&
-        millis() - saber_off_time_ > 1000) {
-    FastOn();
-//      On();
-      last_twist_ = millis();
-    }
-    return true;
-#endif
+	#ifdef SABERSENSE_TWIST_ON
+  		case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+    		// Delay twist events to prevent false trigger from over twisting
+    		if (millis() - last_twist_ > 2000 &&
+        	millis() - saber_off_time_ > 1000) {
+    			FastOn();
+				//  On();
+      		last_twist_ = millis();
+    		}
+    	return true;
+	#endif
 
 
-#ifdef SA22C_TWIST_OFF
-  case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
-    // Delay twist events to prevent false trigger from over twisting
-    if (millis() - last_twist_ > 3000) {
-      Off();
-      last_twist_ = millis();
-      saber_off_time_ = millis();
-      battle_mode_ = false;
-    }
-    return true;
-#endif
+	#ifdef SABERSENSE_TWIST_OFF
+  		case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
+   			// Delay twist events to prevent false trigger from over twisting
+    		if (millis() - last_twist_ > 3000) {
+      		Off();
+      			last_twist_ = millis();
+      			saber_off_time_ = millis();
+      			battle_mode_ = false;
+    		}
+    	return true;
+	#endif
 
 
-#ifdef SA22C_STAB_ON
-      case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
-        if (millis() - saber_off_time_ > 1000) {
-//    FastOn();
-      On();
-        }
+	#ifdef SABERSENSE_STAB_ON
+      	case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
+        	if (millis() - saber_off_time_ > 1000) {
+				FastOn();
+				//  On();
+        	}
         return true;
-#endif
+	#endif
 
 
-#ifdef SA22C_THRUST_ON
+	#ifdef SABERSENSE_THRUST_ON
       case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
-        if (millis() - saber_off_time_ > 1000) {
-    FastOn();
-//      On();
-        }
+        	if (millis() - saber_off_time_ > 1000) {
+    			FastOn();
+				//  On();
+        	}
         return true;
-#endif
+	#endif
 
 
-#ifdef SA22C_FORCE_PUSH
-      case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
-        if (FORCE_PUSH_CONDITION &&
+	#ifdef SABERSENSE_FORCE_PUSH
+      	case EVENTID(BUTTON_NONE, EVENT_PUSH, MODE_ON):
+          if (FORCE_PUSH_CONDITION &&
             millis() - last_push_ > 2000) {
           if (SFX_push) {
             hybrid_font.PlayCommon(&SFX_push);
           } else {
             hybrid_font.DoEffect(EFFECT_FORCE, 0);
           }
-          last_push_ = millis();
-        }
+          	last_push_ = millis();
+          }
         return true;
-#endif
+	#endif
 
 
 //  Multiple Skips only available with 2 button installs.
 //  Skips forward five fonts if pointing up, skips back five fonts if pointing down.
-case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
-    // backwards if pointing down
-    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
+	case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+    		// backwards if pointing down
+    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
+		#ifdef SAVE_PRESET
+    		SaveState(current_preset_.preset_num);
+		#endif
     return true;
 
  
 // Skips forward ten fonts if pointing up, skips back ten fonts if pointing down.
-case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-    // backwards if pointing down
-    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
+	case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+    		// backwards if pointing down
+    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
+		#ifdef SAVE_PRESET
+    		SaveState(current_preset_.preset_num);
+		#endif
     return true;
 
    
 // Saber ON AND Volume Adjust.
-case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
-    if (!mode_volume_) {
-      On();
-    } else {
-     if (fusor.angle1() > 0) {
-      VolumeUp();
-    } else {
-      VolumeDown();
-    }
-    }
+	case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+    	if (!mode_volume_) {
+      		On();
+    	} else {
+     	if (fusor.angle1() > 0) {
+      		VolumeUp();
+    	} else {
+      		VolumeDown();
+    	}
+    	}
     return true;
 
 
-// Modified 2 and 3 button 'next/previous preset' AND volume down,
+// Modified 2 button 'next/previous preset' AND volume down,
 // to align with multiple skips above.
 // Forward one font pointing up, back one font pointing down.
-  case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
-    // backwards if pointing down
-    if (!mode_volume_) {
-    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+	case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+    	// backwards if pointing down
+    	if (!mode_volume_) {
+    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
         } else {
-      VolumeDown();
-    }
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
-    return true;
+      		VolumeDown();
+    	}
+		#ifdef SAVE_PRESET
+    		SaveState(current_preset_.preset_num);
+		#endif
+	return true;
 
 
 // 1 button 'next/previous preset' command.
 // Forward one font pointing up, back one font pointing down.
-#if NUM_BUTTONS == 1 
+	#if NUM_BUTTONS == 1 
       case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
-    // backwards if pointing down
-    if (!mode_volume_) {
-    SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+    	// backwards if pointing down
+    	if (!mode_volume_) {
+    		SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
         } else {
-      VolumeDown();
-    }
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
-    return true;
-#endif
+      		VolumeDown();
+    	}
+		#ifdef SAVE_PRESET
+    		SaveState(current_preset_.preset_num);
+		#endif
+    	return true;
+	#endif
 
 
 //  1 Button skips to first preset (up) or last preset (down)
 //  or middle preset if horizontal:
-#if NUM_BUTTONS == 2
-case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
-#endif
-case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
-#define DEGREES_TO_RADIANS (M_PI / 180)
- if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-// If pointing up
-SetPreset(0, true);
- } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-// If pointing down
-SetPreset(-1, true);
- } else {
-// If horizontal
-  CurrentPreset tmp;
-  tmp.SetPreset(-1);
-  SetPreset(tmp.preset_num / 2, true);
-}
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
+		#if NUM_BUTTONS == 2
+			case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
+		#endif
+			case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+			#define DEGREES_TO_RADIANS (M_PI / 180)
+ 				if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+					// If pointing up
+					SetPreset(0, true);
+ 				} else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+					// If pointing down
+				SetPreset(-1, true);
+ 				} else {
+					// If horizontal
+					CurrentPreset tmp;
+					tmp.SetPreset(-1);
+					SetPreset(tmp.preset_num / 2, true);
+				}
+			#ifdef SAVE_PRESET
+    				SaveState(current_preset_.preset_num);
+			#endif
     return true;
 
 
-#if NUM_BUTTONS == 2
 // 1 and 2 button: Previous Preset, retained legacy control.
-    case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
-#endif
-    if (!mode_volume_) {
-      previous_preset();
-    }
+	#if NUM_BUTTONS == 2
+		case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
+	#endif
+    	if (!mode_volume_) {
+      	previous_preset();
+   	 }
     return true;
 
 
 //  Skips to first preset (up) or last (battery or charge) preset (down)
 //  or middle preset if horizontal:
-#if NUM_BUTTONS == 2
-// 2 button: First Preset
-case EVENTID(BUTTON_AUX, EVENT_HELD_LONG, MODE_OFF):
-#endif
-#define DEGREES_TO_RADIANS (M_PI / 180)
- if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-// If pointing up
-SetPreset(0, true);
- } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-// If pointing down
-SetPreset(-1, true);
- } else {
-// If horizontal
-  CurrentPreset tmp;
-  tmp.SetPreset(-1);
-  SetPreset(tmp.preset_num / 2, true);
-}
-#ifdef SAVE_PRESET
-    SaveState(current_preset_.preset_num);
-#endif
+	#if NUM_BUTTONS == 2
+	// 2 button: First Preset
+		case EVENTID(BUTTON_AUX, EVENT_HELD_LONG, MODE_OFF):
+	#endif
+		#define DEGREES_TO_RADIANS (M_PI / 180)
+ 		if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+			// If pointing up
+			SetPreset(0, true);
+		} else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+			// If pointing down
+			SetPreset(-1, true);
+ 		} else {
+			// If horizontal
+			CurrentPreset tmp;
+			tmp.SetPreset(-1);
+			SetPreset(tmp.preset_num / 2, true);
+		}
+		#ifdef SAVE_PRESET
+    		SaveState(current_preset_.preset_num);
+		#endif
     return true;
     
 
 //  Manual Blade ID Options
-case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-#ifdef FAKE_BLADE_ID
-//  Toggles between blade arrays regardless of BladeID status.
-//  Cannot use more than two blade/preset arrays.
-      FakeBladeID::toggle();
-      FindBladeAgain();
-      SaberBase::DoBladeDetect(true);
-         return true;
-#else
-//  Runs BladeID Manually to actually check BladeID status.
-//  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
-//  Can use any number of blade/preset arrays.
-    FindBladeAgain();
-    SaberBase::DoBladeDetect(true);
-         return true;
-#endif
+	case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+		#ifdef FAKE_BLADE_ID
+		//  Toggles between blade arrays regardless of BladeID status.
+		//  Cannot use more than two blade/preset arrays.
+      		SabersenseFakeBladeID::toggle();
+      		FindBladeAgain();
+      		SaberBase::DoBladeDetect(true);
+        	return true;
+		#else
+		//  Runs BladeID Manually to actually check BladeID status.
+		//  Won't change arrays unless status tells it to (i.e. Data/Neg resistance changes).
+		//  Can use any number of blade/preset arrays.
+    		FindBladeAgain();
+    		SaberBase::DoBladeDetect(true);
+			return true;
+		#endif
 
  
 // Activate Muted
-//  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
+	//  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_OFF):
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-    if (SetMute(true)) {
-      unmute_on_deactivation_ = true;
-      On();
-    }
+    	if (SetMute(true)) {
+      		unmute_on_deactivation_ = true;
+      	On();
+    	}
     return true;
 
 
 // Turn Blade OFF
 #if NUM_BUTTONS > 1
-// 2 button
-  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
-#else
-// 1 button
-  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_ON):
-#endif
-    if (!SaberBase::Lockup()) {
-#ifndef DISABLE_COLOR_CHANGE
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        // Just exit color change mode.
-        // Don't turn saber off.
-        ToggleColorChangeMode();
+	// 2 button
+		case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
+ 	#else
+	// 1 button
+  		case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_ON):
+	#endif
+    	if (!SaberBase::Lockup()) {
+		#ifndef DISABLE_COLOR_CHANGE
+      	if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        	// Just exit color change mode.
+        	// Don't turn saber off.
+        	ToggleColorChangeMode();
         return true;
-      }
-#endif
-      if (!battle_mode_) {
-        Off();
-      }
-    }
-    saber_off_time_ = millis();
-    battle_mode_ = false;
-    swing_blast_ = false;
+      	}
+	#endif
+      	if (!battle_mode_) {
+       		Off();
+      		}
+    	}
+    	saber_off_time_ = millis();
+    	battle_mode_ = false;
+    	swing_blast_ = false;
     return true;
 
 
 // Character Quote and Force Effect, Blade ON.
 // Hilt pointed UP for Character Quote, plays sequentially,
 // Hilt pointed DOWN for Force Effect, plays randomly.
-case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-    if (SFX_quote) {
-     if (fusor.angle1() > 0) {
-            SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();
-        }
-       }
-      return true;
+	case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+    	if (SFX_quote) {
+     		if (fusor.angle1() > 0) {
+            	SFX_quote.SelectNext();
+          		SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        	} else {
+          		SaberBase::DoForce();
+        	}
+       	}
+	return true;
 
 
 //  Character Quote and Music Track, Blade OFF.
@@ -793,192 +796,186 @@ case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
     
 
 //  Colour Change.
-//  1 and 2 button modes.
-#ifndef DISABLE_COLOR_CHANGE
-case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-      ToggleColorChangeMode();
-    return true;
+	//  1 and 2 button modes.
+	#ifndef DISABLE_COLOR_CHANGE
+		case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+      		ToggleColorChangeMode();
+    	return true;
 
-//  2 button mode only.
-#if NUM_BUTTONS == 2
-case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
-      ToggleColorChangeMode();
-    return true;
-#endif
-#endif
+	//  2 button mode only.
+		#if NUM_BUTTONS == 2
+			case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+      			ToggleColorChangeMode();
+    		return true;
+		#endif
+	#endif
 
 
 // Blaster Deflection
-#if NUM_BUTTONS == 1
-  // 1 button
-  case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-//  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-//  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
-#else
-  // 2 and 3 button
-  case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-  case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-//  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-//  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
-#endif
-    swing_blast_ = false;
-    SaberBase::DoBlast();
+	#if NUM_BUTTONS == 1
+  		// 1 button
+  		case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+		//  case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+		//  case EVENTID(BUTTON_POWER, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+	#else
+  		// 2 button
+  		case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+  		case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+		//  case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+		//  case EVENTID(BUTTON_AUX, EVENT_THIRD_CLICK_SHORT, MODE_ON):
+	#endif
+    	swing_blast_ = false;
+    	SaberBase::DoBlast();
     return true;
 
 
 // Multi-Blaster Deflection mode
-  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
-    swing_blast_ = !swing_blast_;
-    if (swing_blast_) {
-      if (SFX_blstbgn) {
-        hybrid_font.PlayCommon(&SFX_blstbgn);
-      } else {
-        hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-      }
-    } else {
-      if (SFX_blstend) {
-        hybrid_font.PlayCommon(&SFX_blstend);
-      } else {
-        hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-      }
-    }
+	case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+    	swing_blast_ = !swing_blast_;
+    	if (swing_blast_) {
+      		if (SFX_blstbgn) {
+        		hybrid_font.PlayCommon(&SFX_blstbgn);
+      		} else {
+        		hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+      		}
+    	} else {
+      		if (SFX_blstend) {
+        	hybrid_font.PlayCommon(&SFX_blstend);
+      	} else {
+        	hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+      		}
+    	}
     return true;
 
-  case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
-    if (swing_blast_) {
-      SaberBase::DoBlast();
-    }
-    return true;
+	case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+    	if (swing_blast_) {
+      		SaberBase::DoBlast();
+    	}
+  	return true;
 
 
 // Lockup
-#if NUM_BUTTONS == 1
-  // 1 button lockup
-  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
-#else
-#ifndef SA22C_NO_LOCKUP_HOLD
-  // 2 and 3 button lockup
-  case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
-#else
-  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
-#endif
-#endif
-    if (!SaberBase::Lockup() && !battle_mode_) {
-    if (accel_.x < -0.15) {
-        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
-      } else {
-        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
-      }
-      swing_blast_ = false;
-      SaberBase::DoBeginLockup();
+	#if NUM_BUTTONS == 1
+  		// 1 button lockup
+  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+	#else
+		#ifndef SABERSENSE_NO_LOCKUP_HOLD
+  		// 2 button lockup
+  		case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+	#else
+  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+	#endif
+	#endif
+    	if (!SaberBase::Lockup() && !battle_mode_) {
+    	if (accel_.x < -0.15) {
+        	SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+      	} else {
+        	SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+      	}
+      		swing_blast_ = false;
+      		SaberBase::DoBeginLockup();
       return true;
     }
     break;
 
 
 // Lightning Block
-#if NUM_BUTTONS < 3
-  // 1 and 2 button
-  case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
-#else
-  // 3 button
-  case EVENTID(BUTTON_AUX2, EVENT_FIRST_HELD, MODE_ON):
-#endif
-    if (!battle_mode_) {
-      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
-      swing_blast_ = false;
-      SaberBase::DoBeginLockup();
-      return true;
-    }
-    break;
+  	// 1 and 2 button
+	case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+		if (!battle_mode_) {
+      		SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+      		swing_blast_ = false;
+      		SaberBase::DoBeginLockup();
+      	return true;
+    	}
+  	break;
 
 
 // Melt
-  case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
-    if (!SaberBase::Lockup() && !battle_mode_) {
-      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-      swing_blast_ = false;
-      SaberBase::DoBeginLockup();
-      return true;
-    }
+  	case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+    	if (!SaberBase::Lockup() && !battle_mode_) {
+      		SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+      		swing_blast_ = false;
+      		SaberBase::DoBeginLockup();
+      	return true;
+    	}
     break;
 
-
-//  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
-//   case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
-  case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
-    SaberBase::RequestMotion();
+	//  case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_OFF):
+	//  case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_OFF):
+  	case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+    	SaberBase::RequestMotion();
     return true;
 
 
 // Enter Volume MENU
-#if NUM_BUTTONS == 1
-  // 1 button
-  case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
-#else
-  // 2 and 3 button
-  case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
-//  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-#endif
-    if (!mode_volume_) {
-      mode_volume_ = true;
-      if (SFX_vmbegin) {
-        hybrid_font.PlayCommon(&SFX_vmbegin);
-      } else {
-        beeper.Beep(0.5, 3000);
-      }
-      STDOUT.println("Enter Volume Menu");
-    } else {
-      mode_volume_ = false;
-      if (SFX_vmend) {
-        hybrid_font.PlayCommon(&SFX_vmend);
-      } else {
-        beeper.Beep(0.5, 3000);
-      }
+	#if NUM_BUTTONS == 1
+  		// 1 button
+  		case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+	#else
+  		// 2 button
+  		case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+		//  case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+	#endif
+    	if (!mode_volume_) {
+      		mode_volume_ = true;
+      	if (SFX_vmbegin) {
+        	hybrid_font.PlayCommon(&SFX_vmbegin);
+      	} else {
+        	beeper.Beep(0.5, 3000);
+      	}
+      		STDOUT.println("Enter Volume Menu");
+    	} else {
+      		mode_volume_ = false;
+      	if (SFX_vmend) {
+        	hybrid_font.PlayCommon(&SFX_vmend);
+      	} else {
+        	beeper.Beep(0.5, 3000);
+      	}
       STDOUT.println("Exit Volume Menu");
     }
     return true;
 
 
 // Battery level
-  case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
-//  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
-    talkie.SayDigit((int)floorf(battery_monitor.battery()));
-    talkie.Say(spPOINT);
-    talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
-    talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
-    talkie.Say(spVOLTS);
-    SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);        
+	case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
+	//  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+    	talkie.SayDigit((int)floorf(battery_monitor.battery()));
+    	talkie.Say(spPOINT);
+    	talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+    	talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+    	talkie.Say(spVOLTS);
+    	SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);        
     return true;
  
  
-#ifdef BLADE_DETECT_PIN
-      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
-        // Might need to do something cleaner, but let's try this for now.
-        blade_detected_ = true;
-        FindBladeAgain();
-        SaberBase::DoBladeDetect(true);
+	#ifdef BLADE_DETECT_PIN
+      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+        	// Might need to do something cleaner, but let's try this for now.
+        	blade_detected_ = true;
+        	FindBladeAgain();
+        	SaberBase::DoBladeDetect(true);
         return true;
 
-      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
-      case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
-        // Might need to do something cleaner, but let's try this for now.
-        blade_detected_ = false;
-        FindBladeAgain();
-        SaberBase::DoBladeDetect(false);
+      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+      	case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+        	// Might need to do something cleaner, but let's try this for now.
+        	blade_detected_ = false;
+        	FindBladeAgain();
+        	SaberBase::DoBladeDetect(false);
         return true;
-#endif
+	#endif
 
 
 // Events that needs to be handled regardless of what other buttons
 // are pressed.
-//    case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-//    case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+	//  case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+	//  case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
     case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-      if (SaberBase::Lockup()) {
-        SaberBase::DoEndLockup();
-        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+      	if (SaberBase::Lockup()) {
+        	SaberBase::DoEndLockup();
+        	SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         return true;
       }
     }
@@ -987,29 +984,29 @@ case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
 
 
 
-void SB_Effect(EffectType effect, float location) override {
-    switch (effect) {
+	void SB_Effect(EffectType effect, float location) override {
+    	switch (effect) {
       
-      case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
+      	case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return;
       
-      case EFFECT_POWERSAVE:
-        if (SFX_dim) {
-          hybrid_font.PlayCommon(&SFX_dim);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        return;
-      case EFFECT_BATTERY_LEVEL:
-        if (SFX_battery) {
-          hybrid_font.PlayCommon(&SFX_battery);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        return;
-      case EFFECT_FAST_ON:
-        if (SFX_faston) {
-          hybrid_font.PlayCommon(&SFX_faston);
-        }
+      	case EFFECT_POWERSAVE:
+        	if (SFX_dim) {
+          		hybrid_font.PlayCommon(&SFX_dim);
+        	} else {
+          		beeper.Beep(0.5, 3000);
+        	}
+        	return;
+      	case EFFECT_BATTERY_LEVEL:
+        	if (SFX_battery) {
+          		hybrid_font.PlayCommon(&SFX_battery);
+        	} else {
+          		beeper.Beep(0.5, 3000);
+        	}
+        	return;
+      	case EFFECT_FAST_ON:
+        	if (SFX_faston) {
+          		hybrid_font.PlayCommon(&SFX_faston);
+        	}
         return;
 
       default: break; // avoids compiler warning
@@ -1017,20 +1014,20 @@ void SB_Effect(EffectType effect, float location) override {
   }
 
 private:
-  bool pointing_down_ = false;
-  bool swing_blast_ = false;
-  bool mode_volume_ = false;
-  bool auto_lockup_on_ = false;
-  bool auto_melt_on_ = false;
-  bool battle_mode_ = false;
-  bool max_vol_reached_ = false;
-  bool min_vol_reached_ = false;
-  uint32_t thrust_begin_millis_ = millis();
-  uint32_t push_begin_millis_ = millis();
-  uint32_t clash_impact_millis_ = millis();
-  uint32_t last_twist_ = millis();
-  uint32_t last_push_ = millis();
-  uint32_t saber_off_time_ = millis();
-};
+  	bool pointing_down_ = false;
+  	bool swing_blast_ = false;
+  	bool mode_volume_ = false;
+ 	bool auto_lockup_on_ = false;
+  	bool auto_melt_on_ = false;
+  	bool battle_mode_ = false;
+  	bool max_vol_reached_ = false;
+  	bool min_vol_reached_ = false;
+  	uint32_t thrust_begin_millis_ = millis();
+  	uint32_t push_begin_millis_ = millis();
+  	uint32_t clash_impact_millis_ = millis();
+  	uint32_t last_twist_ = millis();
+  	uint32_t last_push_ = millis();
+  	uint32_t saber_off_time_ = millis();
+	};
 
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -120,7 +120,7 @@ FUNCTIONS WITH BLADE OFF
 Next preset				Short click AUX, hilt pointing upwards.
 Previous preset			Short click AUX, hilt pointing downwards.
 Previous preset			Hold AUX and short click MAIN.
-							(Duplicate command for backwards compatibility).
+							(Duplicate legacy command).
 Skip to first preset    Press and hold any button until it switches, hilt upwards.
 Skip to middle preset   Press and hold any button  until it switches, hilt horizontal.
 Skip to last preset     Press and hold any button  until it switches, hilt downwards.
@@ -131,7 +131,7 @@ Skip back 10 presets	Fast triple-click AUX, hilt pointing downwards.
 Play Character Quote	Fast double-click MAIN, pointing up. Quotes play sequentially.
 							To reset sequential quotes, change font or run BladeID.
 Play Music Track	    Fast double-click MAIN, pointing down.
-Speak battery voltage	Fast four clicks MAIN.
+Speak battery voltage	Fast four clicks MAIN or hold hold AUX for one second and let go.
 Run/Toggle BladeID		Fast triple-click MAIN. (Applicable installs only).
 Enter/Exit VOLUME MENU 	Hold MAIN then quickly click AUX
 						and release both buttons simultaneously.
@@ -149,7 +149,7 @@ Force Effect (Quote)	Fast double-click MAIN, hilt pointing down.
 Character Quote			Fast double-click MAIN, hilt pointing up.
 							Plays sequential character quote.
 Lightning block			Double-click MAIN and hold.
-Melt         			Hold MAIN and push blade tip against wall (clash).
+Melt         			Hold MAIN and push blade tip against wall (stab).
 Blaster blocks			Short click AUX.
 Enter multi-blast mode	Hold MAIN while swinging for one second and release. 
 							Saber will play two quick blasts confirming mode.
@@ -939,7 +939,9 @@ case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
 
 // Battery level
 	case EVENTID(BUTTON_POWER, EVENT_FOURTH_SAVED_CLICK_SHORT, MODE_OFF):
-	//  case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+	#if NUM_BUTTONS == 2
+	case EVENTID(BUTTON_AUX, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+	#endif
     	talkie.SayDigit((int)floorf(battery_monitor.battery()));
     	talkie.Say(spPOINT);
     	talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
@@ -1031,3 +1033,4 @@ private:
 	};
 
 #endif
+


### PR DESCRIPTION
Proposed additional button prop file for ProffieOS by Chris at Sabersense Lightsabers.

This is a submission for an alternative prop file to be made available as part of ProffieOS. 

OVERVIEW
Based on Matthew McGeary’s SA22C prop, my modifications have been made with simplicity in mind. It is not intended to be as full-featured as some more complex props - instead it is designed to be very easy to use, idiot-proof and consistent in terms of ‘rules’. It doesn’t require a ‘knack’ to access certain features, and tricky combinations like holding a button while simultaneously twisting or making other active gestures have been mostly eliminated. More complex features like Battle Mode that have the potential to confuse inexperienced users or tie them in a knot have also been removed.

HARMONIZED 1-BUTTON AND 2-BUTTON CONTROLS
Basic features like normal ignition, track playing, force effects, mute ignition, quotes etc. all have the same button controls on both 1-button and 2-button setups. This means users with large hilt collections which include 1-button and 2-button sabers don’t need to remember different sets of controls for these core features.

CONSISTENT ‘RULES’
This again means the user has less to remember. For example, one click of POWER with blade off ALWAYS lights the blade - short click for normal, long click for muted; double click POWER ALWAYS plays a sound effect - track or character quote with blade off, force effect or character quote with blade on pointed up/down respectively. This is all intended to make it easier for people to remember the various controls.

COMPREHENSIVE FONT NAVIGATION
1-button and 2-button setups both allow users to move forwards or backwards one font at a time, or to skip to first font, last font or middle font. 2-button setups include additional navigation features which allow the user to skip forwards or backwards 5 and 10 fonts at a time.

MANUAL AND FAKE BLADE ID
This allows users to run blade ID with a button press, eliminating potential blade ID scan errors that might occur when blades are lit. It can also be set with a define to toggle between two blade/preset arrays with a button press regardless of the actual BladeID status.

BUILT IN BUTTON ‘CLICKER’
For hilts that have buttons with poor tactile feedback (KR’s Scavenger for instance, with the emitter wheel button setup), simply adding a press.wav and release.wav of a clicking sound to the font, shared or common folder will play those effects with their respective button actions to aid in feature navigation.