### PR TITLE
Add idle.wav option

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -408,7 +408,8 @@ public:
     hybrid_font.hum_player_.Free();
 #ifdef ENABLE_IDLE_SOUND
     hybrid_font.idling_ = true;
-#endif    FreeBladeStyles();
+#endif
+    FreeBladeStyles();
     current_preset_.SetPreset(preset_num);
     AllocateBladeStyles();
     chdir(current_preset_.font.get());

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -405,7 +405,7 @@ public:
     SaveColorChangeIfNeeded();
     // First free all styles, then allocate new ones to avoid memory
     // fragmentation.
-    hybrid_font.idle_player_.Free();
+    hybrid_font.hum_player_.Free();
     hybrid_font.idling_ = true;
     FreeBladeStyles();
     current_preset_.SetPreset(preset_num);

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -405,6 +405,8 @@ public:
     SaveColorChangeIfNeeded();
     // First free all styles, then allocate new ones to avoid memory
     // fragmentation.
+    hybrid_font.idle_player_.Free();
+    hybrid_font.idling_ = true;
     FreeBladeStyles();
     current_preset_.SetPreset(preset_num);
     AllocateBladeStyles();

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -405,10 +405,6 @@ public:
     SaveColorChangeIfNeeded();
     // First free all styles, then allocate new ones to avoid memory
     // fragmentation.
-    hybrid_font.hum_player_.Free();
-#ifdef ENABLE_IDLE_SOUND
-    hybrid_font.idling_ = true;
-#endif
     FreeBladeStyles();
     current_preset_.SetPreset(preset_num);
     AllocateBladeStyles();

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -406,8 +406,9 @@ public:
     // First free all styles, then allocate new ones to avoid memory
     // fragmentation.
     hybrid_font.hum_player_.Free();
+#ifdef ENABLE_IDLE_SOUND
     hybrid_font.idling_ = true;
-    FreeBladeStyles();
+#endif    FreeBladeStyles();
     current_preset_.SetPreset(preset_num);
     AllocateBladeStyles();
     chdir(current_preset_.font.get());

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -740,6 +740,7 @@ EFFECT2(lock, lock);
 EFFECT(swng);
 EFFECT(slsh);
 EFFECT(quote);
+EFFECT2(idle, idle);  // Plays when blade is off
 
 // Looped swing fonts. (SmoothSwing V1/V2)
 EFFECT2(swingl, swingl);  // Looped swing, LOW

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -740,8 +740,9 @@ EFFECT2(lock, lock);
 EFFECT(swng);
 EFFECT(slsh);
 EFFECT(quote);
+#ifdef ENABLE_IDLE_SOUND
 EFFECT2(idle, idle);  // Plays when blade is off
-
+#endif
 // Looped swing fonts. (SmoothSwing V1/V2)
 EFFECT2(swingl, swingl);  // Looped swing, LOW
 EFFECT2(swingh, swingh);  // Looped swing, HIGH

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -708,7 +708,14 @@ EFFECT(preon);
 EFFECT(pstoff);
 
 // Monophonic fonts
-EFFECT(boot);     // also polyphonic
+#ifdef ENABLE_IDLE_SOUND
+EFFECT2(idle, idle);
+EFFECT2(boot, idle);
+EFFECT2(font, idle);
+#else
+EFFECT(boot);
+EFFECT(font);     // also polyphonic
+#endif
 EFFECT(bladein);  // also polyphonic
 EFFECT(bladeout);  // also polyphonic
 EFFECT2(hum, hum);
@@ -726,7 +733,6 @@ EFFECT(spin);     // also polyphonic
 EFFECT(blaster);
 EFFECT2(lockup, lockup);
 EFFECT(poweronf); // force poweron
-EFFECT(font);     // also polyphonic
 EFFECT(bgnlock);  // monophonic and polyphonic begin lock
 EFFECT(endlock);  // Plecter endlock support, used for polyphonic name too
 

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -746,9 +746,7 @@ EFFECT2(lock, lock);
 EFFECT(swng);
 EFFECT(slsh);
 EFFECT(quote);
-#ifdef ENABLE_IDLE_SOUND
-EFFECT2(idle, idle);  // Plays when blade is off
-#endif
+
 // Looped swing fonts. (SmoothSwing V1/V2)
 EFFECT2(swingl, swingl);  // Looped swing, LOW
 EFFECT2(swingh, swingh);  // Looped swing, HIGH

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -815,7 +815,16 @@ public:
     }
 #endif
   }
-  
+      void CheckStopIdle() {
+#if defined(ENABLE_IDLE_SOUND) && !defined(DISABLE_DIAGNOSTIC_COMMANDS)
+       // Since idle sound re-uses hum_player,this will prevent
+      // a swing command from triggering monophonic hum while SaberBase is OFF.
+     if (!SaberBase::IsOn() && !GetWavPlayerPlaying(&SFX_idle)) {
+        StopIdleSound();
+      } 
+#endif
+    }
+
   void StopIdleSound() {
   #ifdef ENABLE_IDLE_SOUND
     idling_ = false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -232,12 +232,8 @@ public:
     if (loop) hum_player_->PlayLoop(loop);
    }
 
-  void PlayMonophonic(Effect* f, Effect* loop, float xfade = 0.003f) {
-      Effect::FileID id = f->RandomFile();
-      if (!id && f->GetFollowing()) {
-          id = f->GetFollowing()->RandomFile();
-      }
-      PlayMonophonic(id, loop, xfade);
+  void PlayMonophonic(Effect* f, Effect* loop, float xfade = 0.003f)  {
+    PlayMonophonic(f->RandomFile(), loop, xfade);
   }
   
   // Use after changing alternative.
@@ -266,11 +262,8 @@ public:
     return player;
   }
 
