### PR TITLE
clarify SD mounting in serial mon

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1578,7 +1578,7 @@ public:
 #ifdef MOUNT_SD_SETTING
     if (!strcmp(cmd, "sd")) {
       if (arg) LSFS::SetAllowMount(atoi(arg) > 0);
-      STDOUT.println(LSFS::GetAllowMount());
+      STDOUT << "SD card mounted to PC " << LSFS::GetAllowMount() << "\n";
       return true;
     }
 #endif

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1578,7 +1578,9 @@ public:
 #ifdef MOUNT_SD_SETTING
     if (!strcmp(cmd, "sd")) {
       if (arg) LSFS::SetAllowMount(atoi(arg) > 0);
-      STDOUT << "SD card mounted to PC " << LSFS::GetAllowMount() << "\n";
+      STDOUT << "\nSD Access " 
+             << (LSFS::GetAllowMount() ? "ON" : "OFF") 
+             << "\n\n";
       return true;
     }
 #endif

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1578,9 +1578,9 @@ public:
 #ifdef MOUNT_SD_SETTING
     if (!strcmp(cmd, "sd")) {
       if (arg) LSFS::SetAllowMount(atoi(arg) > 0);
-      STDOUT << "\nSD Access " 
+      STDOUT << "SD Access " 
              << (LSFS::GetAllowMount() ? "ON" : "OFF") 
-             << "\n\n";
+             << "\n";
       return true;
     }
 #endif


### PR DESCRIPTION
THis just showed 
```cpp
1
```
Now it's more helpful?
```cpp
SD card mounted to PC 1
```