-  RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f) {
-    RefPtr<BufferedWavPlayer> p = PlayPolyphonic(f->RandomFile());
-    if (!p && f->GetFollowing())
-        p = PlayPolyphonic(f->GetFollowing()->RandomFile());
-    return p;
+  RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
+    return PlayPolyphonic(f->RandomFile());
   }
 
   void Play(Effect* monophonic, Effect* polyphonic) {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -28,25 +28,25 @@ public:
       char name[32];
       strcpy(name, "ProffieOS.");
       switch (e->GetFileType()) {
-    case Effect::FileType::SOUND:
-      strcat(name, "SFX.");
-      break;
-    case Effect::FileType::IMAGE:
-      strcat(name, "IMG.");
-      break;
-    default:
-      continue;
+        case Effect::FileType::SOUND:
+          strcat(name, "SFX.");
+          break;
+        case Effect::FileType::IMAGE:
+          strcat(name, "IMG.");
+          break;
+        default:
+          continue;
       }
       strcat(name, e->GetName());
       strcat(name, ".");
       char* x = name + strlen(name);
 
       struct PairedVariable : public VariableBase {
-    Effect* e_;
-    PairedVariable(Effect* e) : e_(e) {}
-    void set(float value) override { e_->SetPaired(value > 0.5); }
-    float get() override { return e_->GetPaired(); }
-    void setDefault() override { e_->SetPaired(false);  }
+        Effect* e_;
+        PairedVariable(Effect* e) : e_(e) {}
+        void set(float value) override { e_->SetPaired(value > 0.5); }
+        float get() override { return e_->GetPaired(); }
+        void setDefault() override { e_->SetPaired(false);  }
       };
       
       strcpy(x, "paired");
@@ -54,11 +54,11 @@ public:
       op->run(name, &var1);
 
       struct VolumeVariable : public VariableBase {
-    Effect* e_;
-    VolumeVariable(Effect* e) : e_(e) {}
-    void set(float value) override { e_->SetVolume(value); }
-    float get() override { return e_->GetVolume(); }
-    void setDefault() override { e_->SetVolume(100);  }
+        Effect* e_;
+        VolumeVariable(Effect* e) : e_(e) {}
+        void set(float value) override { e_->SetVolume(value); }
+        float get() override { return e_->GetVolume(); }
+        void setDefault() override { e_->SetVolume(100);  }
       };
       
       strcpy(x, "volume");
@@ -148,7 +148,7 @@ public:
     if (monophonic_hum_) {
       if (SFX_clash || SFX_blaster || SFX_swing) {
         if (SFX_humm) {
-      monophonic_hum_ = false;
+          monophonic_hum_ = false;
           guess_monophonic_ = false;
           STDOUT.print("plecter polyphonic");
         } else {
@@ -244,10 +244,10 @@ public:
   void RestartHum(int previous_alternative) {
     if (hum_player_ && hum_player_->isPlaying()) {
       if (SFX_chhum) {
-    SFX_chhum.Select(previous_alternative);
-    PlayMonophonic(&SFX_chhum, getHum());
+        SFX_chhum.Select(previous_alternative);
+        PlayMonophonic(&SFX_chhum, getHum());
       } else {
-    PlayMonophonic(getHum(), NULL, 0.2f);
+        PlayMonophonic(getHum(), NULL, 0.2f);
       }
     }
   }
@@ -317,16 +317,16 @@ public:
         if (!swing_player_) {
           if (!swinging_) {
             Effect* effect;
-        if (rss > slashThreshold && SFX_slsh) {
+              if (rss > slashThreshold && SFX_slsh) {
               effect = &SFX_slsh;
             } else if (SFX_swng) {
               effect = &SFX_swng;
             } else {
               effect = &SFX_swing;
             }
-        if (font_config.ProffieOSMaxSwingAcceleration > font_config.ProffieOSMinSwingAcceleration) {
+            if (font_config.ProffieOSMaxSwingAcceleration > font_config.ProffieOSMinSwingAcceleration) {
               float s = (rss - font_config.ProffieOSMinSwingAcceleration) / font_config.ProffieOSMaxSwingAcceleration;
-          effect->SelectFloat(s);
+              effect->SelectFloat(s);
             }
             swing_player_ = PlayPolyphonic(effect);
             swinging_ = true;
@@ -403,8 +403,8 @@ public:
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&SFX_preon);
       
       if (monophonic_hum_) {
-    getOut()->SetFollowing(getHum());
-    hum_player_ = tmp;
+        getOut()->SetFollowing(getHum());
+        hum_player_ = tmp;
       }
     }
     SaberBase::RequestMotion();
@@ -446,7 +446,7 @@ public:
         hum_player_ = GetFreeWavPlayer();
         if (hum_player_) {
           hum_player_->set_volume_now(0);
-      hum_player_->PlayOnce(getNext(GetWavPlayerPlaying(getOut()), SFX_humm ? &SFX_humm : &SFX_hum));
+          hum_player_->PlayOnce(getNext(GetWavPlayerPlaying(getOut()), SFX_humm ? &SFX_humm : &SFX_hum));
           hum_player_->PlayLoop(SFX_humm ? &SFX_humm : &SFX_hum);
         }
         hum_start_ = millis();
@@ -511,23 +511,23 @@ public:
       case OFF_NORMAL:
         if (!SFX_in) {
           size_t total = SFX_poweroff.files_found() + SFX_pwroff.files_found();
-      Effect* effect;
+          Effect* effect;
           if (total) {
             if ((rand() % total) < SFX_poweroff.files_found()) {
-          effect = &SFX_poweroff;
+              effect = &SFX_poweroff;
             } else {
-          effect = &SFX_pwroff;
+              effect = &SFX_pwroff;
             }
-        if (monophonic_hum_) {
-          state_ = STATE_OFF;
-          PlayMonophonic(effect, NULL);
-        } else {
-          state_ = STATE_HUM_FADE_OUT;
-          PlayPolyphonic(effect);
-        }
-        hum_fade_out_ = current_effect_length_;
+            if (monophonic_hum_) {
+              state_ = STATE_OFF;
+              PlayMonophonic(effect, NULL);
+            } else {
+              state_ = STATE_HUM_FADE_OUT;
+              PlayPolyphonic(effect);
+            }
+            hum_fade_out_ = current_effect_length_;
           } else if (monophonic_hum_) {
-        state_ = STATE_OFF;
+            state_ = STATE_OFF;
             // No poweroff, just fade out...
             hum_player_->set_fade_time(0.2);
             hum_player_->FadeAndStop();
@@ -539,14 +539,14 @@ public:
         } else {
           state_ = STATE_HUM_FADE_OUT;
           PlayPolyphonic(getNext(hum_player_, &SFX_in));
-      hum_fade_out_ = 0.2;
+          hum_fade_out_ = 0.2;
         }
-    if (state_ == STATE_HUM_FADE_OUT && !most_blades) {
-      state_ = STATE_HUM_ON;
-    } else {
-      check_postoff_ = !!SFX_pstoff && off_type != OFF_FAST;
-      saved_location_ = location;
-    }
+        if (state_ == STATE_HUM_FADE_OUT && !most_blades) {
+          state_ = STATE_HUM_ON;
+        } else {
+          check_postoff_ = !!SFX_pstoff && off_type != OFF_FAST;
+          saved_location_ = location;
+        }
         break;
       case OFF_BLAST:
         if (monophonic_hum_) {
@@ -574,12 +574,12 @@ public:
           SaberBase::sound_length = 0.2;
           beeper.Beep(0.05, 2000.0);
         }
-    return;
+        return;
       case EFFECT_PREON: SB_Preon(location); return;
       case EFFECT_POSTOFF: SB_Postoff(); return;
       case EFFECT_STAB:
-    if (SFX_stab) { PlayCommon(&SFX_stab); return; }
-    // If no stab sounds are found, fall through to clash
+        if (SFX_stab) { PlayCommon(&SFX_stab); return; }
+        // If no stab sounds are found, fall through to clash
       case EFFECT_CLASH: Play(&SFX_clash, &SFX_clsh); return;
       case EFFECT_FORCE: PlayCommon(&SFX_force); return;
       case EFFECT_BLAST: Play(&SFX_blaster, &SFX_blst); return;
@@ -590,21 +590,21 @@ public:
       case EFFECT_LOCKUP_END: SB_EndLockup(); return;
       case EFFECT_LOW_BATTERY: SB_LowBatt(); return;
       case EFFECT_ALT_SOUND:
-    if (num_alternatives) {
-      int previous_alternative = current_alternative;
-      if (SaberBase::sound_number == -1) {
-        // Next alternative
-        if (++current_alternative >= num_alternatives)  current_alternative = 0;
-      } else {
-        // Select a specific alternative.
-        current_alternative = std::min<int>(SaberBase::sound_number, num_alternatives - 1);
-        // Set the sound num to -1 so that the altchng sound is random.
-        SaberBase::sound_number = -1;
+      if (num_alternatives) {
+        int previous_alternative = current_alternative;
+        if (SaberBase::sound_number == -1) {
+          // Next alternative
+          if (++current_alternative >= num_alternatives)  current_alternative = 0;
+        } else {
+          // Select a specific alternative.
+          current_alternative = std::min<int>(SaberBase::sound_number, num_alternatives - 1);
+          // Set the sound num to -1 so that the altchng sound is random.
+          SaberBase::sound_number = -1;
+        }
+        RestartHum(previous_alternative);
       }
-      RestartHum(previous_alternative);
-    }
-    PlayCommon(&SFX_altchng);
-    break;
+      PlayCommon(&SFX_altchng);
+      break;
     }
   }
 
@@ -663,23 +663,23 @@ public:
         if (!SFX_armhum && SFX_swing) loop = &SFX_swing;  // Thermal-D fallback
         break;
       case SaberBase::LOCKUP_AUTOFIRE:
-    if (SFX_bgnauto) once = &SFX_bgnauto;
-    if (SFX_auto) loop = &SFX_auto;
-    break;
+        if (SFX_bgnauto) once = &SFX_bgnauto;
+        if (SFX_auto) loop = &SFX_auto;
+        break;
       case SaberBase::LOCKUP_LIGHTNING_BLOCK:
-    if (SFX_bgnlb) once = &SFX_bgnlb;
-    if (SFX_lb) loop = &SFX_lb;
-    goto normal_fallback;
+        if (SFX_bgnlb) once = &SFX_bgnlb;
+        if (SFX_lb) loop = &SFX_lb;
+        goto normal_fallback;
       case SaberBase::LOCKUP_MELT:
-    if (SFX_bgnmelt) once = &SFX_bgnmelt;
-    if (SFX_melt) loop = &SFX_melt;
+        if (SFX_bgnmelt) once = &SFX_bgnmelt;
+        if (SFX_melt) loop = &SFX_melt;
         // fall through
       case SaberBase::LOCKUP_DRAG:
         if (!once && SFX_bgndrag) once = &SFX_bgndrag;
         if (!loop && SFX_drag) loop = &SFX_drag;
         // fall through
       case SaberBase::LOCKUP_NORMAL:
-    normal_fallback:
+        normal_fallback:
         if (!once && SFX_bgnlock) once = &SFX_bgnlock;
         // fall through
       case SaberBase::LOCKUP_NONE:
@@ -713,16 +713,16 @@ public:
         if (!end) end = &SFX_blast; // if we don't, end with a blast
         break;
       case SaberBase::LOCKUP_LIGHTNING_BLOCK:
-    if (SFX_endlb) end = &SFX_endlb;
-    goto normal_fallback_end;
+        if (SFX_endlb) end = &SFX_endlb;
+        goto normal_fallback_end;
       case SaberBase::LOCKUP_MELT:
-    if (SFX_endmelt) end = &SFX_endmelt;
+        if (SFX_endmelt) end = &SFX_endmelt;
         // fall through
       case SaberBase::LOCKUP_DRAG:
         if (!end && SFX_enddrag) end = &SFX_enddrag;
         // fall through
       case SaberBase::LOCKUP_NORMAL:
-    normal_fallback_end:
+        normal_fallback_end:
         if (!end && SFX_endlock) end = &SFX_endlock;
         if (!end) end = &SFX_clash;
         // fall through
@@ -811,16 +811,16 @@ public:
   void Loop() override {
     if (state_ == STATE_WAIT_FOR_ON) {
       if (!GetWavPlayerPlaying(&SFX_preon)) {
-    SaberBase::TurnOn(saved_location_);
-    return;
+        SaberBase::TurnOn(saved_location_);
+        return;
       }
     }
     if (check_postoff_) {
       if (!GetWavPlayerPlaying(&SFX_in) &&
-      !GetWavPlayerPlaying(&SFX_poweroff) &&
-      !GetWavPlayerPlaying(&SFX_pwroff)) {
-    check_postoff_ = false;
-    SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
+          !GetWavPlayerPlaying(&SFX_poweroff) &&
+          !GetWavPlayerPlaying(&SFX_pwroff)) {
+        check_postoff_ = false;
+        SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
       }
     }
   }
@@ -841,8 +841,8 @@ bool swinging_ = false;
   void SB_Motion(const Vec3& gyro, bool clear) override {
     if (active_state() && !(SFX_lockup && SaberBase::Lockup())) {
       StartSwing(gyro,
-         font_config.ProffieOSSwingSpeedThreshold,
-         font_config.ProffieOSSlashAccelerationThreshold);
+                 font_config.ProffieOSSwingSpeedThreshold,
+                 font_config.ProffieOSSlashAccelerationThreshold);
     }
   }
 

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -479,10 +479,10 @@ public:
     SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
     switch (off_type) {
       case OFF_CANCEL_PREON:
-        if (state_ == STATE_WAIT_FOR_ON) {
-          state_ = STATE_OFF;
-        }
-        break;
+  if (state_ == STATE_WAIT_FOR_ON) {
+    state_ = STATE_OFF;
+  }
+  break;
       case OFF_IDLE:
         StopIdleSound();
         break;
@@ -820,9 +820,9 @@ public:
   #ifdef ENABLE_IDLE_SOUND
     idling_ = false;
     if (idle_player_ && idle_player_->isPlaying()) {
-      idle_player_->set_fade_time(0.2);   // Set fade-out time (optional)
-      idle_player_->FadeAndStop();        // Smoothly stop the idle sound
-      idle_player_.Free();                // Free the player for future use
+      idle_player_->set_fade_time(0.5);
+      idle_player_->FadeAndStop();
+      idle_player_.Free();
       STDOUT.println("End idle wav Player");
     }
   #endif

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -833,7 +833,10 @@ public:
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
         PVLOG_DEBUG << "************ Playing idle.wav\n";
+        hum_player_->set_volume_now(0.0f);
         hum_player_->PlayOnce(&SFX_idle);
+        hum_player_->set_fade_time(0.2f);
+        hum_player_->set_volume(1.0f);
       } else {
         STDOUT.println("Out of WAV players!");
       }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -205,7 +205,6 @@ public:
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
   RefPtr<BufferedWavPlayer> lock_player_;
-  RefPtr<BufferedWavPlayer> hum_player_;
 
   void PlayMonophonic(const Effect::FileID& f, Effect* loop, float xfade = 0.003f)  {
     EnableAmplifier();

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -479,10 +479,10 @@ public:
     SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
     switch (off_type) {
       case OFF_CANCEL_PREON:
-  if (state_ == STATE_WAIT_FOR_ON) {
-    state_ = STATE_OFF;
-  }
-  break;
+        if (state_ == STATE_WAIT_FOR_ON) {
+          state_ = STATE_OFF;
+        }
+        break;
       case OFF_IDLE:
         StopIdleSound();
         break;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -205,7 +205,7 @@ public:
   RefPtr<BufferedWavPlayer> next_hum_player_;
   RefPtr<BufferedWavPlayer> swing_player_;
   RefPtr<BufferedWavPlayer> lock_player_;
-  RefPtr<BufferedWavPlayer> idle_player_;
+  RefPtr<BufferedWavPlayer> hum_player_;
 
   void PlayMonophonic(const Effect::FileID& f, Effect* loop, float xfade = 0.003f)  {
     EnableAmplifier();
@@ -819,21 +819,21 @@ public:
   void StopIdleSound() {
   #ifdef ENABLE_IDLE_SOUND
     idling_ = false;
-    if (idle_player_ && idle_player_->isPlaying()) {
-      idle_player_->set_fade_time(0.5);
-      idle_player_->FadeAndStop();
-      idle_player_.Free();
+    if (hum_player_ && hum_player_->isPlaying()) {
+      hum_player_->set_fade_time(0.5);
+      hum_player_->FadeAndStop();
+      hum_player_.Free();
       STDOUT.println("End idle wav Player");
     }
   #endif
   }
 
   void StartIdleSound() {
-    if (SFX_idle && (!idle_player_ || !idle_player_->isPlaying())) {
-      idle_player_ = GetFreeWavPlayer();
-      if (idle_player_) {
+    if (SFX_idle && (!hum_player_ || !hum_player_->isPlaying())) {
+      hum_player_ = GetFreeWavPlayer();
+      if (hum_player_) {
         PVLOG_DEBUG << "************ Playing idle.wav\n";
-        idle_player_->PlayOnce(&SFX_idle);
+        hum_player_->PlayOnce(&SFX_idle);
       } else {
         STDOUT.println("Out of WAV players!");
       }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -814,15 +814,15 @@ public:
     }
 #endif
   }
-      void CheckStopIdle() {
-#if defined(ENABLE_IDLE_SOUND) && !defined(DISABLE_DIAGNOSTIC_COMMANDS)
-       // Since idle sound re-uses hum_player,this will prevent
-      // a swing command from triggering monophonic hum while SaberBase is OFF.
-     if (!SaberBase::IsOn() && !GetWavPlayerPlaying(&SFX_idle)) {
-        StopIdleSound();
-      } 
-#endif
+  void CheckStopIdle() {
+#ifdef ENABLE_IDLE_SOUND
+    // Since idle sound re-uses hum_player,this will prevent
+    // a swing command from triggering monophonic hum while SaberBase is OFF.
+    if (!SaberBase::IsOn() && !GetWavPlayerPlaying(&SFX_idle)) {
+      StopIdleSound();
     }
+#endif
+  }
 
   void StopIdleSound() {
 #ifdef ENABLE_IDLE_SOUND

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -826,7 +826,7 @@ public:
     }
 
   void StopIdleSound() {
-  #ifdef ENABLE_IDLE_SOUND
+#ifdef ENABLE_IDLE_SOUND
     idling_ = false;
     if (hum_player_ && hum_player_->isPlaying()) {
       hum_player_->set_fade_time(0.5);
@@ -834,10 +834,11 @@ public:
       hum_player_.Free();
       STDOUT.println("End idle wav Player");
     }
-  #endif
+#endif
   }
 
   void StartIdleSound() {
+#ifdef ENABLE_IDLE_SOUND
     if (SFX_idle && (!hum_player_ || !hum_player_->isPlaying())) {
       hum_player_ = GetFreeWavPlayer();
       if (hum_player_) {
@@ -850,6 +851,7 @@ public:
         STDOUT.println("Out of WAV players!");
       }
     }
+#endif
   }
 
 bool swinging_ = false;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -814,15 +814,6 @@ public:
     }
 #endif
   }
-  void CheckStopIdle() {
-#ifdef ENABLE_IDLE_SOUND
-    // Since idle sound re-uses hum_player,this will prevent
-    // a swing command from triggering monophonic hum while SaberBase is OFF.
-    if (!SaberBase::IsOn() && !GetWavPlayerPlaying(&SFX_idle)) {
-      StopIdleSound();
-    }
-#endif
-  }
 
   void StopIdleSound() {
 #ifdef ENABLE_IDLE_SOUND

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -28,25 +28,25 @@ public:
       char name[32];
       strcpy(name, "ProffieOS.");
       switch (e->GetFileType()) {
-	case Effect::FileType::SOUND:
-	  strcat(name, "SFX.");
-	  break;
-	case Effect::FileType::IMAGE:
-	  strcat(name, "IMG.");
-	  break;
-	default:
-	  continue;
+    case Effect::FileType::SOUND:
+      strcat(name, "SFX.");
+      break;
+    case Effect::FileType::IMAGE:
+      strcat(name, "IMG.");
+      break;
+    default:
+      continue;
       }
       strcat(name, e->GetName());
       strcat(name, ".");
       char* x = name + strlen(name);
 
       struct PairedVariable : public VariableBase {
-	Effect* e_;
-	PairedVariable(Effect* e) : e_(e) {}
-	void set(float value) override { e_->SetPaired(value > 0.5); }
-	float get() override { return e_->GetPaired(); }
-	void setDefault() override { e_->SetPaired(false);  }
+    Effect* e_;
+    PairedVariable(Effect* e) : e_(e) {}
+    void set(float value) override { e_->SetPaired(value > 0.5); }
+    float get() override { return e_->GetPaired(); }
+    void setDefault() override { e_->SetPaired(false);  }
       };
       
       strcpy(x, "paired");
@@ -54,11 +54,11 @@ public:
       op->run(name, &var1);
 
       struct VolumeVariable : public VariableBase {
-	Effect* e_;
-	VolumeVariable(Effect* e) : e_(e) {}
-	void set(float value) override { e_->SetVolume(value); }
-	float get() override { return e_->GetVolume(); }
-	void setDefault() override { e_->SetVolume(100);  }
+    Effect* e_;
+    VolumeVariable(Effect* e) : e_(e) {}
+    void set(float value) override { e_->SetVolume(value); }
+    float get() override { return e_->GetVolume(); }
+    void setDefault() override { e_->SetVolume(100);  }
       };
       
       strcpy(x, "volume");
@@ -148,7 +148,7 @@ public:
     if (monophonic_hum_) {
       if (SFX_clash || SFX_blaster || SFX_swing) {
         if (SFX_humm) {
-	  monophonic_hum_ = false;
+      monophonic_hum_ = false;
           guess_monophonic_ = false;
           STDOUT.print("plecter polyphonic");
         } else {
@@ -232,18 +232,22 @@ public:
     if (loop) hum_player_->PlayLoop(loop);
    }
 
-  void PlayMonophonic(Effect* f, Effect* loop, float xfade = 0.003f)  {
-    PlayMonophonic(f->RandomFile(), loop, xfade);
+  void PlayMonophonic(Effect* f, Effect* loop, float xfade = 0.003f) {
+      Effect::FileID id = f->RandomFile();
+      if (!id && f->GetFollowing()) {
+          id = f->GetFollowing()->RandomFile();
+      }
+      PlayMonophonic(id, loop, xfade);
   }
   
   // Use after changing alternative.
   void RestartHum(int previous_alternative) {
     if (hum_player_ && hum_player_->isPlaying()) {
       if (SFX_chhum) {
-	SFX_chhum.Select(previous_alternative);
-	PlayMonophonic(&SFX_chhum, getHum());
+    SFX_chhum.Select(previous_alternative);
+    PlayMonophonic(&SFX_chhum, getHum());
       } else {
-	PlayMonophonic(getHum(), NULL, 0.2f);
+    PlayMonophonic(getHum(), NULL, 0.2f);
       }
     }
   }
@@ -261,8 +265,12 @@ public:
     }
     return player;
   }
-  RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f)  {
-    return PlayPolyphonic(f->RandomFile());
+
+  RefPtr<BufferedWavPlayer> PlayPolyphonic(Effect* f) {
+    RefPtr<BufferedWavPlayer> p = PlayPolyphonic(f->RandomFile());
+    if (!p && f->GetFollowing())
+        p = PlayPolyphonic(f->GetFollowing()->RandomFile());
+    return p;
   }
 
   void Play(Effect* monophonic, Effect* polyphonic) {
@@ -309,16 +317,16 @@ public:
         if (!swing_player_) {
           if (!swinging_) {
             Effect* effect;
-	    if (rss > slashThreshold && SFX_slsh) {
+        if (rss > slashThreshold && SFX_slsh) {
               effect = &SFX_slsh;
             } else if (SFX_swng) {
               effect = &SFX_swng;
             } else {
               effect = &SFX_swing;
             }
-	    if (font_config.ProffieOSMaxSwingAcceleration > font_config.ProffieOSMinSwingAcceleration) {
+        if (font_config.ProffieOSMaxSwingAcceleration > font_config.ProffieOSMinSwingAcceleration) {
               float s = (rss - font_config.ProffieOSMinSwingAcceleration) / font_config.ProffieOSMaxSwingAcceleration;
-	      effect->SelectFloat(s);
+          effect->SelectFloat(s);
             }
             swing_player_ = PlayPolyphonic(effect);
             swinging_ = true;
@@ -395,8 +403,8 @@ public:
       RefPtr<BufferedWavPlayer> tmp = PlayPolyphonic(&SFX_preon);
       
       if (monophonic_hum_) {
-	getOut()->SetFollowing(getHum());
-	hum_player_ = tmp;
+    getOut()->SetFollowing(getHum());
+    hum_player_ = tmp;
       }
     }
     SaberBase::RequestMotion();
@@ -435,23 +443,23 @@ public:
     } else {
       state_ = STATE_OUT;
       if (!hum_player_) {
-      	hum_player_ = GetFreeWavPlayer();
-      	if (hum_player_) {
-      	  hum_player_->set_volume_now(0);
-	  hum_player_->PlayOnce(getNext(GetWavPlayerPlaying(getOut()), SFX_humm ? &SFX_humm : &SFX_hum));
-      	  hum_player_->PlayLoop(SFX_humm ? &SFX_humm : &SFX_hum);
-      	}
+        hum_player_ = GetFreeWavPlayer();
+        if (hum_player_) {
+          hum_player_->set_volume_now(0);
+      hum_player_->PlayOnce(getNext(GetWavPlayerPlaying(getOut()), SFX_humm ? &SFX_humm : &SFX_hum));
+          hum_player_->PlayLoop(SFX_humm ? &SFX_humm : &SFX_hum);
+        }
         hum_start_ = millis();
       }
       RefPtr<BufferedWavPlayer> tmp;
       if (already_started) {
         tmp = GetWavPlayerPlaying(getOut());
-      	// Set the length for WavLen<>
-      	if (tmp) {
-      	  tmp->UpdateSaberBaseSoundInfo();
-      	} else {
-      	  SaberBase::ClearSoundInfo();
-      	}
+        // Set the length for WavLen<>
+        if (tmp) {
+          tmp->UpdateSaberBaseSoundInfo();
+        } else {
+          SaberBase::ClearSoundInfo();
+        }
       } else {
         tmp = PlayPolyphonic(faston && SFX_fastout ? &SFX_fastout : getOut());
       }
@@ -473,9 +481,22 @@ public:
   }
 
   void SB_Off(OffType off_type, EffectLocation location) override {
-    idling_ = true;
     bool most_blades = location.on_blade(0);
-    SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
+    // SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
+#ifdef ENABLE_IDLE_SOUND
+    if (most_blades) {
+        if (SFX_pstoff) {
+            SFX_in.SetFollowing(&SFX_pstoff);
+            SFX_pstoff.SetFollowing(&SFX_idle);
+        } else {
+            SFX_in.SetFollowing(&SFX_idle);
+        }
+    } else {
+        SFX_in.SetFollowing(nullptr);
+    }
+#else
+    SFX_in.SetFollowing(most_blades ? &SFX_pstoff : nullptr);
+#endif
     switch (off_type) {
       case OFF_CANCEL_PREON:
         if (state_ == STATE_WAIT_FOR_ON) {
@@ -490,23 +511,23 @@ public:
       case OFF_NORMAL:
         if (!SFX_in) {
           size_t total = SFX_poweroff.files_found() + SFX_pwroff.files_found();
-	  Effect* effect;
+      Effect* effect;
           if (total) {
             if ((rand() % total) < SFX_poweroff.files_found()) {
-	      effect = &SFX_poweroff;
+          effect = &SFX_poweroff;
             } else {
-	      effect = &SFX_pwroff;
+          effect = &SFX_pwroff;
             }
-	    if (monophonic_hum_) {
-	      state_ = STATE_OFF;
-	      PlayMonophonic(effect, NULL);
-	    } else {
-	      state_ = STATE_HUM_FADE_OUT;
-	      PlayPolyphonic(effect);
-	    }
-	    hum_fade_out_ = current_effect_length_;
+        if (monophonic_hum_) {
+          state_ = STATE_OFF;
+          PlayMonophonic(effect, NULL);
+        } else {
+          state_ = STATE_HUM_FADE_OUT;
+          PlayPolyphonic(effect);
+        }
+        hum_fade_out_ = current_effect_length_;
           } else if (monophonic_hum_) {
-	    state_ = STATE_OFF;
+        state_ = STATE_OFF;
             // No poweroff, just fade out...
             hum_player_->set_fade_time(0.2);
             hum_player_->FadeAndStop();
@@ -518,14 +539,14 @@ public:
         } else {
           state_ = STATE_HUM_FADE_OUT;
           PlayPolyphonic(getNext(hum_player_, &SFX_in));
-	  hum_fade_out_ = 0.2;
+      hum_fade_out_ = 0.2;
         }
-	if (state_ == STATE_HUM_FADE_OUT && !most_blades) {
-	  state_ = STATE_HUM_ON;
-	} else {
-	  check_postoff_ = !!SFX_pstoff && off_type != OFF_FAST;
-	  saved_location_ = location;
-	}
+    if (state_ == STATE_HUM_FADE_OUT && !most_blades) {
+      state_ = STATE_HUM_ON;
+    } else {
+      check_postoff_ = !!SFX_pstoff && off_type != OFF_FAST;
+      saved_location_ = location;
+    }
         break;
       case OFF_BLAST:
         if (monophonic_hum_) {
@@ -553,12 +574,12 @@ public:
           SaberBase::sound_length = 0.2;
           beeper.Beep(0.05, 2000.0);
         }
-	return;
+    return;
       case EFFECT_PREON: SB_Preon(location); return;
       case EFFECT_POSTOFF: SB_Postoff(); return;
       case EFFECT_STAB:
-	if (SFX_stab) { PlayCommon(&SFX_stab); return; }
-	// If no stab sounds are found, fall through to clash
+    if (SFX_stab) { PlayCommon(&SFX_stab); return; }
+    // If no stab sounds are found, fall through to clash
       case EFFECT_CLASH: Play(&SFX_clash, &SFX_clsh); return;
       case EFFECT_FORCE: PlayCommon(&SFX_force); return;
       case EFFECT_BLAST: Play(&SFX_blaster, &SFX_blst); return;
@@ -569,21 +590,21 @@ public:
       case EFFECT_LOCKUP_END: SB_EndLockup(); return;
       case EFFECT_LOW_BATTERY: SB_LowBatt(); return;
       case EFFECT_ALT_SOUND:
-	if (num_alternatives) {
-	  int previous_alternative = current_alternative;
-	  if (SaberBase::sound_number == -1) {
-	    // Next alternative
-	    if (++current_alternative >= num_alternatives)  current_alternative = 0;
-	  } else {
-	    // Select a specific alternative.
-	    current_alternative = std::min<int>(SaberBase::sound_number, num_alternatives - 1);
-	    // Set the sound num to -1 so that the altchng sound is random.
-	    SaberBase::sound_number = -1;
-	  }
-	  RestartHum(previous_alternative);
-	}
-	PlayCommon(&SFX_altchng);
-	break;
+    if (num_alternatives) {
+      int previous_alternative = current_alternative;
+      if (SaberBase::sound_number == -1) {
+        // Next alternative
+        if (++current_alternative >= num_alternatives)  current_alternative = 0;
+      } else {
+        // Select a specific alternative.
+        current_alternative = std::min<int>(SaberBase::sound_number, num_alternatives - 1);
+        // Set the sound num to -1 so that the altchng sound is random.
+        SaberBase::sound_number = -1;
+      }
+      RestartHum(previous_alternative);
+    }
+    PlayCommon(&SFX_altchng);
+    break;
     }
   }
 
@@ -642,23 +663,23 @@ public:
         if (!SFX_armhum && SFX_swing) loop = &SFX_swing;  // Thermal-D fallback
         break;
       case SaberBase::LOCKUP_AUTOFIRE:
-	if (SFX_bgnauto) once = &SFX_bgnauto;
-	if (SFX_auto) loop = &SFX_auto;
-	break;
+    if (SFX_bgnauto) once = &SFX_bgnauto;
+    if (SFX_auto) loop = &SFX_auto;
+    break;
       case SaberBase::LOCKUP_LIGHTNING_BLOCK:
-	if (SFX_bgnlb) once = &SFX_bgnlb;
-	if (SFX_lb) loop = &SFX_lb;
-	goto normal_fallback;
+    if (SFX_bgnlb) once = &SFX_bgnlb;
+    if (SFX_lb) loop = &SFX_lb;
+    goto normal_fallback;
       case SaberBase::LOCKUP_MELT:
-	if (SFX_bgnmelt) once = &SFX_bgnmelt;
-	if (SFX_melt) loop = &SFX_melt;
+    if (SFX_bgnmelt) once = &SFX_bgnmelt;
+    if (SFX_melt) loop = &SFX_melt;
         // fall through
       case SaberBase::LOCKUP_DRAG:
         if (!once && SFX_bgndrag) once = &SFX_bgndrag;
         if (!loop && SFX_drag) loop = &SFX_drag;
         // fall through
       case SaberBase::LOCKUP_NORMAL:
-	normal_fallback:
+    normal_fallback:
         if (!once && SFX_bgnlock) once = &SFX_bgnlock;
         // fall through
       case SaberBase::LOCKUP_NONE:
@@ -692,16 +713,16 @@ public:
         if (!end) end = &SFX_blast; // if we don't, end with a blast
         break;
       case SaberBase::LOCKUP_LIGHTNING_BLOCK:
-	if (SFX_endlb) end = &SFX_endlb;
-	goto normal_fallback_end;
+    if (SFX_endlb) end = &SFX_endlb;
+    goto normal_fallback_end;
       case SaberBase::LOCKUP_MELT:
-	if (SFX_endmelt) end = &SFX_endmelt;
+    if (SFX_endmelt) end = &SFX_endmelt;
         // fall through
       case SaberBase::LOCKUP_DRAG:
         if (!end && SFX_enddrag) end = &SFX_enddrag;
         // fall through
       case SaberBase::LOCKUP_NORMAL:
-	normal_fallback_end:
+    normal_fallback_end:
         if (!end && SFX_endlock) end = &SFX_endlock;
         if (!end) end = &SFX_clash;
         // fall through
@@ -790,57 +811,29 @@ public:
   void Loop() override {
     if (state_ == STATE_WAIT_FOR_ON) {
       if (!GetWavPlayerPlaying(&SFX_preon)) {
-	SaberBase::TurnOn(saved_location_);
-	return;
+    SaberBase::TurnOn(saved_location_);
+    return;
       }
     }
     if (check_postoff_) {
       if (!GetWavPlayerPlaying(&SFX_in) &&
-	  !GetWavPlayerPlaying(&SFX_poweroff) &&
-	  !GetWavPlayerPlaying(&SFX_pwroff)) {
-	check_postoff_ = false;
-	SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
+      !GetWavPlayerPlaying(&SFX_poweroff) &&
+      !GetWavPlayerPlaying(&SFX_pwroff)) {
+    check_postoff_ = false;
+    SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
       }
     }
-    // Wait for retraction sounds to finish, then play idle.wav
-#ifdef ENABLE_IDLE_SOUND
-    if (idling_) {
-      if (GetWavPlayerPlaying(&SFX_in) || GetWavPlayerPlaying(&SFX_pstoff)) {
-        return;
-      } else {
-        idling_ = false;
-        StartIdleSound();
-      }
-    }
-#endif
   }
 
   void StopIdleSound() {
 #ifdef ENABLE_IDLE_SOUND
-    idling_ = false;
-    if (hum_player_ && hum_player_->isPlaying()) {
-      hum_player_->set_fade_time(0.5);
-      hum_player_->FadeAndStop();
-      hum_player_.Free();
-      STDOUT.println("End idle wav Player");
-    }
-#endif
-  }
-
-  void StartIdleSound() {
-#ifdef ENABLE_IDLE_SOUND
-    if (SFX_idle && (!hum_player_ || !hum_player_->isPlaying())) {
-      hum_player_ = GetFreeWavPlayer();
-      if (hum_player_) {
-        PVLOG_DEBUG << "************ Playing idle.wav\n";
-        hum_player_->set_volume_now(0.0f);
-        hum_player_->PlayOnce(&SFX_idle);
-        hum_player_->set_fade_time(0.2f);
-        hum_player_->set_volume(1.0f);
-      } else {
-        STDOUT.println("Out of WAV players!");
+    RefPtr<BufferedWavPlayer> idlePlayer = GetWavPlayerPlaying(&SFX_idle);
+    if (idlePlayer && idlePlayer->isPlaying()) {
+      idlePlayer->set_fade_time(0.5);
+      idlePlayer->FadeAndStop();
+      idlePlayer.Free();
+      PVLOG_NORMAL << "**** Stopped idle wav\n";
       }
-    }
 #endif
   }
 
@@ -848,8 +841,8 @@ bool swinging_ = false;
   void SB_Motion(const Vec3& gyro, bool clear) override {
     if (active_state() && !(SFX_lockup && SaberBase::Lockup())) {
       StartSwing(gyro,
-		 font_config.ProffieOSSwingSpeedThreshold,
-		 font_config.ProffieOSSlashAccelerationThreshold);
+         font_config.ProffieOSSwingSpeedThreshold,
+         font_config.ProffieOSSlashAccelerationThreshold);
     }
   }
 
@@ -861,7 +854,6 @@ bool swinging_ = false;
     ProffieOSErrors::low_battery();
   }
 
-  bool idling_ = true;
  private:
   uint32_t last_micros_;
   uint32_t last_swing_micros_;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -828,7 +828,7 @@ public:
   void StopIdleSound() {
 #ifdef ENABLE_IDLE_SOUND
     RefPtr<BufferedWavPlayer> idlePlayer = GetWavPlayerPlaying(&SFX_idle);
-    if (idlePlayer && idlePlayer->isPlaying()) {
+    if (idlePlayer) {
       idlePlayer->set_fade_time(0.5);
       idlePlayer->FadeAndStop();
       idlePlayer.Free();


### PR DESCRIPTION
This is a proposal for playing an idle.wav, mirroring idle.bmp image behavior.
I’m not sure this is the best way to do this, but I gave this a shot, and it seems to work well.
The feature is enabled with `#define ENABLE_IDLE_SOUND` and plays a sound named idle.wav whenever the blade is off.

Currently, SB_Off() sets idling_ to true, and after retraction (and postoff if it exists) sounds are finished playing, it starts playing idle.wav by triggering it from Loop().

Then idling_  gets set to false at ignition and when IDLE_OFF_TIME expires (when OFF_IDLE) and it stops playing.