### PR TITLE
New saber_sabersense_buttons.h Prop File Request

### DIFF
--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,0 +1,1273 @@
+/*
+============================================================
+================== SABERSENSE™ PROP FILE ===================
+============================================================
+
+Built on SA22C programming by Matthew McGeary.
+Modified by Chris Carter with substantial support and 
+contributions from Fredrik Hubinette and Brian Conner.
+
+This prop file references certain custom sound files 
+to aid in saber function navigation. These sound files 
+are optional and  are available as a free download from:
+https://sabersense.square.site/downloads
+https://sabersense.square.site/downloads
+
+
+============================================================
+========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES ========= 
+
+The Sabersense™ button control system has been engineered 
+for simplicity and usability. Complex gesture controls and 
+features like Battle Mode are NOT included.
+
+By default, the Sabersense™ button prop features harmonized 
+controls between one-button and two-button operation without 
+compromising the greater usability of two-button systems. 
+
+Where practicable, the same controls apply to both one-button 
+and two-button systems, with two-button operation benefitting 
+from some extra features.
+
+Where possible without causing conflicts, some one-button 
+controls also appear in two-button mode, despite two-button 
+having its own controls for the same feature.
+
+The overall intention is that by default, users need only 
+remember a minimum set of control principles in order to 
+access all functions. As such, the logic is that the 
+same button presses do the same thing within the various 
+states, subject to inevitable and obvious variants.
+
+Hence:
+  ONE AND TWO BUTTON:
+      Single click MAIN always lights the blade...
+      Short click lights blade with sound
+      Long click lights blade mute
+
+      Double click MAIN always plays a sound file...
+        Character Quote or Music track with blade OFF
+        Character Quote or Force Effect with blade ON
+        Battery level announcement if held down on second click
+
+      Holding down MAIN (1-button) or AUX (2-button) 
+      and waiting with blade OFF always skips to specific preset...
+        Hilt pointing up - first preset
+        Hilt horizontal - middle preset
+        Hilt pointing down - last preset
+
+      Triple-clicking MAIN is always a saber management feature
+        Colour change with blade ON
+        BladeID/Array Switch with blade OFF
+
+  TWO BUTTON ONLY:
+      Short clicking AUX with blade OFF always moves to a different preset, 
+      forward with hilt pointing up, backwards with hilt pointing down...
+        Single short click - one preset
+        Double short click - five presets
+        Triple short click - ten presets
+
+      Holding MAIN and short clicking AUX always enters a control menu...
+        Colour change with blade ON
+        Volume menu with blade OFF
+
+
+==========================================================
+=================== 1 BUTTON CONTROLS ==================== 
+
+MAIN FUNCTIONS
+  Activate blade            Short click while OFF. *
+  Activate blade mute       Long click while OFF, hilt horizontal.
+                              (Hold for one second then release).
+  Deactivate blade          Hold and wait until blade is off while ON.
+
+FUNCTIONS WITH BLADE OFF
+  Next preset               Long click while OFF, hilt pointing up.
+                              (Hold for one second then release).
+  Previous preset           Long click while OFF, hilt pointing down.
+                              (Hold for one second then release).
+  Skip to first preset      Press and hold until it switches, hilt pointing upwards.
+  Skip to middle preset     Press and hold until it switches, hilt horizontal.
+  Skip to last preset       Press and hold until it switches, hilt pointing downwards.
+  Play Character Quote      Fast double-click, hilt pointing up, plays sequentially. **
+  Play Music Track          Fast double-click, hilt pointing down. **
+  Speak battery voltage     Fast double-click-and-hold while OFF.
+  Run BladeID/Array Select  Fast triple-click while OFF. (Applicable installs only).
+  Restore Factory Defaults	Fast four-clicks while OFF, hold on last click. (If enabled).
+                              Release once announcement starts.
+  Enter/Exit VOLUME MENU    Hold and clash while OFF.
+    Volume up               Click while in VOLUME MENU, hilt pointing up.
+    Volume down             Click while in VOLUME MENU, hilt pointing down.
+                              Volume adjusts in increments per click.
+                              You must exit VOLUME MENU to resume using lightsaber normally.
+
+FUNCTIONS WITH BLADE ON
+  Blade lockup              Hold and hit clash while ON.
+  Blade tip drag            Hold and hit clash while ON pointing the blade tip down.
+  Play Character Quote      Fast double-click, hilt pointing up, plays sequentially. **
+  Force Effect              Fast double-click, hilt pointing down, plays randomly. **
+  Lightning block           Double click and hold while ON.
+  Melt                      Hold and thrust forward clash while ON. (Selected fonts only).
+  Blaster blocks            Short click/double click/triple click while ON.
+  Enter multi-blast mode    Hold while swinging for one second and release.
+                              To trigger blaster block, swing saber while in multi-blast mode.
+                              To exit, hold while swinging for one second and release.
+
+COLOUR CHANGE FUNCTIONS WITH BLADE ON
+  Enter COLOUR MENU         Fast triple-click while ON.
+                              Announcement confirms you are in the COLOUR MENU. 
+  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+  Exit COLOUR MENU          Short click saves new colour and exits.
+                            Fast-double-click exits and reverts to original colour.
+                              Announcement confirms you are exiting COLOUR MENU.
+                              You must exit COLOUR MENU to resume using lightsaber normally.
+                              
+  *   = Gesture ignitions also available via defines.
+  **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
+
+
+============================================================
+===================== 2 BUTTON CONTROLS ====================
+
+MAIN FUNCTIONS
+  Activate blade            Short click MAIN. *
+  Activate blade mute       Long click MAIN (hold for one second then release). 
+  Deactivate blade          Press and hold MAIN and wait until blade is off.
+
+FUNCTIONS WITH BLADE OFF
+  Next preset               Short click AUX, hilt pointing upwards.
+  Previous preset           Short click AUX, hilt pointing downwards.
+  Previous preset           Hold AUX and short click MAIN.
+                              (Duplicate legacy command).
+  Skip to first preset      Press and hold any button until it switches, hilt upwards.
+  Skip to middle preset     Press and hold any button  until it switches, hilt horizontal.
+  Skip to last preset       Press and hold any button  until it switches, hilt downwards.
+  Skip forward 5 presets    Fast double-click AUX, hilt pointing upwards.
+  Skip back 5 presets       Fast double-click AUX, hilt pointing downwards.
+  Skip forward 10 presets   Fast triple-click AUX, hilt pointing upwards.
+  Skip back 10 presets      Fast triple-click AUX, hilt pointing downwards.
+  Play Character Quote      Fast double-click MAIN, hilt pointing up, plays sequentially. **
+  Play Music Track          Fast double-click MAIN, pointing down. **
+  Speak battery voltage     Fast double-click-and-hold MAIN, or hold AUX for one second.
+  Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
+  Restore Factory Defaults	Fast four-clicks MAIN, hold on last click. (If enabled).
+                              Release once announcement starts.
+  Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
+    Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
+    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down, OR click 
+                              AUX while in VOLUME MENU.
+                              Volume adjusts in increments per click.
+                              You must exit VOLUME MENU to resume using saber normally.
+
+FUNCTIONS WITH BLADE ON
+  Blade lockup              Press and hold AUX.
+  Blade tip drag            Press and hold AUX while blade is pointing down.
+  Play Character Quote      Fast double-click MAIN, hilt pointing up, plays sequentially. **
+  Force Effect              Fast double-click MAIN, hilt pointing down, plays randomly. **
+  Lightning block           Double-click MAIN and hold.
+  Melt                      Hold MAIN and push blade tip against wall (stab).
+  Blaster blocks            Short click AUX. (Add Short click MAIN using define).
+  Enter multi-blast mode    Hold MAIN while swinging for one second and release. 
+                              Saber will play two quick blasts confirming mode.
+                              Swing blade to trigger blaster block.
+                              To exit multi-blast mode, fast single click AUX.
+
+COLOUR CHANGE FUNCTIONS WITH BLADE ON
+  Enter COLOUR MENU         Hold MAIN then quickly click AUX and release both
+                            buttons simultaneously. Or fast triple-click MAIN.
+                              Announcement confirms you are in the COLOUR MENU.
+  Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
+                              Most Sabersense presets have 12 colour options.
+  Exit COLOUR MENU          Short click saves new colour and exits.
+                            Fast-double-click exits and reverts to original colour.
+                              Announcement confirms you are exiting COLOUR MENU.
+                              You must exit COLOUR MENU to resume using lightsaber normally.
+                              
+  *  = Gesture ignitions also available via defines.
+  ** = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
+
+
+===========================================================
+=================== SABERSENSE™ DEFINES ===================
+
+#define SABERSENSE_BLADE_ID
+  Replaces regular BladeID with on-demand BladeID scanning. 
+  Plays array-specific bladeidX.wav files when switching.
+  
+#define SABERSENSE_ARRAY_SELECTOR
+  Replaces regular BladeID and allows cycling between 
+  different blade/preset arrays manually, regardless 
+  of actual BladeID status. Plays array-specific 
+  arrayX.wav files when switching.
+  
+#define SABERSENSE_ENABLE_ARRAY_FONT_IDENT
+  Plays font ident after array ident when switching arrays.
+  Use with SABERSENSE_BLADE_ID and SABERSENSE_ARRAY_SELECTOR.
+
+#define SABERSENSE_FLIP_AUDIO_PLAYERS
+  Reverses UP/DOWN orientation for playing FORCE, QUOTE and 
+  MUSIC TRACK audio files. Default (no define) is UP for 
+  sequential QUOTE with blade ON and OFF, and DOWN for random 
+  FORCE effect (ON) and music TRACK (OFF). Define acts on 
+  both ON and OFF states for consistency.
+  
+#define SABERSENSE_BLAST_MAIN_AND_AUX
+  Adds blaster block button to MAIN as well as AUX in 
+  2-button mode. Improves 1 and 2-button harmonization, 
+  but makes accidental blasts more likely when double-clicking 
+  for Quotes or Force Effect.
+  
+#define SABERSENSE_BUTTON_CLICKER
+  Button Clicker to play press/release wav files when 
+  buttons are pressed. Intended for Scavenger hilt 
+  where wheel makes tactile feel difficult.
+  Requires press.wav and release.wav files to work.
+  
+#define SABERSENSE_ENABLE_RESET
+  Enables system to be completely reset to 'factory defaults' 
+  i.e. original config, using button press to delete 
+  all save files.
+  
+#define SABERSENSE_OS7_LEGACY_SUPPORT
+  Required when using this prop file with ProffieOS 7.x. 
+  Not needed (will not work) with ProffieOS 8.x or later.
+  
+#define SABERSENSE_NO_COLOR_CHANGE
+  Use instead of DISABLE_COLOR_CHANGE.
+  
+#define SABERSENSE_NO_LOCKUP_HOLD
+  Applicable to two-button mode only, reverts to lockup being 
+  triggered by clash while holding aux.
+
+GESTURE CONTROLS
+  There are four gesture types: Twist, Stab, Swing and Thrust.
+  Gesture controls bypass all preon effects.
+  #define SABERSENSE_TWIST_ON
+  #define SABERSENSE_TWIST_OFF
+  #define SABERSENSE_STAB_ON
+  #define SABERSENSE_SWING_ON
+  #define SABERSENSE_THRUST_ON
+
+============================================================
+============================================================
+*/
+#ifndef PROPS_SABER_SABERSENSE_BUTTONS_H
+#define PROPS_SABER_SABERSENSE_BUTTONS_H
+ 
+ 
+#include "prop_base.h"
+#include "../sound/hybrid_font.h"
+
+#undef PROP_TYPE
+#define PROP_TYPE SabersenseButtons
+ 
+#ifndef MOTION_TIMEOUT
+#define MOTION_TIMEOUT 60 * 15 * 1000
+#endif
+ 
+#ifndef SABERSENSE_SWING_ON_SPEED
+#define SABERSENSE_SWING_ON_SPEED 250
+#endif
+ 
+#ifndef SABERSENSE_LOCKUP_DELAY
+#define SABERSENSE_LOCKUP_DELAY 200
+#endif
+ 
+#ifndef SABERSENSE_FORCE_PUSH_LENGTH
+#define SABERSENSE_FORCE_PUSH_LENGTH 5
+#endif
+ 
+#ifndef BUTTON_DOUBLE_CLICK_TIMEOUT
+#define BUTTON_DOUBLE_CLICK_TIMEOUT 300
+#endif
+ 
+#ifndef BUTTON_SHORT_CLICK_TIMEOUT
+#define BUTTON_SHORT_CLICK_TIMEOUT 300
+#endif
+ 
+#ifndef BUTTON_HELD_TIMEOUT
+#define BUTTON_HELD_TIMEOUT 300
+#endif
+ 
+#ifndef BUTTON_HELD_MEDIUM_TIMEOUT
+#define BUTTON_HELD_MEDIUM_TIMEOUT 1000
+#endif
+ 
+#ifndef BUTTON_HELD_LONG_TIMEOUT
+#define BUTTON_HELD_LONG_TIMEOUT 2000
+#endif
+ 
+#ifdef SABERSENSE_SWING_ON
+#define SABERSENSE_SWING_GESTURE
+#endif
+ 
+#ifdef SABERSENSE_STAB_ON
+#define SABERSENSE_STAB_GESTURE
+#endif
+ 
+#ifdef SABERSENSE_TWIST_ON
+#define SABERSENSE_TWIST_GESTURE
+#endif
+ 
+#ifdef SABERSENSE_THRUST_ON
+#define SABERSENSE_THRUST_GESTURE
+#endif
+ 
+EFFECT(dim);      // for EFFECT_POWERSAVE
+EFFECT(battery);  // for EFFECT_BATTERY_LEVEL
+EFFECT(vmbegin);  // for Begin Volume Menu
+EFFECT(vmend);    // for End Volume Menu
+EFFECT(volup);    // for increse volume
+EFFECT(voldown);  // for decrease volume
+EFFECT(volmin);   // for minimum volume reached
+EFFECT(volmax);   // for maximum volume reached
+EFFECT(faston);   // for EFFECT_FAST_ON
+EFFECT(blstbgn);  // for Begin Multi-Blast
+EFFECT(blstend);  // for End Multi-Blast
+EFFECT(array);    // for playing array idents
+EFFECT(bladeid);  // for playing bladeid idents
+EFFECT(reset);    // for playing factory default reset completed
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+EFFECT(quote);    // for playing quotes. Required for ProffieOS 7.x.
+#endif
+
+
+  // The Saber class implements the basic states and actions
+  // for the saber.
+class SabersenseButtons : public PROP_INHERIT_PREFIX PropBase {
+public:
+  SabersenseButtons() : PropBase() {}
+  const char* name() override { return "SabersenseButtons"; }
+
+
+  // MAIN LOOP
+  void Loop() override {
+    PropBase::Loop();
+    DetectTwist();
+    Vec3 mss = fusor.mss();
+    if (SaberBase::IsOn()) {
+      DetectSwing();
+      if (auto_lockup_on_ &&
+        !swinging_ &&
+        fusor.swing_speed() > 120 &&
+        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
+          SaberBase::DoEndLockup();
+          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        auto_lockup_on_ = false;
+      }
+      if (auto_melt_on_ &&
+        !swinging_ &&
+        fusor.swing_speed() > 60 &&
+        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
+          SaberBase::DoEndLockup();
+          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        auto_melt_on_ = false;
+      }
+
+      // EVENT_PUSH
+      if (fabs(mss.x) < 3.0 &&
+        mss.y * mss.y + mss.z * mss.z > 70 &&
+        fusor.swing_speed() < 30 &&
+        fabs(fusor.gyro().x) < 10) {
+          if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
+            Event(BUTTON_NONE, EVENT_PUSH);
+            push_begin_millis_ = millis();
+            }
+          } else {
+            push_begin_millis_ = millis();
+          }
+      } else {
+        // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
+        if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
+          SaberBase::RequestMotion();
+            if (swinging_ && fusor.swing_speed() < 90) {
+              swinging_ = false;
+            }
+            if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
+              swinging_ = true;
+            Event(BUTTON_NONE, EVENT_SWING);
+            }
+        }
+      // EVENT_THRUST
+        if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
+          mss.x > 14  &&
+          fusor.swing_speed() < 150) {
+          if (millis() - thrust_begin_millis_ > 15) {
+            Event(BUTTON_NONE, EVENT_THRUST);
+            thrust_begin_millis_ = millis();
+          }
+          } else {
+          thrust_begin_millis_ = millis();
+        }
+      }
+      //  Enables sequential sounds and processes on array handling.
+#ifdef SABERSENSE_BLADE_ID
+        if (do_font_after_sound_ && !IsBladeidSoundPlaying()) {
+        SaberBase::DoNewFont();
+        do_font_after_sound_ = !do_font_after_sound_;
+        }
+#endif
+
+#ifdef SABERSENSE_ARRAY_SELECTOR
+        if (do_font_after_sound_ && !IsArraySoundPlaying()) {
+        SaberBase::DoNewFont();
+        do_font_after_sound_ = !do_font_after_sound_;
+        }
+#endif
+    }
+
+
+  // VOLUME MENU
+  void VolumeUp() {
+    STDOUT.println("Volume up");
+    if (dynamic_mixer.get_volume() < VOLUME) {
+      dynamic_mixer.set_volume(std::min<int>(VOLUME + VOLUME * 0.1,
+        dynamic_mixer.get_volume() + VOLUME * 0.10));
+      if (SFX_volup) {
+        hybrid_font.PlayCommon(&SFX_volup);
+      } else {
+        beeper.Beep(0.5, 2000);
+      }
+      STDOUT.print("Volume Up - Current Volume: ");
+      STDOUT.println(dynamic_mixer.get_volume());
+    } else {
+      // Cycle through ends of Volume Menu option
+      #ifdef VOLUME_MENU_CYCLE
+        if (!max_vol_reached_) {
+          if (SFX_volmax) {
+            hybrid_font.PlayCommon(&SFX_volmax);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          STDOUT.print("Maximum Volume: ");
+          max_vol_reached_ = true;
+        } else {
+          dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
+          dynamic_mixer.get_volume() - VOLUME * 0.90));
+          if (SFX_volmin) {
+            hybrid_font.PlayCommon(&SFX_volmin);
+          } else {
+            beeper.Beep(0.5, 1000);
+          }
+          STDOUT.print("Minimum Volume: ");
+          max_vol_reached_ = false;
+        }
+      #else
+        if (SFX_volmax) {
+          hybrid_font.PlayCommon(&SFX_volmax);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.print("Maximum Volume: ");
+      #endif
+    }
+  }
+
+  void VolumeDown() {
+    STDOUT.println("Volume Down");
+    if (dynamic_mixer.get_volume() > (0.10 * VOLUME)) {
+      dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
+        dynamic_mixer.get_volume() - VOLUME * 0.10));
+      if (SFX_voldown) {
+        hybrid_font.PlayCommon(&SFX_voldown);
+      } else {
+        beeper.Beep(0.5, 2000);
+      }
+      STDOUT.print("Volume Down - Current Volume: ");
+      STDOUT.println(dynamic_mixer.get_volume());
+    } else {
+      #ifdef VOLUME_MENU_CYCLE
+        if (!min_vol_reached_) {
+          if (SFX_volmin) {
+            hybrid_font.PlayCommon(&SFX_volmin);
+          } else {
+            beeper.Beep(0.5, 1000);
+          }
+          STDOUT.print("Minimum Volume: ");
+          min_vol_reached_ = true;
+        } else {
+          dynamic_mixer.set_volume(VOLUME);
+          if (SFX_volmax) {
+            hybrid_font.PlayCommon(&SFX_volmax);
+          } else {
+            beeper.Beep(0.5, 3000);
+          }
+          STDOUT.print("Maximum Volume: ");
+          min_vol_reached_ = false;
+        }
+      #else
+        if (SFX_volmin) {
+          hybrid_font.PlayCommon(&SFX_volmin);
+        } else {
+          beeper.Beep(0.5, 1000);
+        }
+        STDOUT.print("Minimum Volume: ");
+      #endif
+ 
+    }
+  }
+
+
+  //  BLADE ID OPTIONS AND ARRAY MANAGEMENT
+  //  True BladeID, runs scan on-demand with unique 'bladeid' ident sound.
+#ifdef SABERSENSE_BLADE_ID
+  #ifndef ENABLE_POWER_FOR_ID    
+    #error "SABERSENSE_BLADE_ID requires ENABLE_POWER_FOR_ID to be defined."
+  #endif
+
+    bool IsBladeidSoundPlaying() {
+      return !!GetWavPlayerPlaying(&SFX_bladeid);
+    }
+#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  //  Plays 'bladeid' sound AND 'font' sound.
+    void TriggerBladeID() {
+      FindBladeAgain();
+        SFX_bladeid.Select(current_config - blades);
+        hybrid_font.PlayCommon(&SFX_bladeid);
+          //  Calls Loop function to handle waiting for effect before running DoNewFont.
+          do_font_after_sound_ = !do_font_after_sound_;
+        }
+#else
+    //  Plays 'bladeid' sound only, or 'font' sound if no 'bladeid' sound available.
+    void TriggerBladeID() {
+      FindBladeAgain();
+        if (SFX_bladeid) {
+          SFX_bladeid.Select(current_config - blades);
+          hybrid_font.PlayCommon(&SFX_bladeid);  //  Play 'bladeid' sound file if available.
+        } else {
+        SaberBase::DoNewFont();  //  Play font ident if 'bladeid' sound file missing.
+        }
+#endif
+#endif
+
+
+    //  Manual Array Selector, switches on-demand to next array, plays 'array' ident sound. 
+#ifdef SABERSENSE_ARRAY_SELECTOR
+  #ifdef SABERSENSE_BLADE_ID    //  Only one Sabersense BladeID standard permitted.
+    #error "SABERSENSE_ARRAY_SELECTOR and SABERSENSE_BLADE_ID cannot be defined at the same time."
+  #endif
+    bool IsArraySoundPlaying() {
+     return !!GetWavPlayerPlaying(&SFX_array);
+    } 
+#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  //  Plays 'array' sound AND 'font' sound.
+    void NextBladeArray() {
+      FakeFindBladeAgain();
+        SFX_array.Select(current_config - blades);
+        hybrid_font.PlayCommon(&SFX_array);
+          //  Calls Loop function to handle waiting for effect before running DoNewFont.
+          do_font_after_sound_ = !do_font_after_sound_;
+        }
+#else
+    //  Plays 'array' sound only, or 'font' sound if no 'array' sound available.
+    void NextBladeArray() {
+      FakeFindBladeAgain();
+        if (SFX_array) {
+          SFX_array.Select(current_config - blades);
+          hybrid_font.PlayCommon(&SFX_array);  //  Play 'array' sound file if available.
+        } else {
+        SaberBase::DoNewFont();  //  Play font ident if 'array' sound file missing.
+        }
+    }
+#endif
+
+  // Manual Blade Array Selection version of FindBladeAgain()
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+#undef ACTIVATE
+#define ACTIVATE(N) do {                        \
+    if (!current_config->blade##N) {            \
+      goto bad_blade;                           \
+    }                                           \
+    current_config->blade##N->Activate();       \
+  } while(0);
+#else
+#undef ACTIVATE
+#define ACTIVATE(N) do {                        \
+    if (!current_config->blade##N) {            \
+      goto bad_blade;                           \
+    }                                           \
+    current_config->blade##N->Activate(N);      \
+  } while(0);
+#endif
+
+  void FakeFindBladeAgain() {
+    // Reverse everything FindBladeAgain does, except for recalculating best_config.
+    ONCEPERBLADE(UNSET_BLADE_STYLE)
+#undef DEACTIVATE
+#define DEACTIVATE(N) do {                      \
+    if (current_config->blade##N)               \
+      current_config->blade##N->Deactivate();   \
+  } while(0);
+    ONCEPERBLADE(DEACTIVATE);
+    SaveVolumeIfNeeded();
+      if (fusor.angle1() > 0) {
+        //  Cycle forwards (next array) if hilt pointing up...
+        current_config = blades + (current_config - blades + 1) % NELEM(blades);
+      } else {
+        //  Cycle backwards (previous array) if hilt pointing down.
+        current_config = blades + (current_config - blades - 1) % NELEM(blades);
+      }   
+
+    ONCEPERBLADE(ACTIVATE);
+    RestoreGlobalState();
+#ifdef SAVE_PRESET
+    ResumePreset();
+#else
+    SetPreset(0, false);
+#endif // SAVE_PRESET
+//    PVLOG_NORMAL << "** FakeFindBladeAgain() Completed\n";
+    return;    
+#if NUM_BLADES != 0
+  bad_blade:
+    ProffieOSErrors::error_in_blade_array();
+#endif
+  }
+#endif 
+
+ 
+  //  RESET FACTORY DEFAULTS (Delete Save Files).
+  //  Script to determine if sound effect has finished.
+#ifdef SABERSENSE_ENABLE_RESET
+    bool IsResetSoundPlaying() {
+     return !!GetWavPlayerPlaying(&SFX_reset);
+    }
+#endif
+
+
+    //  CLICK PLAYER FOR BUTTON PRESSES (optional).
+    void PlaySound(const char* sound) {
+      RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+       if (player) {
+         if (!player->PlayInCurrentDir(sound)) player->Play(sound);
+       }
+    } 
+    bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
+      switch (EVENTID(button, event, modifiers)) {
+        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+          SaberBase::RequestMotion();
+    #ifdef SABERSENSE_BUTTON_CLICKER 
+          //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
+          PlaySound("press.wav");  //  Requires press.wav file to work.
+    #endif
+            return false;
+        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+    #ifdef SABERSENSE_BUTTON_CLICKER
+          //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
+          PlaySound("release.wav");  //  Requires release.wav file to work.
+    #endif
+          if (SaberBase::Lockup()) {
+            SaberBase::DoEndLockup();
+            SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+          return true;
+        } else {
+          return false;
+        }
+        
+        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
+        case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
+          if (accel_.x < -0.15) {
+            pointing_down_ = true;
+          } else {
+            pointing_down_ = false;
+          }
+          return true;
+
+
+  //  GESTURE CONTROLS
+#ifdef SABERSENSE_SWING_ON
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
+      // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
+      if (millis() > 3000) {
+        FastOn();
+      }
+      return true;
+#endif
+ 
+#ifdef SABERSENSE_TWIST_ON
+    case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
+      // Delay twist events to prevent false trigger from over twisting
+      if (millis() - last_twist_ > 2000 &&
+        millis() - saber_off_time_ > 1000) {
+          FastOn();
+        last_twist_ = millis();
+      }
+      return true;
+#endif
+
+#ifdef SABERSENSE_TWIST_OFF
+    case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_ON):
+      // Delay twist events to prevent false trigger from over twisting
+      if (millis() - last_twist_ > 3000) {
+        Off();
+      last_twist_ = millis();
+      saber_off_time_ = millis();
+      }
+      return true;
+#endif
+
+#ifdef SABERSENSE_STAB_ON
+    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_OFF):
+      if (millis() - saber_off_time_ > 1000) {
+        FastOn();
+      }
+      return true;
+#endif
+
+#ifdef SABERSENSE_THRUST_ON
+    case EVENTID(BUTTON_NONE, EVENT_THRUST, MODE_OFF):
+      if (millis() - saber_off_time_ > 1000) {
+        FastOn();
+      }
+      return true;
+#endif
+
+
+    //  MAIN ACTIVATION
+    // Saber ON AND Volume Adjust, 1 and 2 Button.
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+      IgnoreClash(100);  //  Hopefully prevents false clashes due to 'clicky' button.
+                        //  Low threshold so as not to conflict with 1-button volume menu access.
+        if (!mode_volume_) {
+          On();
+        } else {
+          if (fusor.angle1() > 0) {
+            VolumeUp();
+          } else {
+            VolumeDown();
+          }
+        }
+        return true;
+
+
+    //  1 Button Activate Muted and next/previous preset.
+#if NUM_BUTTONS == 1
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+      IgnoreClash(100);  //  Hopefully prevents false clashes due to 'clicky' button.
+                         //  Low threshold so as not to conflict with 1-button volume menu access.
+      #define DEGREES_TO_RADIANS (M_PI / 180)
+        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+          // If pointing up
+          next_preset();
+        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+          // If pointing down
+          previous_preset();
+        } else {
+          // If horizontal
+          if (SetMute(true)) {
+          unmute_on_deactivation_ = true;
+            On();
+        }
+      }
+#ifdef SAVE_PRESET
+        SaveState(current_preset_.preset_num);
+#endif
+return true;
+#endif
+
+
+    // 2 Button Activate Muted 
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
+      if (SetMute(true)) {
+        unmute_on_deactivation_ = true;
+          On();
+      }
+      return true;
+#endif
+ 
+ 
+    // Turn Blade OFF
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
+      if (!SaberBase::Lockup()) {
+#ifndef DISABLE_COLOR_CHANGE
+        if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+          // Just exit color change mode.
+          // Don't turn saber off.
+          ToggleColorChangeMode();
+        return true;
+      } 
+#endif
+        Off();
+      }
+    saber_off_time_ = millis();
+    swing_blast_ = false;
+    return true;
+
+        
+    //  PRESET NAVIGATION 
+    // Next/previous preset and volume down. Next preset (UP), previous preset (DOWN).
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+      if (!mode_volume_) {
+        SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -1 : 1), true);
+      } else {
+        VolumeDown();
+      }
+#ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+#endif
+return true;
+#endif
+
+    // 2 button: Previous Preset, retained legacy control.
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
+      if (!mode_volume_) {
+        previous_preset();
+      }
+      return true;
+#endif
+
+    //  Multiple preset skips - 2 button sabers only.
+#if NUM_BUTTONS == 2
+    //  Skips forward five presets pointing up, back five pointing down.
+    case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+      SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
+  #ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+  #endif
+return true;
+ 
+    //  Skips forward ten presets pointing up, back ten pointing down.
+    case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      // backwards if pointing down
+      SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
+  #ifdef SAVE_PRESET
+      SaveState(current_preset_.preset_num);
+  #endif
+return true;
+#endif
+
+    //  Skips to first preset (up) or last preset (down)
+    //  or middle preset if horizontal:
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
+#endif
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
+      #define DEGREES_TO_RADIANS (M_PI / 180)
+        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+          // If pointing up
+          SetPreset(0, true);
+        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+          // If pointing down
+          SetPreset(-1, true);
+        } else {
+          // If horizontal
+          CurrentPreset tmp;
+          tmp.SetPreset(-1);
+          SetPreset(tmp.preset_num / 2, true);
+        }
+#ifdef SAVE_PRESET
+        SaveState(current_preset_.preset_num);
+#endif
+return true;
+
+
+    //  BLADE ID OPTIONS AND ARRAY NAVIGATION
+    //  True Blade ID with BladeID audio idents.
+#ifdef SABERSENSE_BLADE_ID
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      TriggerBladeID();
+      return true;
+#endif
+
+
+    //  Manual Array Selector with Array audio idents.
+    //  Cycles through blade arrays regardless of BladeID status.
+    //  UP cycles forward, DOWN cycles back (handled in main code).
+#ifdef SABERSENSE_ARRAY_SELECTOR
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      NextBladeArray(); 
+    return true;
+#endif
+
+
+    // SOUND EFFECT PLAYERS.
+    // Blade ON - UP for Character Quote, plays sequentially.
+    // Blade ON - DOWN for Force Effect, plays randomly.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  
+      // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
+      // Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
+#else
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
+#endif
+
+
+    // Blade OFF - UP for Character Quote, plays sequentially.
+    // Blade OFF - DOWN for Music Track.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
+  // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
+#else
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+        SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
+#endif
+
+
+    //  COLOUR CHANGE.
+#ifdef DISABLE_COLOR_CHANGE
+  #error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
+#endif
+
+    //  1 and 2 button modes.
+#ifndef SABERSENSE_NO_COLOR_CHANGE
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+      ToggleColorChangeMode();
+    return true;
+    //  2 button mode only.
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+      ToggleColorChangeMode();
+    return true;
+#endif
+#endif
+
+
+    // BLASTER DEFLECTION
+    //  1 Button
+#if NUM_BUTTONS == 1
+    // 1 button
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode();
+      } else {
+        //  Fires blast in all OSs.
+        swing_blast_ = false;
+        SaberBase::DoBlast();
+      }
+    return true;
+#endif
+
+    //  2 Button
+#if NUM_BUTTONS == 2
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+    return true;
+
+    //  Add blast to MAIN on 2-button sabers, 
+    //  plus harmonized 'Exit Colour Menu' control under OS-7.x.
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode();          
+      } else {  
+        //  Fires blast in all OSs.
+        swing_blast_ = false;
+        SaberBase::DoBlast();
+      }
+    return true;
+#else
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode(); 
+      }
+    return true;
+#endif 
+#endif
+
+
+    // Multi-Blaster Deflection mode
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+      swing_blast_ = !swing_blast_;
+      if (swing_blast_) {
+        if (SFX_blstbgn) {
+          hybrid_font.PlayCommon(&SFX_blstbgn);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+          }
+        } else {
+          if (SFX_blstend) {
+          hybrid_font.PlayCommon(&SFX_blstend);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+        }
+      }
+      return true;
+ 
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+      if (swing_blast_) {
+        SaberBase::DoBlast();
+      }
+      return true;
+
+
+    // LOCKUP
+#if NUM_BUTTONS == 1
+    // 1 button lockup
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+#else
+#ifndef SABERSENSE_NO_LOCKUP_HOLD
+    // 2 button lockup
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+#else
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+#endif
+#endif
+      if (accel_.x < -0.15) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+      } else {
+        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+      }
+        swing_blast_ = false;
+        SaberBase::DoBeginLockup();
+        return true;
+      break;
+
+    // Lightning Block, 1 and 2 button.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
+    break;
+
+    // Melt
+    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
+    break;
+
+    case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+      SaberBase::RequestMotion();
+    return true;
+
+
+    // ENTER VOLUME MENU
+#if NUM_BUTTONS == 1
+    // 1 button
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+#else
+    // 2 button
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+#endif
+      if (!mode_volume_) {
+        mode_volume_ = true;
+        if (SFX_vmbegin) {
+          hybrid_font.PlayCommon(&SFX_vmbegin);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Enter Volume Menu");
+      } else {
+        mode_volume_ = false;
+        if (SFX_vmend) {
+          hybrid_font.PlayCommon(&SFX_vmend);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Exit Volume Menu");
+      }
+      return true;
+      
+      
+    //  RESTORE FACTORY DEFAULTS 
+    //  Deletes all save files in root and first level directories.      
+#ifdef SABERSENSE_ENABLE_RESET
+    case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
+      // Lock SD card to prevent other operations during deletion.
+      LOCK_SD(true);
+        const char* filesToDelete[] = {   
+          "curstate.ini",
+          "curstate.tmp",
+          "preset.ini",
+          "preset.tmp",
+          "global.ini",
+          "global.tmp"
+        };
+        // Delete files from the root directory.
+        for (const char* targetFile : filesToDelete) {
+          if (LSFS::Exists(targetFile)) {
+            LSFS::Remove(targetFile);
+              Serial.print("Deleted from root: ");
+              Serial.println(targetFile);
+              }
+           }
+        // Find all immediate subdirectories of the root and delete files.
+        LSFS::Iterator dirIterator("/");  // Iterator for the root directory.
+          while (dirIterator) {
+            const char* subdirName = dirIterator.name();
+            if (dirIterator.isdir()) {
+              // Construct the full path to the subdirectory.
+              PathHelper subdirPath("/");
+              subdirPath.Append(subdirName);
+                // Iterate over the files to delete in this subdirectory.
+                for (const char* targetFile : filesToDelete) {
+                  PathHelper filePath(subdirPath);
+                  filePath.Append(targetFile);
+                    // If the file exists in this subdirectory, delete it.
+                    if (LSFS::Exists(filePath)) {
+                      LSFS::Remove(filePath);
+                      Serial.print("Deleted from ");
+                      Serial.print(subdirPath);
+                      Serial.print(": ");
+                      Serial.println(targetFile);
+                    }
+                  }
+                }
+              ++dirIterator;  // Move to the next entry in the root directory.
+            }
+      // Unlock SD card after deletion is complete.
+      LOCK_SD(false);
+          
+      if (SFX_reset) {  //  Optional confirmation sound file 'reset'.
+        hybrid_font.PlayCommon(&SFX_reset);
+          while(IsResetSoundPlaying());  //  Lock system while sound finishes...
+        STM32.reset();  //  ...then reboot saber.
+      } else {
+        STM32.reset(); // Immediate reboot if 'reset' sound file is missing.
+      }
+    break;
+  }
+#endif
+
+
+    // BATTERY LEVEL
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
+      talkie.SayDigit((int)floorf(battery_monitor.battery()));
+      talkie.Say(spPOINT);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+      talkie.Say(spVOLTS);
+      SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
+    return true;
+
+
+#ifdef BLADE_DETECT_PIN
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+      // Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = true;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
+    return true;
+ 
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+      // Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = false;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(false);
+    return true;
+#endif
+ 
+ 
+    // Events that needs to be handled regardless of what other buttons are pressed.
+    case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+      if (SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        return true;
+        }
+      }
+      return false;
+    }
+ 
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+  void SB_Effect(EffectType effect, float location) override {  //  Required for ProffieOS 7.x.
+    switch (effect) {
+      case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return; 
+#else
+  void SB_Effect(EffectType effect, EffectLocation location) override {  //  Required for ProffieOS 8.x.
+    switch (effect) {
+#endif
+      case EFFECT_POWERSAVE:
+        if (SFX_dim) {
+          hybrid_font.PlayCommon(&SFX_dim);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_BATTERY_LEVEL:
+        if (SFX_battery) {
+          hybrid_font.PlayCommon(&SFX_battery);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_FAST_ON:
+        if (SFX_faston) {
+          hybrid_font.PlayCommon(&SFX_faston);
+        }
+        return;
+ 
+      default: break; // avoids compiler warning
+      }
+    }
+
+ 
+  private:
+    bool do_font_after_sound_ = false;
+    bool pointing_down_ = false;
+    bool swing_blast_ = false;
+    bool mode_volume_ = false;
+    bool auto_lockup_on_ = false;
+    bool auto_melt_on_ = false;
+    bool max_vol_reached_ = false;
+    bool min_vol_reached_ = false;
+    uint32_t thrust_begin_millis_ = millis();
+    uint32_t push_begin_millis_ = millis();
+    uint32_t clash_impact_millis_ = millis();
+    uint32_t last_twist_ = millis();
+    uint32_t last_push_ = millis();
+    uint32_t saber_off_time_ = millis();
+  };
+ 
+#endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -6,7 +6,6 @@
 Built on SA22C programming by Matthew McGeary.
 Modified by Chris Carter with substantial support and 
 contributions from Fredrik Hubinette and Brian Conner.
-Version 121.
 
 This prop file references certain custom sound files 
 to aid in saber function navigation. These sound files 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,5 +1,4 @@
 /*
-
 ============================================================
 ================== SABERSENSE™ PROP FILE ===================
 ============================================================
@@ -10,7 +9,7 @@ contributions from Fredrik Hubinette and Brian Conner.
 
 This prop file references certain custom sound files 
 to aid in saber function navigation. These sound files 
-are optional and  are available as a free download from:
+are optional and are available as a free download from:
 https://sabersense.square.site/downloads
 
 
@@ -42,8 +41,8 @@ states, subject to inevitable and obvious variants.
 Hence:
   ONE AND TWO BUTTON:
       Single click MAIN always lights the blade...
-      Short click lights blade with sound
-      Long click lights blade mute
+        Short click lights blade with sound
+        Long click lights blade mute
 
       Double click MAIN always plays a sound file...
         Character Quote or Music track with blade OFF
@@ -56,7 +55,7 @@ Hence:
         Hilt horizontal - middle preset
         Hilt pointing down - last preset
 
-      Triple-clicking MAIN is always a saber management feature
+      Triple-clicking MAIN is always a saber management feature...
         Colour change with blade ON
         BladeID/Array Switch with blade OFF
 
@@ -93,7 +92,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click, hilt pointing down. **
   Speak battery voltage     Fast double-click-and-hold while OFF.
   Run BladeID/Array Select  Fast triple-click while OFF. (Applicable installs only).
-  Restore Factory Defaults	Fast four-clicks while OFF, hold on last click. ***
+  Restore Factory Defaults  Fast four-clicks while OFF, hold on last click. ***
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold and clash while OFF.
     Volume up               Click while in VOLUME MENU, hilt pointing up.
@@ -151,7 +150,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click MAIN, pointing down. **
   Speak battery voltage     Fast double-click-and-hold MAIN, or hold AUX for one second.
   Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
-  Restore Factory Defaults	Fast four-clicks MAIN, hold on last click. ***
+  Restore Factory Defaults  Fast four-clicks MAIN, hold on last click. ***
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
     Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
@@ -191,6 +190,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 
 ===========================================================
 =================== SABERSENSE™ DEFINES ===================
+
 #define SABERSENSE_BLADE_ID
   Replaces regular BladeID with on-demand BladeID scanning. 
   Plays array-specific bladeidX.wav files when switching.
@@ -333,8 +333,8 @@ EFFECT(quote);    // for playing quotes. Required for ProffieOS 7.x.
 #endif
 
 
-  // The Saber class implements the basic states and actions
-  // for the saber.
+  //  The Saber class implements the basic states and actions
+  //  for the saber.
 class SabersenseButtons : public PROP_INHERIT_PREFIX PropBase {
 public:
   SabersenseButtons() : PropBase() {}
@@ -367,7 +367,7 @@ public:
         auto_melt_on_ = false;
       }
 
-      // EVENT_PUSH
+      //  EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
         mss.y * mss.y + mss.z * mss.z > 70 &&
         fusor.swing_speed() < 30 &&
@@ -380,7 +380,7 @@ public:
             push_begin_millis_ = millis();
           }
       } else {
-        // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
+        //  EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
         if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
           SaberBase::RequestMotion();
             if (swinging_ && fusor.swing_speed() < 90) {
@@ -391,7 +391,7 @@ public:
             Event(BUTTON_NONE, EVENT_SWING);
             }
         }
-      // EVENT_THRUST
+      //  EVENT_THRUST
         if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
           mss.x > 14  &&
           fusor.swing_speed() < 150) {
@@ -420,7 +420,7 @@ public:
     }
 
 
-  // VOLUME MENU
+  //  VOLUME MENU
   void VolumeUp() {
     STDOUT.println("Volume up");
     if (dynamic_mixer.get_volume() < VOLUME) {
@@ -572,7 +572,7 @@ public:
     }
 #endif
 
-  // Manual Blade Array Selection version of FindBladeAgain()
+  //  Manual Blade Array Selection version of FindBladeAgain()
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
 #undef ACTIVATE
 #define ACTIVATE(N) do {                        \
@@ -692,7 +692,7 @@ public:
  
 #ifdef SABERSENSE_TWIST_ON
     case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
-      // Delay twist events to prevent false trigger from over twisting
+      //  Delay twist events to prevent false trigger from over twisting
       if (millis() - last_twist_ > 2000 &&
         millis() - saber_off_time_ > 1000) {
           FastOn();
@@ -730,10 +730,10 @@ public:
 
 
     //  MAIN ACTIVATION
-    // Saber ON AND Volume Adjust, 1 and 2 Button.
+    //  Saber ON AND Volume Adjust, 1 and 2 Button.
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       IgnoreClash(100);  //  Hopefully prevents false clashes due to 'clicky' button.
-                        //  Low threshold so as not to conflict with 1-button volume menu access.
+                         //  Low threshold so as not to conflict with 1-button volume menu access.
         if (!mode_volume_) {
           On();
         } else {
@@ -772,7 +772,7 @@ return true;
 #endif
 
 
-    // 2 Button Activate Muted 
+    //  2 Button Activate Muted 
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
       if (SetMute(true)) {
@@ -783,13 +783,13 @@ return true;
 #endif
  
  
-    // Turn Blade OFF
+    //  Turn Blade OFF
     case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
       if (!SaberBase::Lockup()) {
 #ifndef DISABLE_COLOR_CHANGE
         if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-          // Just exit color change mode.
-          // Don't turn saber off.
+          //  Just exit color change mode.
+          //  Don't turn saber off.
           ToggleColorChangeMode();
         return true;
       } 
@@ -802,7 +802,7 @@ return true;
 
         
     //  PRESET NAVIGATION 
-    // Next/previous preset and volume down. Next preset (UP), previous preset (DOWN).
+    //  Next/previous preset and volume down. Next preset (UP), previous preset (DOWN).
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
@@ -817,7 +817,7 @@ return true;
 return true;
 #endif
 
-    // 2 button: Previous Preset, retained legacy control.
+    //  2 button: Previous Preset, retained legacy control.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
       if (!mode_volume_) {
@@ -830,7 +830,7 @@ return true;
 #if NUM_BUTTONS == 2
     //  Skips forward five presets pointing up, back five pointing down.
     case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
-      // backwards if pointing down
+      //  Backwards if pointing down
       SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
   #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
@@ -839,7 +839,7 @@ return true;
  
     //  Skips forward ten presets pointing up, back ten pointing down.
     case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-      // backwards if pointing down
+      //  Backwards if pointing down
       SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
   #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
@@ -873,7 +873,7 @@ return true;
 
 
     //  BLADE ID OPTIONS AND ARRAY NAVIGATION
-    //  True Blade ID with BladeID audio idents.
+    //  True Blade ID on-demand with BladeID audio idents.
 #ifdef SABERSENSE_BLADE_ID
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
       TriggerBladeID();
@@ -891,13 +891,13 @@ return true;
 #endif
 
 
-    // SOUND EFFECT PLAYERS.
-    // Blade ON - UP for Character Quote, plays sequentially.
-    // Blade ON - DOWN for Force Effect, plays randomly.
+    //  SOUND EFFECT PLAYERS.
+    //  With Blade ON - UP for Character Quote, plays sequentially.
+    //  With Blade ON - DOWN for Force Effect, plays randomly.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  
-      // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
-      // Quote player points upwards.
+      //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
+      //  Quote player points upwards.
       if (SFX_quote) {
         if (fusor.angle1() > 0) {
         SFX_quote.SelectNext();
@@ -925,8 +925,8 @@ return true;
 #endif
 
 
-    // Blade OFF - UP for Character Quote, plays sequentially.
-    // Blade OFF - DOWN for Music Track.
+    //  With Blade OFF - UP for Character Quote, plays sequentially.
+    //  With Blade OFF - DOWN for Music Track.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
   // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
@@ -977,10 +977,10 @@ return true;
 #endif
 
 
-    // BLASTER DEFLECTION
+    //  BLASTER DEFLECTION
     //  1 Button
 #if NUM_BUTTONS == 1
-    // 1 button
+    //  1 button
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
       //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
@@ -1023,7 +1023,7 @@ return true;
 #endif
 
 
-    // Multi-Blaster Deflection mode
+    //  Multi-Blaster Deflection mode
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
       swing_blast_ = !swing_blast_;
       if (swing_blast_) {
@@ -1048,13 +1048,13 @@ return true;
       return true;
 
 
-    // LOCKUP
+    //  LOCKUP
 #if NUM_BUTTONS == 1
-    // 1 button lockup
+    //  1 button lockup
     case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
 #else
 #ifndef SABERSENSE_NO_LOCKUP_HOLD
-    // 2 button lockup
+    //  2 button lockup
     case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
 #else
     case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
@@ -1070,7 +1070,7 @@ return true;
         return true;
       break;
 
-    // Lightning Block, 1 and 2 button.
+    //  Lightning Block, 1 and 2 button.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
       SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
       swing_blast_ = false;
@@ -1078,7 +1078,7 @@ return true;
       return true;
     break;
 
-    // Melt
+    //  Melt
     case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
       SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
       swing_blast_ = false;
@@ -1091,12 +1091,12 @@ return true;
     return true;
 
 
-    // ENTER VOLUME MENU
+    //  ENTER VOLUME MENU
 #if NUM_BUTTONS == 1
-    // 1 button
+    //  1 button
     case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
 #else
-    // 2 button
+    //  2 button
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
 #endif
       if (!mode_volume_) {
@@ -1117,8 +1117,8 @@ return true;
         STDOUT.println("Exit Volume Menu");
       }
       return true;
-      
-      
+
+
     //  RESTORE FACTORY DEFAULTS 
     //  Deletes all save files in root and first level directories.      
 #ifdef SABERSENSE_ENABLE_RESET
@@ -1167,11 +1167,11 @@ return true;
             }
       // Unlock SD card after deletion is complete.
       LOCK_SD(false);
-          
+
       if (SFX_reset) {  //  Optional confirmation sound file 'reset'.
         hybrid_font.PlayCommon(&SFX_reset);
           while(IsResetSoundPlaying());  //  Lock system while sound finishes...
-        STM32.reset();  //  ...then reboot saber.
+        STM32.reset(); //  ...then reboot saber.
       } else {
         STM32.reset(); // Immediate reboot if 'reset' sound file is missing.
       }
@@ -1180,7 +1180,7 @@ return true;
 #endif
 
 
-    // BATTERY LEVEL
+    //  BATTERY LEVEL
     case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
       talkie.SayDigit((int)floorf(battery_monitor.battery()));
       talkie.Say(spPOINT);
@@ -1194,7 +1194,7 @@ return true;
 #ifdef BLADE_DETECT_PIN
     case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
     case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
-      // Might need to do something cleaner, but let's try this for now.
+      //  Might need to do something cleaner, but let's try this for now.
       blade_detected_ = true;
       FindBladeAgain();
       SaberBase::DoBladeDetect(true);
@@ -1202,7 +1202,7 @@ return true;
  
     case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
     case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
-      // Might need to do something cleaner, but let's try this for now.
+      //  Might need to do something cleaner, but let's try this for now.
       blade_detected_ = false;
       FindBladeAgain();
       SaberBase::DoBladeDetect(false);
@@ -1253,7 +1253,7 @@ return true;
       }
     }
 
- 
+
   private:
     bool do_font_after_sound_ = false;
     bool pointing_down_ = false;

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,5 @@
 /*
+
 ============================================================
 ================== SABERSENSE™ PROP FILE ===================
 ============================================================
@@ -10,7 +11,6 @@ contributions from Fredrik Hubinette and Brian Conner.
 This prop file references certain custom sound files 
 to aid in saber function navigation. These sound files 
 are optional and  are available as a free download from:
-https://sabersense.square.site/downloads
 https://sabersense.square.site/downloads
 
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -12,7 +12,6 @@ to aid in saber function navigation. These sound files
 are optional and are available as a free download from:
 https://sabersense.square.site/downloads
 
-
 ============================================================
 ========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES ========= 
 
@@ -70,7 +69,6 @@ Hence:
         Colour change with blade ON
         Volume menu with blade OFF
 
-
 ==========================================================
 =================== 1 BUTTON CONTROLS ==================== 
 
@@ -124,7 +122,6 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
-
 
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
@@ -187,7 +184,6 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
-
 ===========================================================
 =================== SABERSENSE DEFINES ====================
 
@@ -248,7 +244,6 @@ GESTURE CONTROLS
 ============================================================
 ============================================================
 */
-
 #ifndef PROPS_SABER_SABERSENSE_BUTTONS_H
 #define PROPS_SABER_SABERSENSE_BUTTONS_H
 
@@ -933,14 +928,8 @@ case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
 #if NUM_BUTTONS == 1
 //  1 button
 case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-    ToggleColorChangeMode();
-  } else {
-    //  Fires blast in all OSs.
     swing_blast_ = false;
     SaberBase::DoBlast();
-  }
   return true;
 #endif
 
@@ -1184,7 +1173,6 @@ return false;
         hybrid_font.PlayCommon(&SFX_faston);
       }
       return;
-
     default: break; // avoids compiler warning
   }
 }
@@ -1205,5 +1193,4 @@ private:
   uint32_t last_push_ = millis();
   uint32_t saber_off_time_ = millis();
 };
-
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -4,37 +4,38 @@
 ============================================================
 
 Built on SA22C programming by Matthew McGeary.
-Modified by Chris Carter with substantial support and 
+Modified by Chris Carter with substantial support and
 contributions from Fredrik Hubinette and Brian Conner.
+Optimized for ProffieOS 8.x.
 
-This prop file references certain custom sound files 
-to aid in saber function navigation. These sound files 
+This prop file references certain custom sound files
+to aid in saber function navigation. These sound files
 are optional and are available as a free download from:
 https://sabersense.square.site/downloads
 
 ============================================================
-========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES ========= 
+========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES =========
 
-The Sabersense button control system has been engineered 
-for simplicity and usability. Complex gesture controls and 
+The Sabersense button control system has been engineered
+for simplicity and usability. Complex gesture controls and
 features like Battle Mode are NOT included.
 
-By default, the Sabersense button prop features harmonized 
-controls between one-button and two-button operation without 
-compromising the greater usability of two-button systems. 
+By default, the Sabersense button prop features harmonized
+controls between one-button and two-button operation without
+compromising the greater usability of two-button systems.
 
-Where practicable, the same controls apply to both one-button 
-and two-button systems, with two-button operation benefitting 
+Where practicable, the same controls apply to both one-button
+and two-button systems, with two-button operation benefitting
 from some extra features.
 
-Where possible without causing conflicts, some one-button 
-controls also appear in two-button mode, despite two-button 
+Where possible without causing conflicts, some one-button
+controls also appear in two-button mode, despite two-button
 having its own controls for the same feature.
 
-The overall intention is that by default, users need only 
-remember a minimum set of control principles in order to 
-access all functions. As such, the logic is that the 
-same button presses do the same thing within the various 
+The overall intention is that by default, users need only
+remember a minimum set of control principles in order to
+access all functions. As such, the logic is that the
+same button presses do the same thing within the various
 states, subject to inevitable and obvious variants.
 
 Hence:
@@ -48,7 +49,7 @@ Hence:
         Character Quote or Force Effect with blade ON
         Battery level announcement if held down on second click
 
-      Holding down MAIN (1-button) or AUX (2-button) 
+      Holding down MAIN (1-button) or AUX (2-button)
       and waiting with blade OFF always skips to specific preset...
         Hilt pointing up - first preset
         Hilt horizontal - middle preset
@@ -59,7 +60,7 @@ Hence:
         BladeID/Array Switch with blade OFF
 
   TWO BUTTON ONLY:
-      Short clicking AUX with blade OFF always moves to a different preset, 
+      Short clicking AUX with blade OFF always moves to a different preset,
       forward with hilt pointing up, backwards with hilt pointing down...
         Single short click - one preset
         Double short click - five presets
@@ -70,7 +71,7 @@ Hence:
         Volume menu with blade OFF
 
 ==========================================================
-=================== 1 BUTTON CONTROLS ==================== 
+=================== 1 BUTTON CONTROLS ====================
 
 MAIN FUNCTIONS
   Activate blade            Short click while OFF. *
@@ -112,13 +113,13 @@ FUNCTIONS WITH BLADE ON
 
 COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Enter COLOUR MENU         Fast triple-click while ON.
-                              Announcement confirms you are in the COLOUR MENU. 
+                              Announcement confirms you are in the COLOUR MENU.
   Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
   Exit COLOUR MENU          Short click saves new colour and exits.
                             Fast-double-click exits and reverts to original colour.
                               Announcement confirms you are exiting COLOUR MENU.
                               You must exit COLOUR MENU to resume using lightsaber normally.
-                              
+
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
@@ -128,7 +129,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 
 MAIN FUNCTIONS
   Activate blade            Short click MAIN. *
-  Activate blade mute       Long click MAIN (hold for one second then release). 
+  Activate blade mute       Long click MAIN (hold for one second then release).
   Deactivate blade          Press and hold MAIN and wait until blade is off.
 
 FUNCTIONS WITH BLADE OFF
@@ -151,7 +152,7 @@ FUNCTIONS WITH BLADE OFF
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
     Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
-    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down, OR click 
+    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down, OR click
                               AUX while in VOLUME MENU.
                               Volume adjusts in increments per click.
                               You must exit VOLUME MENU to resume using saber normally.
@@ -164,7 +165,7 @@ FUNCTIONS WITH BLADE ON
   Lightning block           Double-click MAIN and hold.
   Melt                      Hold MAIN and stab blade tip against wall. Rotate for heat colours.
   Blaster blocks            Short click AUX. (Add Short click MAIN using define).
-  Enter multi-blast mode    Hold MAIN while swinging for one second and release. 
+  Enter multi-blast mode    Hold MAIN while swinging for one second and release.
                               Saber will play two quick blasts confirming mode.
                               Swing blade to trigger blaster block.
                               To exit multi-blast mode, fast single click AUX.
@@ -179,7 +180,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
                             Fast-double-click exits and reverts to original colour.
                               Announcement confirms you are exiting COLOUR MENU.
                               You must exit COLOUR MENU to resume using lightsaber normally.
-                              
+
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
@@ -188,48 +189,48 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 =================== SABERSENSE DEFINES ====================
 
 #define SABERSENSE_BLADE_ID
-  Replaces regular BladeID with on-demand BladeID scanning. 
+  Replaces regular BladeID with on-demand BladeID scanning.
   Plays array-specific bladeidX.wav files when switching.
-  
+
 #define SABERSENSE_ARRAY_SELECTOR
-  Replaces regular BladeID and allows cycling between 
-  different blade/preset arrays manually, regardless 
-  of actual BladeID status. Plays array-specific 
+  Replaces regular BladeID and allows cycling between
+  different blade/preset arrays manually, regardless
+  of actual BladeID status. Plays array-specific
   arrayX.wav files when switching.
-  
+
 #define SABERSENSE_ENABLE_ARRAY_FONT_IDENT
   Plays font ident after array ident when switching arrays.
   Use with SABERSENSE_BLADE_ID and SABERSENSE_ARRAY_SELECTOR.
 
 #define SABERSENSE_FLIP_AUDIO_PLAYERS
-  Reverses UP/DOWN orientation for playing FORCE, QUOTE and 
-  MUSIC TRACK audio files. Default (no define) is UP for 
-  sequential QUOTE with blade ON and OFF, and DOWN for random 
-  FORCE effect (ON) and music TRACK (OFF). Define acts on 
+  Reverses UP/DOWN orientation for playing FORCE, QUOTE and
+  MUSIC TRACK audio files. Default (no define) is UP for
+  sequential QUOTE with blade ON and OFF, and DOWN for random
+  FORCE effect (ON) and music TRACK (OFF). Define acts on
   both ON and OFF states for consistency.
-  
+
 #define SABERSENSE_BLAST_MAIN_AND_AUX
-  Adds blaster block button to MAIN as well as AUX in 
-  2-button mode. Improves 1 and 2-button harmonization, 
-  but makes accidental blasts more likely when double-clicking 
+  Adds blaster block button to MAIN as well as AUX in
+  2-button mode. Improves 1 and 2-button harmonization,
+  but makes accidental blasts more likely when double-clicking
   for Quotes or Force Effect.
-  
+
 #define SABERSENSE_BUTTON_CLICKER
-  Button Clicker to play press/release wav files when 
-  buttons are pressed. Intended for Scavenger hilt 
+  Button Clicker to play press/release wav files when
+  buttons are pressed. Intended for Scavenger hilt
   where wheel makes tactile feel difficult.
   Requires press.wav and release.wav files to work.
-  
+
 #define SABERSENSE_ENABLE_RESET
-  Enables system to be completely reset to 'factory defaults' 
-  i.e. original config, using button press to delete 
+  Enables system to be completely reset to 'factory defaults'
+  i.e. original config, using button press to delete
   all save files.
 
 #define SABERSENSE_NO_COLOR_CHANGE
   Use instead of DISABLE_COLOR_CHANGE.
-  
+
 #define SABERSENSE_NO_LOCKUP_HOLD
-  Applicable to two-button mode only, reverts to lockup being 
+  Applicable to two-button mode only, reverts to lockup being
   triggered by clash while holding aux.
 
 GESTURE CONTROLS
@@ -414,7 +415,7 @@ public:
         max_vol_reached_ = true;
       } else {
         dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
-          dynamic_mixer.get_volume() - VOLUME * 0.90));
+        dynamic_mixer.get_volume() - VOLUME * 0.90));
         if (SFX_volmin) {
           hybrid_font.PlayCommon(&SFX_volmin);
         } else {
@@ -480,13 +481,14 @@ public:
   // BLADE ID OPTIONS AND ARRAY MANAGEMENT
   // True BladeID, runs scan on-demand with unique 'bladeid' ident sound.
 #ifdef SABERSENSE_BLADE_ID
-#ifndef ENABLE_POWER_FOR_ID    
+#ifndef ENABLE_POWER_FOR_ID
 #error "SABERSENSE_BLADE_ID requires ENABLE_POWER_FOR_ID to be defined."
 #endif
 
   bool IsBladeidSoundPlaying() {
     return !!GetWavPlayerPlaying(&SFX_bladeid);
   }
+
 #ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'bladeid' sound AND 'font' sound.
   void TriggerBladeID() {
     FindBladeAgain();
@@ -509,14 +511,15 @@ public:
 #endif
 #endif
 
-  // Manual Array Selector, switches on-demand to next array, plays 'array' ident sound. 
+  // Manual Array Selector, switches on-demand to next array, plays 'array' ident sound.
 #ifdef SABERSENSE_ARRAY_SELECTOR
 #ifdef SABERSENSE_BLADE_ID    // Only one Sabersense BladeID standard permitted.
 #error "SABERSENSE_ARRAY_SELECTOR and SABERSENSE_BLADE_ID cannot be defined at the same time."
 #endif
   bool IsArraySoundPlaying() {
     return !!GetWavPlayerPlaying(&SFX_array);
-  } 
+  }
+
 #ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'array' sound AND 'font' sound.
   void NextBladeArray() {
     FakeFindBladeAgain();
@@ -540,7 +543,7 @@ public:
 
 // Manual Blade Array Selection version of FindBladeAgain()
 #undef ACTIVATE
-#define ACTIVATE(N) do {                        \
+#define ACTIVATE(N) do {                      \
   if (!current_config->blade##N) {            \
     goto bad_blade;                           \
   }                                           \
@@ -551,7 +554,7 @@ void FakeFindBladeAgain() {
   // Reverse everything FindBladeAgain does, except for recalculating best_config.
   ONCEPERBLADE(UNSET_BLADE_STYLE)
 #undef DEACTIVATE
-#define DEACTIVATE(N) do {                      \
+#define DEACTIVATE(N) do {                    \
   if (current_config->blade##N)               \
     current_config->blade##N->Deactivate();   \
 } while(0);
@@ -579,7 +582,7 @@ bad_blade:
   ProffieOSErrors::error_in_blade_array();
 #endif
 }
-#endif 
+#endif
 
 // RESET FACTORY DEFAULTS (Delete Save Files).
 // Script to determine if sound effects have finished.
@@ -587,6 +590,7 @@ bad_blade:
 bool IsResetSoundPlaying() {
   return !!GetWavPlayerPlaying(&SFX_reset);
 }
+
 bool IsBootSoundPlaying() {
   return !!GetWavPlayerPlaying(&SFX_boot);
 }
@@ -823,359 +827,347 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
       return true;
 
-//  BLADE ID OPTIONS AND ARRAY NAVIGATION
-//  True Blade ID on-demand with BladeID audio idents.
+    // BLADE ID OPTIONS AND ARRAY NAVIGATION
+    // True Blade ID on-demand with BladeID audio idents.
 #ifdef SABERSENSE_BLADE_ID
-case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-  TriggerBladeID();
-  return true;
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      TriggerBladeID();
+      return true;
 #endif
 
-//  Manual Array Selector with Array audio idents.
-//  Cycles through blade arrays regardless of BladeID status.
-//  UP cycles forward, DOWN cycles back (handled in main code).
+    // Manual Array Selector with Array audio idents.
+    // Cycles through blade arrays regardless of BladeID status.
+    // UP cycles forward, DOWN cycles back (handled in main code).
 #ifdef SABERSENSE_ARRAY_SELECTOR
-case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-  NextBladeArray();
-  return true;
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+      NextBladeArray();
+      return true;
 #endif
 
-//  SOUND EFFECT PLAYERS.
-//  With Blade ON - UP for Character Quote, plays sequentially.
-//  With Blade ON - DOWN for Force Effect, plays randomly.
-case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+    // SOUND EFFECT PLAYERS.
+    // With Blade ON - UP for Character Quote, plays sequentially.
+    // With Blade ON - DOWN for Force Effect, plays randomly.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
-  //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
-  //  Quote player points upwards.
-  if (SFX_quote) {
-    if (fusor.angle1() > 0) {
-      SFX_quote.SelectNext();
-      SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-      SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
-    }
-  } else {
-    SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
-  }
-  return true;
+      //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
 #else
-  //  Quote player points downwards.
-  if (SFX_quote) {
-    if (fusor.angle1() < 0) {
-      SFX_quote.SelectNext();
-      SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-      SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
-    }
-  } else {
-    SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
-  }
-  return true;
+      //  Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+        }
+      } else {
+        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+      }
+      return true;
 #endif
 
-//  With Blade OFF - UP for Character Quote, plays sequentially.
-//  With Blade OFF - DOWN for Music Track.
-case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+    //  With Blade OFF - UP for Character Quote, plays sequentially.
+    //  With Blade OFF - DOWN for Music Track.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
-  // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
-  //  Quote player points upwards.
-  if (SFX_quote) {
-    if (fusor.angle1() > 0) {
-      SFX_quote.SelectNext();
-      SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-      StartOrStopTrack();  // Play track for hilt pointed DOWN.
-    }
-  } else {
-    StartOrStopTrack();  // Fallback: play track if no quotes are available.
-  }
-  return true;
+      // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
+      //  Quote player points upwards.
+      if (SFX_quote) {
+        if (fusor.angle1() > 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
 #else
-  //  Quote player points downwards.
-  if (SFX_quote) {
-    if (fusor.angle1() < 0) {
-      SFX_quote.SelectNext();
-      SaberBase::DoEffect(EFFECT_QUOTE, 0);
-    } else {
-      StartOrStopTrack();  // Play track for hilt pointed DOWN.
-    }
-  } else {
-    StartOrStopTrack();  // Fallback: play track if no quotes are available.
-  }
-  return true;
+      // Quote player points downwards.
+      if (SFX_quote) {
+        if (fusor.angle1() < 0) {
+          SFX_quote.SelectNext();
+          SaberBase::DoEffect(EFFECT_QUOTE, 0);
+        } else {
+          StartOrStopTrack();  // Play track for hilt pointed DOWN.
+        }
+      } else {
+        StartOrStopTrack();  // Fallback: play track if no quotes are available.
+      }
+      return true;
 #endif
 
-//  COLOUR CHANGE.
+    // COLOUR CHANGE.
 #ifdef DISABLE_COLOR_CHANGE
 #error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
 #endif
 
-//  1 and 2 button modes.
+    // 1 and 2 button modes.
 #ifndef SABERSENSE_NO_COLOR_CHANGE
-case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-  ToggleColorChangeMode();
-  return true;
-//  2 button mode only.
+    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+      ToggleColorChangeMode();
+      return true;
+    // 2 button mode only.
 #if NUM_BUTTONS == 2
-case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
-  ToggleColorChangeMode();
-  return true;
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+      ToggleColorChangeMode();
+      return true;
 #endif
 #endif
 
-//  BLASTER DEFLECTION
-//  1 Button
+    // BLASTER DEFLECTION
+    // 1 Button
 #if NUM_BUTTONS == 1
-//  1 button
-case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-    swing_blast_ = false;
-    SaberBase::DoBlast();
-  return true;
+    // 1 button
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+      return true;
 #endif
 
-//  2 Button
+    // 2 Button
 #if NUM_BUTTONS == 2
-case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-  swing_blast_ = false;
-  SaberBase::DoBlast();
-  return true;
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+      return true;
 
-//  Add blast to MAIN on 2-button sabers,
-//  plus harmonized 'Exit Colour Menu' control under OS-7.x.
-case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+    // Add blast to MAIN on 2-button sabers.
 #ifdef SABERSENSE_BLAST_MAIN_AND_AUX
-  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-    ToggleColorChangeMode();
-  } else {
-    //  Fires blast in all OSs.
-    swing_blast_ = false;
-    SaberBase::DoBlast();
-  }
-  return true;
-#else
-  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-    ToggleColorChangeMode();
-  }
-  return true;
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+    }
+    return true;
 #endif
 #endif
 
-//  Multi-Blaster Deflection mode
-case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
-  swing_blast_ = !swing_blast_;
-  if (swing_blast_) {
-    if (SFX_blstbgn) {
-      hybrid_font.PlayCommon(&SFX_blstbgn);
-    } else {
-      hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-    }
-  } else {
-    if (SFX_blstend) {
-      hybrid_font.PlayCommon(&SFX_blstend);
-    } else {
-      hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-    }
-  }
-  return true;
+    //  Multi-Blaster Deflection mode
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+      swing_blast_ = !swing_blast_;
+      if (swing_blast_) {
+        if (SFX_blstbgn) {
+          hybrid_font.PlayCommon(&SFX_blstbgn);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+        }
+      } else {
+        if (SFX_blstend) {
+          hybrid_font.PlayCommon(&SFX_blstend);
+        } else {
+          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+        }
+      }
+      return true;
 
-case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
-  if (swing_blast_) {
-    SaberBase::DoBlast();
-  }
-  return true;
+    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+      if (swing_blast_) {
+        SaberBase::DoBlast();
+      }
+      return true;
 
-//  LOCKUP
+    // LOCKUP
 #if NUM_BUTTONS == 1
-//  1 button lockup
-case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+    // 1 button lockup
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
 #elif defined(SABERSENSE_NO_LOCKUP_HOLD)
-//  2 button lockup
-case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+    // 2 button lockup
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
 #else
-case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
 #endif
 
-  if (accel_.x < -0.15) {
-    SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
-  } else {
-    SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
-  }
-  swing_blast_ = false;
-  SaberBase::DoBeginLockup();
-  return true;
+      if (accel_.x < -0.15) {
+        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+      } else {
+        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+      }
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
 
-//  Lightning Block, 1 and 2 button.
-case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
-  SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
-  swing_blast_ = false;
-  SaberBase::DoBeginLockup();
-  return true;
+    // Lightning Block, 1 and 2 button.
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
 
-//  Melt
-case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
-  SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-  swing_blast_ = false;
-  SaberBase::DoBeginLockup();
-  return true;
+    // Melt
+    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+      swing_blast_ = false;
+      SaberBase::DoBeginLockup();
+      return true;
 
-case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
-  SaberBase::RequestMotion();
-  return true;
+    case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+      SaberBase::RequestMotion();
+      return true;
 
-//  ENTER VOLUME MENU
+    // ENTER VOLUME MENU
 #if NUM_BUTTONS == 1
-//  1 button
-case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+    // 1 button
+    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
 #else
-//  2 button
-case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+    // 2 button
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
 #endif
-  if (!mode_volume_) {
-    mode_volume_ = true;
-    if (SFX_vmbegin) {
-      hybrid_font.PlayCommon(&SFX_vmbegin);
-    } else {
-      beeper.Beep(0.5, 3000);
-    }
-    STDOUT.println("Enter Volume Menu");
-  } else {
-    mode_volume_ = false;
-    if (SFX_vmend) {
-      hybrid_font.PlayCommon(&SFX_vmend);
-    } else {
-      beeper.Beep(0.5, 3000);
-    }
-    STDOUT.println("Exit Volume Menu");
-  }
-  return true;
+      if (!mode_volume_) {
+        mode_volume_ = true;
+        if (SFX_vmbegin) {
+          hybrid_font.PlayCommon(&SFX_vmbegin);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Enter Volume Menu");
+      } else {
+        mode_volume_ = false;
+        if (SFX_vmend) {
+          hybrid_font.PlayCommon(&SFX_vmend);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.println("Exit Volume Menu");
+      }
+      return true;
 
-//  RESTORE FACTORY DEFAULTS
-//  Deletes all save files in root and first-level directories.
+    // RESTORE FACTORY DEFAULTS
+    // Deletes all save files in root and first-level directories.
 #ifdef SABERSENSE_ENABLE_RESET
-case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
-  // Lock SD card to prevent other operations during deletion.        
-  LOCK_SD(true);
-  const char* filesToDelete[] = {   
-    "curstate.ini",
-    "curstate.tmp",
-    "preset.ini",
-    "preset.tmp",
-    "global.ini",
-    "global.tmp"
-  };
-  // Delete files from the root directory.
-  for (const char* targetFile : filesToDelete) {
-    if (LSFS::Exists(targetFile)) {
-      LSFS::Remove(targetFile);
-      Serial.print("Deleted from root: ");
-      Serial.println(targetFile);
-    }
-  }
-  // Iterate over the save directories listed in blades[].
-  for (const BladeConfig& blade : blades) {
-    const char* saveDirName = blade.save_dir; // Replace with the correct field.
-
-    if (saveDirName && strlen(saveDirName) > 0) {
-      // Construct the path to the save directory.
-      PathHelper saveDirPath("/");
-      saveDirPath.Append(saveDirName);
-
-      // Iterate over the files to delete in this save directory.
+    case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
+      // Lock SD card to prevent other operations during deletion.
+      LOCK_SD(true);
+      const char* filesToDelete[] = {
+        "curstate.ini",
+        "curstate.tmp",
+        "preset.ini",
+        "preset.tmp",
+        "global.ini",
+        "global.tmp"
+      };
+      // Delete files from the root directory.
       for (const char* targetFile : filesToDelete) {
-        PathHelper filePath(saveDirPath);
-        filePath.Append(targetFile);
-
-        // If the file exists in this directory, delete it.
-        if (LSFS::Exists(filePath)) {
-          LSFS::Remove(filePath);
-          Serial.print("Deleted from ");
-          Serial.print(saveDirPath);
-          Serial.print(": ");
+        if (LSFS::Exists(targetFile)) {
+          LSFS::Remove(targetFile);
+          Serial.print("Deleted from root: ");
           Serial.println(targetFile);
         }
       }
-    }
-  }
-  // Unlock SD card after deletion is complete.
-  LOCK_SD(false);
+      // Iterate over the save directories listed in blades[].
+      for (const BladeConfig& blade : blades) {
+        const char* saveDirName = blade.save_dir; // Replace with the correct field.
 
-  if (SFX_reset) {  // Optional confirmation sound file 'reset'.
-    hybrid_font.PlayCommon(&SFX_reset);
-    while(IsResetSoundPlaying());  // Lock system while sound finishes.
-  } else {
-    beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
-    delay(800); // Allow beep to play.
-  }
-  STM32.reset(); // Reboot saber.
-}
-break;
+        if (saveDirName && strlen(saveDirName) > 0) {
+          // Construct the path to the save directory.
+          PathHelper saveDirPath("/");
+          saveDirPath.Append(saveDirName);
+
+          // Iterate over the files to delete in this save directory.
+          for (const char* targetFile : filesToDelete) {
+            PathHelper filePath(saveDirPath);
+            filePath.Append(targetFile);
+
+            // If the file exists in this directory, delete it.
+            if (LSFS::Exists(filePath)) {
+              LSFS::Remove(filePath);
+              Serial.print("Deleted from ");
+              Serial.print(saveDirPath);
+              Serial.print(": ");
+              Serial.println(targetFile);
+            }
+          }
+        }
+      }
+      // Unlock SD card after deletion is complete.
+      LOCK_SD(false);
+
+      if (SFX_reset) {  // Optional confirmation sound file 'reset'.
+        hybrid_font.PlayCommon(&SFX_reset);
+        while(IsResetSoundPlaying());  // Lock system while sound finishes.
+      } else {
+        beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
+        delay(800); // Allow beep to play.
+      }
+      STM32.reset(); // Reboot saber.
+    }
+    break;
 #endif
 
-//  BATTERY LEVEL
-case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
-  talkie.SayDigit((int)floorf(battery_monitor.battery()));
-  talkie.Say(spPOINT);
-  talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
-  talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
-  talkie.Say(spVOLTS);
-  SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
-  return true;
+    // BATTERY LEVEL
+    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
+      talkie.SayDigit((int)floorf(battery_monitor.battery()));
+      talkie.Say(spPOINT);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+      talkie.Say(spVOLTS);
+      SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
+      return true;
 
 #ifdef BLADE_DETECT_PIN
-case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
-case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
-  //  Might need to do something cleaner, but let's try this for now.
-  blade_detected_ = true;
-  FindBladeAgain();
-  SaberBase::DoBladeDetect(true);
-  return true;
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+      //  Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = true;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(true);
+      return true;
 
-case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
-case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
-  //  Might need to do something cleaner, but let's try this for now.
-  blade_detected_ = false;
-  FindBladeAgain();
-  SaberBase::DoBladeDetect(false);
-  return true;
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+      //  Might need to do something cleaner, but let's try this for now.
+      blade_detected_ = false;
+      FindBladeAgain();
+      SaberBase::DoBladeDetect(false);
+      return true;
 #endif
 
-// Events that need to be handled regardless of what other buttons are pressed.
-case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-  if (SaberBase::Lockup()) {
-    SaberBase::DoEndLockup();
-    SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
-    return true;
+    // Events that need to be handled regardless of what other buttons are pressed.
+    case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+      if (SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        return true;
+      }
+    }
+    return false;
   }
-}
-return false;
-}
 
   void SB_Effect(EffectType effect, EffectLocation location) override {
     switch (effect) {
-    case EFFECT_POWERSAVE:  
-      if (SFX_dim) {
-        hybrid_font.PlayCommon(&SFX_dim);
-      } else {
-        beeper.Beep(0.5, 3000);
-      }
-      return;
-    case EFFECT_BATTERY_LEVEL:
-      if (SFX_battery) {
-        hybrid_font.PlayCommon(&SFX_battery);
-      } else {
-        beeper.Beep(0.5, 3000);
-      }
-      return;
-    case EFFECT_FAST_ON:
-      if (SFX_faston) {
-        hybrid_font.PlayCommon(&SFX_faston);
-      }
-      return;
-    default: break; // avoids compiler warning
+      case EFFECT_POWERSAVE:
+        if (SFX_dim) {
+          hybrid_font.PlayCommon(&SFX_dim);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_BATTERY_LEVEL:
+        if (SFX_battery) {
+          hybrid_font.PlayCommon(&SFX_battery);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        return;
+      case EFFECT_FAST_ON:
+        if (SFX_faston) {
+          hybrid_font.PlayCommon(&SFX_faston);
+        }
+        return;
+      default: break; // avoids compiler warning
+    }
   }
-}
 
 private:
   bool do_font_after_sound_ = false;

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -540,7 +540,6 @@ public:
     hybrid_font.PlayCommon(&SFX_array);
     // Calls Loop function to handle waiting for effect before running DoNewFont.
     do_font_after_sound_ = true;
-    do_font_after_sound_ = true;
   }
 #else
   // Plays 'array' sound only, or 'font' sound if no 'array' sound available.

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -682,7 +682,7 @@ public:
   //  GESTURE CONTROLS
 #ifdef SABERSENSE_SWING_ON
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
-      // Due to motion chip startup on boot creating false ignition we delay Swing On at boot for 3000ms
+      // Motion chip startup on boot can create false ignition, so delay SwingOn at boot for 3000ms
       if (millis() > 3000) {
         FastOn();
       }
@@ -1225,7 +1225,7 @@ return true;
     switch (effect) {
       case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return; 
 #else
-  void SB_Effect(EffectType effect, EffectLocation location) override {  //  Required for ProffieOS 8.x.
+  void SB_Effect(EffectType effect, EffectLocation location) override {  //  For ProffieOS 8.x.
     switch (effect) {
 #endif
       case EFFECT_POWERSAVE:

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -334,18 +334,18 @@ public:
     if (SaberBase::IsOn()) {
       DetectSwing();
       if (auto_lockup_on_ &&
-        !swinging_ &&
-        fusor.swing_speed() > 120 &&
-        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
-        SaberBase::Lockup()) {
+          !swinging_ &&
+          fusor.swing_speed() > 120 &&
+          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_lockup_on_ = false;
       }
       if (auto_melt_on_ &&
-        !swinging_ &&
-        fusor.swing_speed() > 60 &&
-        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+          !swinging_ &&
+          fusor.swing_speed() > 60 &&
+          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
         SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
@@ -378,8 +378,8 @@ public:
       }
       // EVENT_THRUST
       if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
-        mss.x > 14 &&
-        fusor.swing_speed() < 150) {
+          mss.x > 14 &&
+          fusor.swing_speed() < 150) {
         if (millis() - thrust_begin_millis_ > 15) {
           Event(BUTTON_NONE, EVENT_THRUST);
           thrust_begin_millis_ = millis();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -93,7 +93,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click, hilt pointing down. **
   Speak battery voltage     Fast double-click-and-hold while OFF.
   Run BladeID/Array Select  Fast triple-click while OFF. (Applicable installs only).
-  Restore Factory Defaults	Fast four-clicks while OFF, hold on last click. (If enabled).
+  Restore Factory Defaults	Fast four-clicks while OFF, hold on last click. ***
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold and clash while OFF.
     Volume up               Click while in VOLUME MENU, hilt pointing up.
@@ -107,7 +107,7 @@ FUNCTIONS WITH BLADE ON
   Play Character Quote      Fast double-click, hilt pointing up, plays sequentially. **
   Force Effect              Fast double-click, hilt pointing down, plays randomly. **
   Lightning block           Double click and hold while ON.
-  Melt                      Hold and thrust forward clash while ON. (Selected fonts only).
+  Melt                      Hold and push blade tip against wall (stab). Rotate for heat colours.
   Blaster blocks            Short click/double click/triple click while ON.
   Enter multi-blast mode    Hold while swinging for one second and release.
                               To trigger blaster block, swing saber while in multi-blast mode.
@@ -124,6 +124,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
                               
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
+  *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
 
 ============================================================
@@ -150,7 +151,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click MAIN, pointing down. **
   Speak battery voltage     Fast double-click-and-hold MAIN, or hold AUX for one second.
   Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
-  Restore Factory Defaults	Fast four-clicks MAIN, hold on last click. (If enabled).
+  Restore Factory Defaults	Fast four-clicks MAIN, hold on last click. ***
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
     Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
@@ -165,7 +166,7 @@ FUNCTIONS WITH BLADE ON
   Play Character Quote      Fast double-click MAIN, hilt pointing up, plays sequentially. **
   Force Effect              Fast double-click MAIN, hilt pointing down, plays randomly. **
   Lightning block           Double-click MAIN and hold.
-  Melt                      Hold MAIN and push blade tip against wall (stab).
+  Melt                      Hold MAIN and stab blade tip against wall. Rotate for heat colours.
   Blaster blocks            Short click AUX. (Add Short click MAIN using define).
   Enter multi-blast mode    Hold MAIN while swinging for one second and release. 
                               Saber will play two quick blasts confirming mode.
@@ -183,13 +184,13 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
                               Announcement confirms you are exiting COLOUR MENU.
                               You must exit COLOUR MENU to resume using lightsaber normally.
                               
-  *  = Gesture ignitions also available via defines.
-  ** = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
+  *   = Gesture ignitions also available via defines.
+  **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
+  *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
 
 ===========================================================
 =================== SABERSENSE™ DEFINES ===================
-
 #define SABERSENSE_BLADE_ID
   Replaces regular BladeID with on-demand BladeID scanning. 
   Plays array-specific bladeidX.wav files when switching.

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -622,6 +622,7 @@ public:
        }
     } 
     bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
+      if (GetWavPlayerPlaying(&SFX_boot)) return false;
       switch (EVENTID(button, event, modifiers)) {
         case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
         case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
@@ -1132,8 +1133,8 @@ return true;
       hybrid_font.PlayCommon(&SFX_reset);
       while(IsResetSoundPlaying());  // Lock system while sound finishes.
     } else {
-      beeper.Beep(0.5, 2000); // Generate beep to prompt user to release button.
-      delay(1200); // Give time for slow users to release button, avoids boot conflicts.
+      beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
+      delay(800); // Allow beep to play.
     }
     STM32.reset(); // Reboot saber.
   }

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -6,11 +6,17 @@
 Built on SA22C programming by Matthew McGeary.
 Modified by Chris Carter with substantial support and
 contributions from Fredrik Hubinette and Brian Conner.
-Optimized for ProffieOS 8.x.
 
 This prop file references certain custom sound files
 to aid in saber function navigation. These sound files
-are optional and are available as a free download from:
+are optional and are available as a free download from
+the Sabersense website. (Link below).
+
+This prop file has been optimized for ProffieOS 8.x
+or later. A ProffieOS 7.x compatible version of this 
+prop file is available as a free download from the 
+Sabersense website.
+
 https://sabersense.square.site/downloads
 
 ============================================================

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -312,8 +312,8 @@ EFFECT(blstend);  // for End Multi-Blast
 EFFECT(array);    // for playing array idents
 EFFECT(bladeid);  // for playing bladeid idents
 EFFECT(reset);    // for playing factory default reset completed
-#ifndef HAVE_EFFECT_QUOTE
-EFFECT(quote);    // for playing quotes with earlier OS sound/effect.h file.
+#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
+EFFECT(quote);    // for playing quotes with ProfieOS 7.x.
 #endif
 
   //  The Saber class implements the basic states and actions

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -921,14 +921,12 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     // 1 and 2 button modes.
 #ifndef SABERSENSE_NO_COLOR_CHANGE
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-      ToggleColorChangeMode();
-      return true;
     // 2 button mode only.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+#endif
       ToggleColorChangeMode();
       return true;
-#endif
 #endif
 
     // BLASTER DEFLECTION

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -12,6 +12,7 @@ to aid in saber function navigation. These sound files
 are optional and are available as a free download from:
 https://sabersense.square.site/downloads
 
+
 ============================================================
 ========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES ========= 
 
@@ -69,6 +70,7 @@ Hence:
         Colour change with blade ON
         Volume menu with blade OFF
 
+
 ==========================================================
 =================== 1 BUTTON CONTROLS ==================== 
 
@@ -122,6 +124,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
+
 
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
@@ -184,6 +187,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
+
 ===========================================================
 =================== SABERSENSE DEFINES ====================
 
@@ -224,11 +228,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Enables system to be completely reset to 'factory defaults' 
   i.e. original config, using button press to delete 
   all save files.
-  
-#define SABERSENSE_OS7_LEGACY_SUPPORT
-  Required when using this prop file with ProffieOS 7.x. 
-  Not needed (will not work) with ProffieOS 8.x or later.
-  
+
 #define SABERSENSE_NO_COLOR_CHANGE
   Use instead of DISABLE_COLOR_CHANGE.
   
@@ -248,6 +248,7 @@ GESTURE CONTROLS
 ============================================================
 ============================================================
 */
+
 #ifndef PROPS_SABER_SABERSENSE_BUTTONS_H
 #define PROPS_SABER_SABERSENSE_BUTTONS_H
 
@@ -307,9 +308,6 @@ EFFECT(blstend);  // for End Multi-Blast
 EFFECT(array);    // for playing array idents
 EFFECT(bladeid);  // for playing bladeid idents
 EFFECT(reset);    // for playing factory default reset completed
-#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-EFFECT(quote);    // for playing quotes with ProfileOS 7.x.
-#endif
 
 // The Saber class implements the basic states and actions
 // for the saber.
@@ -546,15 +544,6 @@ public:
 #endif
 
 // Manual Blade Array Selection version of FindBladeAgain()
-#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-#undef ACTIVATE
-#define ACTIVATE(N) do {                        \
-  if (!current_config->blade##N) {            \
-    goto bad_blade;                           \
-  }                                           \
-  current_config->blade##N->Activate();       \
-} while(0);
-#else
 #undef ACTIVATE
 #define ACTIVATE(N) do {                        \
   if (!current_config->blade##N) {            \
@@ -562,7 +551,6 @@ public:
   }                                           \
   current_config->blade##N->Activate(N);      \
 } while(0);
-#endif
 
 void FakeFindBladeAgain() {
   // Reverse everything FindBladeAgain does, except for recalculating best_config.
@@ -1175,18 +1163,8 @@ case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
 return false;
 }
 
-#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-void SB_Effect(EffectType effect, float location) override  //  Required for ProffieOS 7.x.
-#else
-void SB_Effect(EffectType effect, EffectLocation location) override  //  For ProffieOS 8.x.
-#endif  
-{
-  switch (effect) {
-#ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-    case EFFECT_QUOTE: 
-      hybrid_font.PlayCommon(&SFX_quote); 
-      return; 
-#endif
+  void SB_Effect(EffectType effect, EffectLocation location) override {
+    switch (effect) {
     case EFFECT_POWERSAVE:  
       if (SFX_dim) {
         hybrid_font.PlayCommon(&SFX_dim);
@@ -1227,4 +1205,5 @@ private:
   uint32_t last_push_ = millis();
   uint32_t saber_off_time_ = millis();
 };
+
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -4,6 +4,7 @@
 ================            by            ==================
 ================       CHRIS CARTER       ==================
 ============================================================
+V.8-142.
 
 Built on Matthew McGeary's SA22C button prop file for one
 and two button replica lightsabers. Modified by Chris
@@ -389,6 +390,7 @@ public:
       }
     }
     // Enables sequential sounds and processes on array handling.
+    // Prop only permits one of these defines at a time.
 #ifdef SABERSENSE_BLADE_ID
     if (do_font_after_sound_ && !IsBladeidSoundPlaying()) {
       SaberBase::DoNewFont();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,6 +1,6 @@
 /*
 ============================================================
-================== SABERSENSE™ PROP FILE ===================
+================== SABERSENSE PROP FILE ====================
 ============================================================
 
 Built on SA22C programming by Matthew McGeary.
@@ -12,15 +12,14 @@ to aid in saber function navigation. These sound files
 are optional and are available as a free download from:
 https://sabersense.square.site/downloads
 
-
 ============================================================
 ========= BUTTON SYSTEM PRINCIPLES AND LOGIC NOTES ========= 
 
-The Sabersense™ button control system has been engineered 
+The Sabersense button control system has been engineered 
 for simplicity and usability. Complex gesture controls and 
 features like Battle Mode are NOT included.
 
-By default, the Sabersense™ button prop features harmonized 
+By default, the Sabersense button prop features harmonized 
 controls between one-button and two-button operation without 
 compromising the greater usability of two-button systems. 
 
@@ -69,7 +68,6 @@ Hence:
       Holding MAIN and short clicking AUX always enters a control menu...
         Colour change with blade ON
         Volume menu with blade OFF
-
 
 ==========================================================
 =================== 1 BUTTON CONTROLS ==================== 
@@ -124,7 +122,6 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
-
 
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
@@ -187,9 +184,8 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
   *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
-
 ===========================================================
-=================== SABERSENSE™ DEFINES ===================
+=================== SABERSENSE DEFINES ====================
 
 #define SABERSENSE_BLADE_ID
   Replaces regular BladeID with on-demand BladeID scanning. 
@@ -254,55 +250,54 @@ GESTURE CONTROLS
 */
 #ifndef PROPS_SABER_SABERSENSE_BUTTONS_H
 #define PROPS_SABER_SABERSENSE_BUTTONS_H
- 
- 
+
 #include "prop_base.h"
 #include "../sound/hybrid_font.h"
 
 #undef PROP_TYPE
 #define PROP_TYPE SabersenseButtons
- 
+
 #ifndef MOTION_TIMEOUT
 #define MOTION_TIMEOUT 60 * 15 * 1000
 #endif
- 
+
 #ifndef SABERSENSE_SWING_ON_SPEED
 #define SABERSENSE_SWING_ON_SPEED 250
 #endif
- 
+
 #ifndef SABERSENSE_LOCKUP_DELAY
 #define SABERSENSE_LOCKUP_DELAY 200
 #endif
- 
+
 #ifndef SABERSENSE_FORCE_PUSH_LENGTH
 #define SABERSENSE_FORCE_PUSH_LENGTH 5
 #endif
- 
+
 #ifndef BUTTON_DOUBLE_CLICK_TIMEOUT
 #define BUTTON_DOUBLE_CLICK_TIMEOUT 300
 #endif
- 
+
 #ifndef BUTTON_SHORT_CLICK_TIMEOUT
 #define BUTTON_SHORT_CLICK_TIMEOUT 300
 #endif
- 
+
 #ifndef BUTTON_HELD_TIMEOUT
 #define BUTTON_HELD_TIMEOUT 300
 #endif
- 
+
 #ifndef BUTTON_HELD_MEDIUM_TIMEOUT
 #define BUTTON_HELD_MEDIUM_TIMEOUT 1000
 #endif
- 
+
 #ifndef BUTTON_HELD_LONG_TIMEOUT
 #define BUTTON_HELD_LONG_TIMEOUT 2000
 #endif
- 
+
 EFFECT(dim);      // for EFFECT_POWERSAVE
 EFFECT(battery);  // for EFFECT_BATTERY_LEVEL
 EFFECT(vmbegin);  // for Begin Volume Menu
 EFFECT(vmend);    // for End Volume Menu
-EFFECT(volup);    // for increse volume
+EFFECT(volup);    // for increase volume
 EFFECT(voldown);  // for decrease volume
 EFFECT(volmin);   // for minimum volume reached
 EFFECT(volmax);   // for maximum volume reached
@@ -313,11 +308,11 @@ EFFECT(array);    // for playing array idents
 EFFECT(bladeid);  // for playing bladeid idents
 EFFECT(reset);    // for playing factory default reset completed
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-EFFECT(quote);    // for playing quotes with ProfieOS 7.x.
+EFFECT(quote);    // for playing quotes with ProfileOS 7.x.
 #endif
 
-  //  The Saber class implements the basic states and actions
-  //  for the saber.
+// The Saber class implements the basic states and actions
+// for the saber.
 class SabersenseButtons : public PROP_INHERIT_PREFIX PropBase {
 public:
   SabersenseButtons() : PropBase() {}
@@ -333,58 +328,58 @@ public:
         !swinging_ &&
         fusor.swing_speed() > 120 &&
         millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
-          SaberBase::Lockup()) {
-          SaberBase::DoEndLockup();
-          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_lockup_on_ = false;
       }
       if (auto_melt_on_ &&
         !swinging_ &&
         fusor.swing_speed() > 60 &&
         millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
-          SaberBase::Lockup()) {
-          SaberBase::DoEndLockup();
-          SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_melt_on_ = false;
       }
 
-      //  EVENT_PUSH
+      // EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
         mss.y * mss.y + mss.z * mss.z > 70 &&
         fusor.swing_speed() < 30 &&
         fabs(fusor.gyro().x) < 10) {
-          if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
-            Event(BUTTON_NONE, EVENT_PUSH);
-            push_begin_millis_ = millis();
-            }
-          } else {
-            push_begin_millis_ = millis();
-          }
+        if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
+          Event(BUTTON_NONE, EVENT_PUSH);
+          push_begin_millis_ = millis();
+        }
       } else {
-        //  EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
-        if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
-          SaberBase::RequestMotion();
-            if (swinging_ && fusor.swing_speed() < 90) {
-              swinging_ = false;
-            }
-            if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
-              swinging_ = true;
-            Event(BUTTON_NONE, EVENT_SWING);
-            }
+        push_begin_millis_ = millis();
+      }
+    } else {
+      // EVENT_SWING - Swing On gesture control to allow fine tuning of speed needed to ignite
+      if (millis() - saber_off_time_ < MOTION_TIMEOUT) {
+        SaberBase::RequestMotion();
+        if (swinging_ && fusor.swing_speed() < 90) {
+          swinging_ = false;
         }
-        //  EVENT_THRUST
-        if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
-          mss.x > 14  &&
-          fusor.swing_speed() < 150) {
-          if (millis() - thrust_begin_millis_ > 15) {
-            Event(BUTTON_NONE, EVENT_THRUST);
-            thrust_begin_millis_ = millis();
-            }
-          } else {
-            thrust_begin_millis_ = millis();
-          }
+        if (!swinging_ && fusor.swing_speed() > SABERSENSE_SWING_ON_SPEED) {
+          swinging_ = true;
+          Event(BUTTON_NONE, EVENT_SWING);
         }
-    //  Enables sequential sounds and processes on array handling.
+      }
+      // EVENT_THRUST
+      if (mss.y * mss.y + mss.z * mss.z < 16.0 &&
+        mss.x > 14 &&
+        fusor.swing_speed() < 150) {
+        if (millis() - thrust_begin_millis_ > 15) {
+          Event(BUTTON_NONE, EVENT_THRUST);
+          thrust_begin_millis_ = millis();
+        }
+      } else {
+        thrust_begin_millis_ = millis();
+      }
+    }
+    // Enables sequential sounds and processes on array handling.
 #ifdef SABERSENSE_BLADE_ID
     if (do_font_after_sound_ && !IsBladeidSoundPlaying()) {
       SaberBase::DoNewFont();
@@ -393,14 +388,14 @@ public:
 #endif
 
 #ifdef SABERSENSE_ARRAY_SELECTOR
-        if (do_font_after_sound_ && !IsArraySoundPlaying()) {
-        SaberBase::DoNewFont();
-        do_font_after_sound_ = !do_font_after_sound_;
-        }
-#endif
+    if (do_font_after_sound_ && !IsArraySoundPlaying()) {
+      SaberBase::DoNewFont();
+      do_font_after_sound_ = !do_font_after_sound_;
     }
+#endif
+  }
 
-  //  VOLUME MENU
+  // VOLUME MENU
   void VolumeUp() {
     STDOUT.println("Volume up");
     if (dynamic_mixer.get_volume() < VOLUME) {
@@ -416,32 +411,32 @@ public:
     } else {
       // Cycle through ends of Volume Menu option
 #ifdef VOLUME_MENU_CYCLE
-        if (!max_vol_reached_) {
-          if (SFX_volmax) {
-            hybrid_font.PlayCommon(&SFX_volmax);
-          } else {
-            beeper.Beep(0.5, 3000);
-          }
-          STDOUT.print("Maximum Volume: ");
-          max_vol_reached_ = true;
-        } else {
-          dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
-          dynamic_mixer.get_volume() - VOLUME * 0.90));
-          if (SFX_volmin) {
-            hybrid_font.PlayCommon(&SFX_volmin);
-          } else {
-            beeper.Beep(0.5, 1000);
-          }
-          STDOUT.print("Minimum Volume: ");
-          max_vol_reached_ = false;
-        }
-#else
+      if (!max_vol_reached_) {
         if (SFX_volmax) {
           hybrid_font.PlayCommon(&SFX_volmax);
         } else {
           beeper.Beep(0.5, 3000);
         }
         STDOUT.print("Maximum Volume: ");
+        max_vol_reached_ = true;
+      } else {
+        dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
+          dynamic_mixer.get_volume() - VOLUME * 0.90));
+        if (SFX_volmin) {
+          hybrid_font.PlayCommon(&SFX_volmin);
+        } else {
+          beeper.Beep(0.5, 1000);
+        }
+        STDOUT.print("Minimum Volume: ");
+        max_vol_reached_ = false;
+      }
+#else
+      if (SFX_volmax) {
+        hybrid_font.PlayCommon(&SFX_volmax);
+      } else {
+        beeper.Beep(0.5, 3000);
+      }
+      STDOUT.print("Maximum Volume: ");
 #endif
     }
   }
@@ -460,206 +455,207 @@ public:
       STDOUT.println(dynamic_mixer.get_volume());
     } else {
 #ifdef VOLUME_MENU_CYCLE
-        if (!min_vol_reached_) {
-          if (SFX_volmin) {
-            hybrid_font.PlayCommon(&SFX_volmin);
-          } else {
-            beeper.Beep(0.5, 1000);
-          }
-          STDOUT.print("Minimum Volume: ");
-          min_vol_reached_ = true;
-        } else {
-          dynamic_mixer.set_volume(VOLUME);
-          if (SFX_volmax) {
-            hybrid_font.PlayCommon(&SFX_volmax);
-          } else {
-            beeper.Beep(0.5, 3000);
-          }
-          STDOUT.print("Maximum Volume: ");
-          min_vol_reached_ = false;
-        }
-#else
+      if (!min_vol_reached_) {
         if (SFX_volmin) {
           hybrid_font.PlayCommon(&SFX_volmin);
         } else {
           beeper.Beep(0.5, 1000);
         }
         STDOUT.print("Minimum Volume: ");
-#endif 
+        min_vol_reached_ = true;
+      } else {
+        dynamic_mixer.set_volume(VOLUME);
+        if (SFX_volmax) {
+          hybrid_font.PlayCommon(&SFX_volmax);
+        } else {
+          beeper.Beep(0.5, 3000);
+        }
+        STDOUT.print("Maximum Volume: ");
+        min_vol_reached_ = false;
+      }
+#else
+      if (SFX_volmin) {
+        hybrid_font.PlayCommon(&SFX_volmin);
+      } else {
+        beeper.Beep(0.5, 1000);
+      }
+      STDOUT.print("Minimum Volume: ");
+#endif
     }
   }
 
-  //  BLADE ID OPTIONS AND ARRAY MANAGEMENT
-  //  True BladeID, runs scan on-demand with unique 'bladeid' ident sound.
+  // BLADE ID OPTIONS AND ARRAY MANAGEMENT
+  // True BladeID, runs scan on-demand with unique 'bladeid' ident sound.
 #ifdef SABERSENSE_BLADE_ID
 #ifndef ENABLE_POWER_FOR_ID    
 #error "SABERSENSE_BLADE_ID requires ENABLE_POWER_FOR_ID to be defined."
 #endif
 
-    bool IsBladeidSoundPlaying() {
-      return !!GetWavPlayerPlaying(&SFX_bladeid);
-    }
-#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  //  Plays 'bladeid' sound AND 'font' sound.
-    void TriggerBladeID() {
-      FindBladeAgain();
-        SFX_bladeid.Select(current_config - blades);
-        hybrid_font.PlayCommon(&SFX_bladeid);
-          //  Calls Loop function to handle waiting for effect before running DoNewFont.
-          do_font_after_sound_ = !do_font_after_sound_;
-        }
+  bool IsBladeidSoundPlaying() {
+    return !!GetWavPlayerPlaying(&SFX_bladeid);
+  }
+#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'bladeid' sound AND 'font' sound.
+  void TriggerBladeID() {
+    FindBladeAgain();
+    SFX_bladeid.Select(current_config - blades);
+    hybrid_font.PlayCommon(&SFX_bladeid);
+    // Calls Loop function to handle waiting for effect before running DoNewFont.
+    do_font_after_sound_ = !do_font_after_sound_;
+  }
 #else
-    //  Plays 'bladeid' sound only, or 'font' sound if no 'bladeid' sound available.
-    void TriggerBladeID() {
-      FindBladeAgain();
-        if (SFX_bladeid) {
-          SFX_bladeid.Select(current_config - blades);
-          hybrid_font.PlayCommon(&SFX_bladeid);  //  Play 'bladeid' sound file if available.
-        } else {
-        SaberBase::DoNewFont();  //  Play font ident if 'bladeid' sound file missing.
-        }
+  // Plays 'bladeid' sound only, or 'font' sound if no 'bladeid' sound available.
+  void TriggerBladeID() {
+    FindBladeAgain();
+    if (SFX_bladeid) {
+      SFX_bladeid.Select(current_config - blades);
+      hybrid_font.PlayCommon(&SFX_bladeid);  // Play 'bladeid' sound file if available.
+    } else {
+      SaberBase::DoNewFont();  // Play font ident if 'bladeid' sound file missing.
     }
+  }
 #endif
 #endif
 
-    //  Manual Array Selector, switches on-demand to next array, plays 'array' ident sound. 
+  // Manual Array Selector, switches on-demand to next array, plays 'array' ident sound. 
 #ifdef SABERSENSE_ARRAY_SELECTOR
-#ifdef SABERSENSE_BLADE_ID    //  Only one Sabersense BladeID standard permitted.
+#ifdef SABERSENSE_BLADE_ID    // Only one Sabersense BladeID standard permitted.
 #error "SABERSENSE_ARRAY_SELECTOR and SABERSENSE_BLADE_ID cannot be defined at the same time."
 #endif
-    bool IsArraySoundPlaying() {
-     return !!GetWavPlayerPlaying(&SFX_array);
-    } 
-#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  //  Plays 'array' sound AND 'font' sound.
-    void NextBladeArray() {
-      FakeFindBladeAgain();
-        SFX_array.Select(current_config - blades);
-        hybrid_font.PlayCommon(&SFX_array);
-          //  Calls Loop function to handle waiting for effect before running DoNewFont.
-          do_font_after_sound_ = !do_font_after_sound_;
-        }
+  bool IsArraySoundPlaying() {
+    return !!GetWavPlayerPlaying(&SFX_array);
+  } 
+#ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'array' sound AND 'font' sound.
+  void NextBladeArray() {
+    FakeFindBladeAgain();
+    SFX_array.Select(current_config - blades);
+    hybrid_font.PlayCommon(&SFX_array);
+    // Calls Loop function to handle waiting for effect before running DoNewFont.
+    do_font_after_sound_ = !do_font_after_sound_;
+  }
 #else
-    //  Plays 'array' sound only, or 'font' sound if no 'array' sound available.
-    void NextBladeArray() {
-      FakeFindBladeAgain();
-        if (SFX_array) {
-          SFX_array.Select(current_config - blades);
-          hybrid_font.PlayCommon(&SFX_array);  //  Play 'array' sound file if available.
-        } else {
-        SaberBase::DoNewFont();  //  Play font ident if 'array' sound file missing.
-        }
+  // Plays 'array' sound only, or 'font' sound if no 'array' sound available.
+  void NextBladeArray() {
+    FakeFindBladeAgain();
+    if (SFX_array) {
+      SFX_array.Select(current_config - blades);
+      hybrid_font.PlayCommon(&SFX_array);  // Play 'array' sound file if available.
+    } else {
+      SaberBase::DoNewFont();  // Play font ident if 'array' sound file missing.
     }
+  }
 #endif
 
-  //  Manual Blade Array Selection version of FindBladeAgain()
+// Manual Blade Array Selection version of FindBladeAgain()
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
 #undef ACTIVATE
 #define ACTIVATE(N) do {                        \
-    if (!current_config->blade##N) {            \
-      goto bad_blade;                           \
-    }                                           \
-    current_config->blade##N->Activate();       \
-  } while(0);
+  if (!current_config->blade##N) {            \
+    goto bad_blade;                           \
+  }                                           \
+  current_config->blade##N->Activate();       \
+} while(0);
 #else
 #undef ACTIVATE
 #define ACTIVATE(N) do {                        \
-    if (!current_config->blade##N) {            \
-      goto bad_blade;                           \
-    }                                           \
-    current_config->blade##N->Activate(N);      \
-  } while(0);
+  if (!current_config->blade##N) {            \
+    goto bad_blade;                           \
+  }                                           \
+  current_config->blade##N->Activate(N);      \
+} while(0);
 #endif
 
-  void FakeFindBladeAgain() {
-    // Reverse everything FindBladeAgain does, except for recalculating best_config.
-    ONCEPERBLADE(UNSET_BLADE_STYLE)
+void FakeFindBladeAgain() {
+  // Reverse everything FindBladeAgain does, except for recalculating best_config.
+  ONCEPERBLADE(UNSET_BLADE_STYLE)
 #undef DEACTIVATE
 #define DEACTIVATE(N) do {                      \
-    if (current_config->blade##N)               \
-      current_config->blade##N->Deactivate();   \
-  } while(0);
-    ONCEPERBLADE(DEACTIVATE);
-    SaveVolumeIfNeeded();
-      if (fusor.angle1() > 0) {
-        //  Cycle forwards (next array) if hilt pointing up...
-        current_config = blades + (current_config - blades + 1) % NELEM(blades);
-      } else {
-        //  Cycle backwards (previous array) if hilt pointing down.
-        current_config = blades + (current_config - blades - 1) % NELEM(blades);
-      }   
-
-    ONCEPERBLADE(ACTIVATE);
-    RestoreGlobalState();
-#ifdef SAVE_PRESET
-    ResumePreset();
-#else
-    SetPreset(0, false);
-#endif // SAVE_PRESET
-//    PVLOG_NORMAL << "** FakeFindBladeAgain() Completed\n";
-    return;    
-#if NUM_BLADES != 0
-  bad_blade:
-    ProffieOSErrors::error_in_blade_array();
-#endif
+  if (current_config->blade##N)               \
+    current_config->blade##N->Deactivate();   \
+} while(0);
+  ONCEPERBLADE(DEACTIVATE);
+  SaveVolumeIfNeeded();
+  if (fusor.angle1() > 0) {
+    // Cycle forwards (next array) if hilt pointing up...
+    current_config = blades + (current_config - blades + 1) % NELEM(blades);
+  } else {
+    // Cycle backwards (previous array) if hilt pointing down.
+    current_config = blades + (current_config - blades - 1) % NELEM(blades);
   }
+
+  ONCEPERBLADE(ACTIVATE);
+  RestoreGlobalState();
+#ifdef SAVE_PRESET
+  ResumePreset();
+#else
+  SetPreset(0, false);
+#endif // SAVE_PRESET
+  // PVLOG_NORMAL << "** FakeFindBladeAgain() Completed\n";
+  return;
+#if NUM_BLADES != 0
+bad_blade:
+  ProffieOSErrors::error_in_blade_array();
+#endif
+}
 #endif 
 
-  //  RESET FACTORY DEFAULTS (Delete Save Files).
-  //  Script to determine if sound effects have finished.
+// RESET FACTORY DEFAULTS (Delete Save Files).
+// Script to determine if sound effects have finished.
 #ifdef SABERSENSE_ENABLE_RESET
-    bool IsResetSoundPlaying() {
-     return !!GetWavPlayerPlaying(&SFX_reset);
-    }
-    bool IsBootSoundPlaying() {
-     return !!GetWavPlayerPlaying(&SFX_boot);
-    }
+bool IsResetSoundPlaying() {
+  return !!GetWavPlayerPlaying(&SFX_reset);
+}
+bool IsBootSoundPlaying() {
+  return !!GetWavPlayerPlaying(&SFX_boot);
+}
 #endif
 
-    //  CLICK PLAYER FOR BUTTON PRESSES (optional).
-    void PlaySound(const char* sound) {
-      RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
-       if (player) {
-         if (!player->PlayInCurrentDir(sound)) player->Play(sound);
-       }
-    } 
-    bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
-      if (GetWavPlayerPlaying(&SFX_boot)) return false;
-      switch (EVENTID(button, event, modifiers)) {
-        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
-        case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
-        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
-        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
-          SaberBase::RequestMotion();
-#ifdef SABERSENSE_BUTTON_CLICKER 
-          //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
-          PlaySound("press.wav");  //  Requires press.wav file to work.
-#endif
-            return false;
-        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-        case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
-        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-        case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+// CLICK PLAYER FOR BUTTON PRESSES (optional).
+void PlaySound(const char* sound) {
+  RefPtr<BufferedWavPlayer> player = GetFreeWavPlayer();
+  if (player) {
+    if (!player->PlayInCurrentDir(sound)) player->Play(sound);
+  }
+}
+
+bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
+  if (GetWavPlayerPlaying(&SFX_boot)) return false;
+  switch (EVENTID(button, event, modifiers)) {
+    case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_POWER, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+    case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ANY_BUTTON | MODE_OFF):
+      SaberBase::RequestMotion();
 #ifdef SABERSENSE_BUTTON_CLICKER
-          //  Intended for Scavenger hilt where wheel makes tactile feel difficult.
-          PlaySound("release.wav");  //  Requires release.wav file to work.
+      // Intended for Scavenger hilt where wheel makes tactile feel difficult.
+      PlaySound("press.wav");  // Requires press.wav file to work.
 #endif
-          if (SaberBase::Lockup()) {
-            SaberBase::DoEndLockup();
-            SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
-          return true;
-        } else {
-          return false;
-        }
-        
-        case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
-        case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
-          if (accel_.x < -0.15) {
-            pointing_down_ = true;
-          } else {
-            pointing_down_ = false;
-          }
-          return true;
+      return false;
+    case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_POWER, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+    case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+    case EVENTID(BUTTON_AUX, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_OFF):
+#ifdef SABERSENSE_BUTTON_CLICKER
+      // Intended for Scavenger hilt where wheel makes tactile feel difficult.
+      PlaySound("release.wav");  // Requires release.wav file to work.
+#endif
+      if (SaberBase::Lockup()) {
+        SaberBase::DoEndLockup();
+        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+        return true;
+      } else {
+        return false;
+      }
 
-  //  GESTURE CONTROLS
+    case EVENTID(BUTTON_AUX, EVENT_PRESSED, MODE_ON):
+    case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_ON):
+      if (accel_.x < -0.15) {
+        pointing_down_ = true;
+      } else {
+        pointing_down_ = false;
+      }
+      return true;
+
+    // GESTURE CONTROLS
 #ifdef SABERSENSE_SWING_ON
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_OFF):
       // Motion chip startup on boot can create false ignition, so delay SwingOn at boot for 3000ms
@@ -668,13 +664,12 @@ public:
       }
       return true;
 #endif
- 
+
 #ifdef SABERSENSE_TWIST_ON
     case EVENTID(BUTTON_NONE, EVENT_TWIST, MODE_OFF):
-      //  Delay twist events to prevent false trigger from over twisting
-      if (millis() - last_twist_ > 2000 &&
-        millis() - saber_off_time_ > 1000) {
-          FastOn();
+      // Delay twist events to prevent false trigger from over twisting
+      if (millis() - last_twist_ > 2000 && millis() - saber_off_time_ > 1000) {
+        FastOn();
         last_twist_ = millis();
       }
       return true;
@@ -685,8 +680,8 @@ public:
       // Delay twist events to prevent false trigger from over twisting
       if (millis() - last_twist_ > 3000) {
         Off();
-      last_twist_ = millis();
-      saber_off_time_ = millis();
+        last_twist_ = millis();
+        saber_off_time_ = millis();
       }
       return true;
 #endif
@@ -707,76 +702,76 @@ public:
       return true;
 #endif
 
-    //  MAIN ACTIVATION
-    //  Saber ON AND Volume Adjust, 1 and 2 Button.
+    // MAIN ACTIVATION
+    // Saber ON AND Volume Adjust, 1 and 2 Button.
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
-      IgnoreClash(100);  //  Hopefully prevents false clashes due to 'clicky' button.
-                         //  Low threshold so as not to conflict with 1-button volume menu access.
-        if (!mode_volume_) {
-          On();
+      IgnoreClash(100);  // Hopefully prevents false clashes due to 'clicky' button.
+                         // Low threshold so as not to conflict with 1-button volume menu access.
+      if (!mode_volume_) {
+        On();
+      } else {
+        if (fusor.angle1() > 0) {
+          VolumeUp();
         } else {
-          if (fusor.angle1() > 0) {
-            VolumeUp();
-          } else {
-            VolumeDown();
-          }
+          VolumeDown();
         }
-        return true;
+      }
+      return true;
 
-    //  1 Button Activate Muted and next/previous preset.
+    // 1 Button Activate Muted and next/previous preset.
 #if NUM_BUTTONS == 1
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
-      IgnoreClash(100);  //  Hopefully prevents false clashes due to 'clicky' button.
-                         //  Low threshold so as not to conflict with 1-button volume menu access.
-      #define DEGREES_TO_RADIANS (M_PI / 180)
-        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-          // If pointing up
-          next_preset();
-        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-          // If pointing down
-          previous_preset();
-        } else {
-          // If horizontal
-          if (SetMute(true)) {
+      IgnoreClash(100);  // Hopefully prevents false clashes due to 'clicky' button.
+                         // Low threshold so as not to conflict with 1-button volume menu access.
+#define DEGREES_TO_RADIANS (M_PI / 180)
+      if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+        // If pointing up
+        next_preset();
+      } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+        // If pointing down
+        previous_preset();
+      } else {
+        // If horizontal
+        if (SetMute(true)) {
           unmute_on_deactivation_ = true;
-            On();
+          On();
         }
       }
 #ifdef SAVE_PRESET
-        SaveState(current_preset_.preset_num);
+      SaveState(current_preset_.preset_num);
 #endif
-return true;
+      return true;
 #endif
 
-    //  2 Button Activate Muted 
+    // 2 Button Activate Muted
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_POWER, EVENT_FIRST_CLICK_LONG, MODE_OFF):
       if (SetMute(true)) {
         unmute_on_deactivation_ = true;
-          On();
+        On();
       }
       return true;
 #endif
- 
-    //  Turn Blade OFF
+
+    // Turn Blade OFF
     case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_MEDIUM, MODE_ON):
       if (!SaberBase::Lockup()) {
 #ifndef DISABLE_COLOR_CHANGE
         if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-          //  Just exit color change mode.
-          //  Don't turn saber off.
+          // Just exit color change mode.
+          // Don't turn saber off.
           ToggleColorChangeMode();
-        return true;
-      } 
+          return true;
+        }
 #endif
         Off();
       }
-    saber_off_time_ = millis();
-    swing_blast_ = false;
-    return true;
+      saber_off_time_ = millis();
+      swing_blast_ = false;
+      return true;
 
-    //  PRESET NAVIGATION 
-    //  Next/previous preset and volume down. Next preset (UP), previous preset (DOWN).
+    // PRESET NAVIGATION
+    // Next/previous preset and volume down. Next preset (UP), previous preset (DOWN).
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_OFF):
       // backwards if pointing down
@@ -788,10 +783,10 @@ return true;
 #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
 #endif
-return true;
+      return true;
 #endif
 
-    //  2 button: Previous Preset, retained legacy control.
+    // 2 button: Previous Preset, retained legacy control.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_POWER, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_AUX):
       if (!mode_volume_) {
@@ -800,436 +795,436 @@ return true;
       return true;
 #endif
 
-    //  Multiple preset skips - 2 button sabers only.
+    // Multiple preset skips - 2 button sabers only.
 #if NUM_BUTTONS == 2
-    //  Skips forward five presets pointing up, back five pointing down.
+    // Skips forward five presets pointing up, back five pointing down.
     case EVENTID(BUTTON_AUX, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
-      //  Backwards if pointing down
+      // Backwards if pointing down
       SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -5 : 5), true);
 #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
 #endif
-return true;
- 
-    //  Skips forward ten presets pointing up, back ten pointing down.
+      return true;
+
+    // Skips forward ten presets pointing up, back ten pointing down.
     case EVENTID(BUTTON_AUX, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-      //  Backwards if pointing down
+      // Backwards if pointing down
       SetPreset(current_preset_.preset_num + (fusor.angle1() < -M_PI / 4 ? -10 : 10), true);
 #ifdef SAVE_PRESET
       SaveState(current_preset_.preset_num);
 #endif
-return true;
+      return true;
 #endif
 
-    //  Skips to first preset (up) or last preset (down)
-    //  or middle preset if horizontal:
+    // Skips to first preset (up) or last preset (down)
+    // or middle preset if horizontal:
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD_LONG, MODE_OFF):
 #endif
     case EVENTID(BUTTON_POWER, EVENT_FIRST_HELD_LONG, MODE_OFF):
-      #define DEGREES_TO_RADIANS (M_PI / 180)
-        if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
-          // If pointing up
-          SetPreset(0, true);
-        } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
-          // If pointing down
-          SetPreset(-1, true);
-        } else {
-          // If horizontal
-          CurrentPreset tmp;
-          tmp.SetPreset(-1);
-          SetPreset(tmp.preset_num / 2, true);
-        }
+#define DEGREES_TO_RADIANS (M_PI / 180)
+      if (fusor.angle1() > 45 * DEGREES_TO_RADIANS) {
+        // If pointing up
+        SetPreset(0, true);
+      } else if (fusor.angle1() < -45 * DEGREES_TO_RADIANS) {
+        // If pointing down
+        SetPreset(-1, true);
+      } else {
+        // If horizontal
+        CurrentPreset tmp;
+        tmp.SetPreset(-1);
+        SetPreset(tmp.preset_num / 2, true);
+      }
 #ifdef SAVE_PRESET
-        SaveState(current_preset_.preset_num);
+      SaveState(current_preset_.preset_num);
 #endif
-return true;
+      return true;
 
-    //  BLADE ID OPTIONS AND ARRAY NAVIGATION
-    //  True Blade ID on-demand with BladeID audio idents.
+//  BLADE ID OPTIONS AND ARRAY NAVIGATION
+//  True Blade ID on-demand with BladeID audio idents.
 #ifdef SABERSENSE_BLADE_ID
-    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-      TriggerBladeID();
-      return true;
+case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+  TriggerBladeID();
+  return true;
 #endif
 
-    //  Manual Array Selector with Array audio idents.
-    //  Cycles through blade arrays regardless of BladeID status.
-    //  UP cycles forward, DOWN cycles back (handled in main code).
+//  Manual Array Selector with Array audio idents.
+//  Cycles through blade arrays regardless of BladeID status.
+//  UP cycles forward, DOWN cycles back (handled in main code).
 #ifdef SABERSENSE_ARRAY_SELECTOR
-    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
-      NextBladeArray(); 
-    return true;
+case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
+  NextBladeArray();
+  return true;
 #endif
 
-    //  SOUND EFFECT PLAYERS.
-    //  With Blade ON - UP for Character Quote, plays sequentially.
-    //  With Blade ON - DOWN for Force Effect, plays randomly.
-    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
-#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS  
-      //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
-      //  Quote player points upwards.
-      if (SFX_quote) {
-        if (fusor.angle1() > 0) {
-        SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
-        }
-      } else {
-        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
-      }
-      return true;
+//  SOUND EFFECT PLAYERS.
+//  With Blade ON - UP for Character Quote, plays sequentially.
+//  With Blade ON - DOWN for Force Effect, plays randomly.
+case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+#ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
+  //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
+  //  Quote player points upwards.
+  if (SFX_quote) {
+    if (fusor.angle1() > 0) {
+      SFX_quote.SelectNext();
+      SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+      SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+    }
+  } else {
+    SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+  }
+  return true;
 #else
-      //  Quote player points downwards.
-      if (SFX_quote) {
-        if (fusor.angle1() < 0) {
-        SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
-        }
-      } else {
-        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
-      }
-      return true;
+  //  Quote player points downwards.
+  if (SFX_quote) {
+    if (fusor.angle1() < 0) {
+      SFX_quote.SelectNext();
+      SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+      SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
+    }
+  } else {
+    SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
+  }
+  return true;
 #endif
 
-    //  With Blade OFF - UP for Character Quote, plays sequentially.
-    //  With Blade OFF - DOWN for Music Track.
-    case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):  
+//  With Blade OFF - UP for Character Quote, plays sequentially.
+//  With Blade OFF - DOWN for Music Track.
+case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
   // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
-      //  Quote player points upwards.
-      if (SFX_quote) {
-        if (fusor.angle1() > 0) {
-        SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          StartOrStopTrack();  // Play track for hilt pointed DOWN.
-        }
-      } else {
-        StartOrStopTrack();  // Fallback: play track if no quotes are available.
-      }
-      return true;
+  //  Quote player points upwards.
+  if (SFX_quote) {
+    if (fusor.angle1() > 0) {
+      SFX_quote.SelectNext();
+      SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+      StartOrStopTrack();  // Play track for hilt pointed DOWN.
+    }
+  } else {
+    StartOrStopTrack();  // Fallback: play track if no quotes are available.
+  }
+  return true;
 #else
-      //  Quote player points downwards.
-      if (SFX_quote) {
-        if (fusor.angle1() < 0) {
-        SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          StartOrStopTrack();  // Play track for hilt pointed DOWN.
-        }
-      } else {
-        StartOrStopTrack();  // Fallback: play track if no quotes are available.
-      }
-      return true;
+  //  Quote player points downwards.
+  if (SFX_quote) {
+    if (fusor.angle1() < 0) {
+      SFX_quote.SelectNext();
+      SaberBase::DoEffect(EFFECT_QUOTE, 0);
+    } else {
+      StartOrStopTrack();  // Play track for hilt pointed DOWN.
+    }
+  } else {
+    StartOrStopTrack();  // Fallback: play track if no quotes are available.
+  }
+  return true;
 #endif
 
-    //  COLOUR CHANGE.
+//  COLOUR CHANGE.
 #ifdef DISABLE_COLOR_CHANGE
-  #error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
+#error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
 #endif
 
-    //  1 and 2 button modes.
+//  1 and 2 button modes.
 #ifndef SABERSENSE_NO_COLOR_CHANGE
-    case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-      ToggleColorChangeMode();
-    return true;
-    //  2 button mode only.
+case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
+  ToggleColorChangeMode();
+  return true;
+//  2 button mode only.
 #if NUM_BUTTONS == 2
-    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
-      ToggleColorChangeMode();
-    return true;
+case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
+  ToggleColorChangeMode();
+  return true;
 #endif
 #endif
 
-    //  BLASTER DEFLECTION
-    //  1 Button
+//  BLASTER DEFLECTION
+//  1 Button
 #if NUM_BUTTONS == 1
-    //  1 button
-    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode();
-      } else {
-        //  Fires blast in all OSs.
-        swing_blast_ = false;
-        SaberBase::DoBlast();
-      }
-    return true;
+//  1 button
+case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+    ToggleColorChangeMode();
+  } else {
+    //  Fires blast in all OSs.
+    swing_blast_ = false;
+    SaberBase::DoBlast();
+  }
+  return true;
 #endif
 
-    //  2 Button
+//  2 Button
 #if NUM_BUTTONS == 2
-    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-      swing_blast_ = false;
-      SaberBase::DoBlast();
-    return true;
+case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+  swing_blast_ = false;
+  SaberBase::DoBlast();
+  return true;
 
-    //  Add blast to MAIN on 2-button sabers, 
-    //  plus harmonized 'Exit Colour Menu' control under OS-7.x.
-    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+//  Add blast to MAIN on 2-button sabers,
+//  plus harmonized 'Exit Colour Menu' control under OS-7.x.
+case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
 #ifdef SABERSENSE_BLAST_MAIN_AND_AUX
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode();          
-      } else {  
-        //  Fires blast in all OSs.
-        swing_blast_ = false;
-        SaberBase::DoBlast();
-      }
-      return true;
+  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+    ToggleColorChangeMode();
+  } else {
+    //  Fires blast in all OSs.
+    swing_blast_ = false;
+    SaberBase::DoBlast();
+  }
+  return true;
 #else
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode(); 
-      }
-    return true;
-#endif 
+  //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+  if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+    ToggleColorChangeMode();
+  }
+  return true;
+#endif
 #endif
 
-    //  Multi-Blaster Deflection mode
-    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
-      swing_blast_ = !swing_blast_;
-      if (swing_blast_) {
-        if (SFX_blstbgn) {
-          hybrid_font.PlayCommon(&SFX_blstbgn);
-        } else {
-          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-          }
-        } else {
-          if (SFX_blstend) {
-          hybrid_font.PlayCommon(&SFX_blstend);
-        } else {
-          hybrid_font.SB_Effect(EFFECT_BLAST, 0);
-        }
-      }
-      return true;
- 
-    case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
-      if (swing_blast_) {
-        SaberBase::DoBlast();
-      }
-      return true;
+//  Multi-Blaster Deflection mode
+case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
+  swing_blast_ = !swing_blast_;
+  if (swing_blast_) {
+    if (SFX_blstbgn) {
+      hybrid_font.PlayCommon(&SFX_blstbgn);
+    } else {
+      hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+    }
+  } else {
+    if (SFX_blstend) {
+      hybrid_font.PlayCommon(&SFX_blstend);
+    } else {
+      hybrid_font.SB_Effect(EFFECT_BLAST, 0);
+    }
+  }
+  return true;
 
-    //  LOCKUP
+case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON):
+  if (swing_blast_) {
+    SaberBase::DoBlast();
+  }
+  return true;
+
+//  LOCKUP
 #if NUM_BUTTONS == 1
-    //  1 button lockup
-    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
+//  1 button lockup
+case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_POWER):
 #elif defined(SABERSENSE_NO_LOCKUP_HOLD)
-    //  2 button lockup
-    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
+//  2 button lockup
+case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_ON | BUTTON_AUX):
 #else
-    case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
+case EVENTID(BUTTON_AUX, EVENT_FIRST_HELD, MODE_ON):
 #endif
 
-      if (accel_.x < -0.15) {
-        SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
-      } else {
-        SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
-      }
-        swing_blast_ = false;
-        SaberBase::DoBeginLockup();
-        return true;
+  if (accel_.x < -0.15) {
+    SaberBase::SetLockup(SaberBase::LOCKUP_DRAG);
+  } else {
+    SaberBase::SetLockup(SaberBase::LOCKUP_NORMAL);
+  }
+  swing_blast_ = false;
+  SaberBase::DoBeginLockup();
+  return true;
 
-    //  Lightning Block, 1 and 2 button.
-    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
-      SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
-      swing_blast_ = false;
-      SaberBase::DoBeginLockup();
-      return true;
+//  Lightning Block, 1 and 2 button.
+case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD, MODE_ON):
+  SaberBase::SetLockup(SaberBase::LOCKUP_LIGHTNING_BLOCK);
+  swing_blast_ = false;
+  SaberBase::DoBeginLockup();
+  return true;
 
-    //  Melt
-    case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
-      SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
-      swing_blast_ = false;
-      SaberBase::DoBeginLockup();
-      return true;
+//  Melt
+case EVENTID(BUTTON_NONE, EVENT_STAB, MODE_ON | BUTTON_POWER):
+  SaberBase::SetLockup(SaberBase::LOCKUP_MELT);
+  swing_blast_ = false;
+  SaberBase::DoBeginLockup();
+  return true;
 
-    case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
-      SaberBase::RequestMotion();
-    return true;
+case EVENTID(BUTTON_AUX2, EVENT_PRESSED, MODE_OFF):
+  SaberBase::RequestMotion();
+  return true;
 
-    //  ENTER VOLUME MENU
+//  ENTER VOLUME MENU
 #if NUM_BUTTONS == 1
-    //  1 button
-    case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
+//  1 button
+case EVENTID(BUTTON_NONE, EVENT_CLASH, MODE_OFF | BUTTON_POWER):
 #else
-    //  2 button
-    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
+//  2 button
+case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_OFF | BUTTON_POWER):
 #endif
-      if (!mode_volume_) {
-        mode_volume_ = true;
-        if (SFX_vmbegin) {
-          hybrid_font.PlayCommon(&SFX_vmbegin);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        STDOUT.println("Enter Volume Menu");
-      } else {
-        mode_volume_ = false;
-        if (SFX_vmend) {
-          hybrid_font.PlayCommon(&SFX_vmend);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        STDOUT.println("Exit Volume Menu");
-      }
-      return true;
+  if (!mode_volume_) {
+    mode_volume_ = true;
+    if (SFX_vmbegin) {
+      hybrid_font.PlayCommon(&SFX_vmbegin);
+    } else {
+      beeper.Beep(0.5, 3000);
+    }
+    STDOUT.println("Enter Volume Menu");
+  } else {
+    mode_volume_ = false;
+    if (SFX_vmend) {
+      hybrid_font.PlayCommon(&SFX_vmend);
+    } else {
+      beeper.Beep(0.5, 3000);
+    }
+    STDOUT.println("Exit Volume Menu");
+  }
+  return true;
 
-//  RESTORE FACTORY DEFAULTS 
+//  RESTORE FACTORY DEFAULTS
 //  Deletes all save files in root and first-level directories.
 #ifdef SABERSENSE_ENABLE_RESET
-    case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
-      // Lock SD card to prevent other operations during deletion.        
-      LOCK_SD(true);
-        const char* filesToDelete[] = {   
-        "curstate.ini",
-        "curstate.tmp",
-        "preset.ini",
-        "preset.tmp",
-        "global.ini",
-        "global.tmp"
-        };
-      // Delete files from the root directory.
-          for (const char* targetFile : filesToDelete) {
-            if (LSFS::Exists(targetFile)) {
-            LSFS::Remove(targetFile);
-            Serial.print("Deleted from root: ");
-            Serial.println(targetFile);
-            }
-          }
-        // Iterate over the save directories listed in blades[].
-        for (const BladeConfig& blade : blades) {
-          const char* saveDirName = blade.save_dir; // Replace with the correct field.
-
-        if (saveDirName && strlen(saveDirName) > 0) {
-          // Construct the path to the save directory.
-          PathHelper saveDirPath("/");
-          saveDirPath.Append(saveDirName);
-
-        // Iterate over the files to delete in this save directory.
-        for (const char* targetFile : filesToDelete) {
-          PathHelper filePath(saveDirPath);
-          filePath.Append(targetFile);
-
-            // If the file exists in this directory, delete it.
-            if (LSFS::Exists(filePath)) {
-              LSFS::Remove(filePath);
-              Serial.print("Deleted from ");
-              Serial.print(saveDirPath);
-              Serial.print(": ");
-              Serial.println(targetFile);
-              }
-            }
-          }
-        }
-      // Unlock SD card after deletion is complete.
-      LOCK_SD(false);
-    
-    if (SFX_reset) {  // Optional confirmation sound file 'reset'.
-      hybrid_font.PlayCommon(&SFX_reset);
-      while(IsResetSoundPlaying());  // Lock system while sound finishes.
-    } else {
-      beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
-      delay(800); // Allow beep to play.
+case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
+  // Lock SD card to prevent other operations during deletion.        
+  LOCK_SD(true);
+  const char* filesToDelete[] = {   
+    "curstate.ini",
+    "curstate.tmp",
+    "preset.ini",
+    "preset.tmp",
+    "global.ini",
+    "global.tmp"
+  };
+  // Delete files from the root directory.
+  for (const char* targetFile : filesToDelete) {
+    if (LSFS::Exists(targetFile)) {
+      LSFS::Remove(targetFile);
+      Serial.print("Deleted from root: ");
+      Serial.println(targetFile);
     }
-    STM32.reset(); // Reboot saber.
   }
-  break;
+  // Iterate over the save directories listed in blades[].
+  for (const BladeConfig& blade : blades) {
+    const char* saveDirName = blade.save_dir; // Replace with the correct field.
+
+    if (saveDirName && strlen(saveDirName) > 0) {
+      // Construct the path to the save directory.
+      PathHelper saveDirPath("/");
+      saveDirPath.Append(saveDirName);
+
+      // Iterate over the files to delete in this save directory.
+      for (const char* targetFile : filesToDelete) {
+        PathHelper filePath(saveDirPath);
+        filePath.Append(targetFile);
+
+        // If the file exists in this directory, delete it.
+        if (LSFS::Exists(filePath)) {
+          LSFS::Remove(filePath);
+          Serial.print("Deleted from ");
+          Serial.print(saveDirPath);
+          Serial.print(": ");
+          Serial.println(targetFile);
+        }
+      }
+    }
+  }
+  // Unlock SD card after deletion is complete.
+  LOCK_SD(false);
+
+  if (SFX_reset) {  // Optional confirmation sound file 'reset'.
+    hybrid_font.PlayCommon(&SFX_reset);
+    while(IsResetSoundPlaying());  // Lock system while sound finishes.
+  } else {
+    beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
+    delay(800); // Allow beep to play.
+  }
+  STM32.reset(); // Reboot saber.
+}
+break;
 #endif
 
-    //  BATTERY LEVEL
-    case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
-      talkie.SayDigit((int)floorf(battery_monitor.battery()));
-      talkie.Say(spPOINT);
-      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
-      talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
-      talkie.Say(spVOLTS);
-      SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
-    return true;
+//  BATTERY LEVEL
+case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
+  talkie.SayDigit((int)floorf(battery_monitor.battery()));
+  talkie.Say(spPOINT);
+  talkie.SayDigit(((int)floorf(battery_monitor.battery() * 10)) % 10);
+  talkie.SayDigit(((int)floorf(battery_monitor.battery() * 100)) % 10);
+  talkie.Say(spVOLTS);
+  SaberBase::DoEffect(EFFECT_BATTERY_LEVEL, 0);
+  return true;
 
 #ifdef BLADE_DETECT_PIN
-    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
-    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
-      //  Might need to do something cleaner, but let's try this for now.
-      blade_detected_ = true;
-      FindBladeAgain();
-      SaberBase::DoBladeDetect(true);
-      return true;
- 
-    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
-    case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
-      //  Might need to do something cleaner, but let's try this for now.
-      blade_detected_ = false;
-      FindBladeAgain();
-      SaberBase::DoBladeDetect(false);
-      return true;
+case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_ON):
+case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_ON, MODE_ANY_BUTTON | MODE_OFF):
+  //  Might need to do something cleaner, but let's try this for now.
+  blade_detected_ = true;
+  FindBladeAgain();
+  SaberBase::DoBladeDetect(true);
+  return true;
+
+case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_ON):
+case EVENTID(BUTTON_BLADE_DETECT, EVENT_LATCH_OFF, MODE_ANY_BUTTON | MODE_OFF):
+  //  Might need to do something cleaner, but let's try this for now.
+  blade_detected_ = false;
+  FindBladeAgain();
+  SaberBase::DoBladeDetect(false);
+  return true;
 #endif
 
-  // Events that needs to be handled regardless of what other buttons
-  // are pressed.
-    case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
-      if (SaberBase::Lockup()) {
-        SaberBase::DoEndLockup();
-        SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
-        return true;
-      }
-    }
-    return false;
+// Events that need to be handled regardless of what other buttons are pressed.
+case EVENTID(BUTTON_AUX2, EVENT_RELEASED, MODE_ANY_BUTTON | MODE_ON):
+  if (SaberBase::Lockup()) {
+    SaberBase::DoEndLockup();
+    SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
+    return true;
   }
+}
+return false;
+}
 
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-  void SB_Effect(EffectType effect, float location) override  //  Required for ProffieOS 7.x.
+void SB_Effect(EffectType effect, float location) override  //  Required for ProffieOS 7.x.
 #else
-  void SB_Effect(EffectType effect, EffectLocation location) override  //  For ProffieOS 8.x.
+void SB_Effect(EffectType effect, EffectLocation location) override  //  For ProffieOS 8.x.
 #endif  
-  {
+{
   switch (effect) {
 #ifdef SABERSENSE_OS7_LEGACY_SUPPORT
-    case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return; 
+    case EFFECT_QUOTE: 
+      hybrid_font.PlayCommon(&SFX_quote); 
+      return; 
 #endif
-      case EFFECT_POWERSAVE:  
-        if (SFX_dim) {
-          hybrid_font.PlayCommon(&SFX_dim);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        return;
-      case EFFECT_BATTERY_LEVEL:
-        if (SFX_battery) {
-          hybrid_font.PlayCommon(&SFX_battery);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        return;
-      case EFFECT_FAST_ON:
-        if (SFX_faston) {
-          hybrid_font.PlayCommon(&SFX_faston);
-        }
-        return;
- 
-      default: break; // avoids compiler warning
+    case EFFECT_POWERSAVE:  
+      if (SFX_dim) {
+        hybrid_font.PlayCommon(&SFX_dim);
+      } else {
+        beeper.Beep(0.5, 3000);
       }
-    }
+      return;
+    case EFFECT_BATTERY_LEVEL:
+      if (SFX_battery) {
+        hybrid_font.PlayCommon(&SFX_battery);
+      } else {
+        beeper.Beep(0.5, 3000);
+      }
+      return;
+    case EFFECT_FAST_ON:
+      if (SFX_faston) {
+        hybrid_font.PlayCommon(&SFX_faston);
+      }
+      return;
 
-  private:
-    bool do_font_after_sound_ = false;
-    bool pointing_down_ = false;
-    bool swing_blast_ = false;
-    bool mode_volume_ = false;
-    bool auto_lockup_on_ = false;
-    bool auto_melt_on_ = false;
-    bool max_vol_reached_ = false;
-    bool min_vol_reached_ = false;
-    uint32_t thrust_begin_millis_ = millis();
-    uint32_t push_begin_millis_ = millis();
-    uint32_t clash_impact_millis_ = millis();
-    uint32_t last_twist_ = millis();
-    uint32_t last_push_ = millis();
-    uint32_t saber_off_time_ = millis();
-  };
- 
+    default: break; // avoids compiler warning
+  }
+}
+
+private:
+  bool do_font_after_sound_ = false;
+  bool pointing_down_ = false;
+  bool swing_blast_ = false;
+  bool mode_volume_ = false;
+  bool auto_lockup_on_ = false;
+  bool auto_melt_on_ = false;
+  bool max_vol_reached_ = false;
+  bool min_vol_reached_ = false;
+  uint32_t thrust_begin_millis_ = millis();
+  uint32_t push_begin_millis_ = millis();
+  uint32_t clash_impact_millis_ = millis();
+  uint32_t last_twist_ = millis();
+  uint32_t last_push_ = millis();
+  uint32_t saber_off_time_ = millis();
+};
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -539,6 +539,7 @@ public:
         } else {
         SaberBase::DoNewFont();  //  Play font ident if 'bladeid' sound file missing.
         }
+    }
 #endif
 #endif
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -325,10 +325,10 @@ public:
     if (SaberBase::IsOn()) {
       DetectSwing();
       if (auto_lockup_on_ &&
-        !swinging_ &&
-        fusor.swing_speed() > 120 &&
-        millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
-        SaberBase::Lockup()) {
+          !swinging_ &&
+          fusor.swing_speed() > 120 &&
+          millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
+          SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_lockup_on_ = false;
@@ -400,7 +400,7 @@ public:
     STDOUT.println("Volume up");
     if (dynamic_mixer.get_volume() < VOLUME) {
       dynamic_mixer.set_volume(std::min<int>(VOLUME + VOLUME * 0.1,
-        dynamic_mixer.get_volume() + VOLUME * 0.10));
+          dynamic_mixer.get_volume() + VOLUME * 0.10));
       if (SFX_volup) {
         hybrid_font.PlayCommon(&SFX_volup);
       } else {

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -100,7 +100,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click, hilt pointing down. **
   Speak battery voltage     Fast double-click-and-hold while OFF.
   Run BladeID/Array Select  Fast triple-click while OFF. (Applicable installs only).
-  Restore Factory Defaults  Fast four-clicks while OFF, hold on last click. ***
+  Restore Factory Defaults  Fast four-clicks while OFF, hold on last click.
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold and clash while OFF.
     Volume up               Click while in VOLUME MENU, hilt pointing up.
@@ -131,7 +131,6 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
-  *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
 
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
@@ -157,7 +156,7 @@ FUNCTIONS WITH BLADE OFF
   Play Music Track          Fast double-click MAIN, pointing down. **
   Speak battery voltage     Fast double-click-and-hold MAIN.
   Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
-  Restore Factory Defaults  Fast four-clicks MAIN, hold on last click. ***
+  Restore Factory Defaults  Fast four-clicks MAIN, hold on last click.
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
     Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
@@ -192,8 +191,7 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 
   *   = Gesture ignitions also available via defines.
   **  = Audio player orientations can be reversed using SABERSENSE_FLIP_AUDIO_PLAYERS define.
-  *** = Feature must be enabled in config file using SABERSENSE_ENABLE_RESET define.
-
+  
 ===========================================================
 =================== SABERSENSE DEFINES ====================
 
@@ -238,10 +236,10 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   where wheel makes tactile feel difficult.
   Requires press.wav and release.wav files to work.
 
-#define SABERSENSE_ENABLE_RESET
-  Enables system to be completely reset to 'factory defaults'
-  i.e. original config, using button press to delete
-  all save files.
+#define SABERSENSE_DISABLE_RESET
+  By default, all save files can be deleted with
+  button press, effectively restoring 'factory' defaults.
+  This define disables that feature.
 
 #define SABERSENSE_NO_COLOR_CHANGE
   Use instead of DISABLE_COLOR_CHANGE.
@@ -592,7 +590,7 @@ bad_blade:
 
 // RESET FACTORY DEFAULTS (Delete Save Files).
 // Script to determine if sound effects have finished.
-#ifdef SABERSENSE_ENABLE_RESET
+#ifndef SABERSENSE_DISABLE_RESET
 bool IsSoundPlaying(const Effect* sound) {
   return !!GetWavPlayerPlaying(sound);
 }
@@ -698,12 +696,17 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       if (!mode_volume_) {
         On();
       } else {
+#if NUM_BUTTONS == 1
         if (fusor.angle1() > 0) {
           VolumeUp();
         } else {
           VolumeDown();
         }
       }
+#else
+        VolumeUp();
+      }
+#endif
       return true;
 
     // 1 Button Activate Muted and next/previous preset.
@@ -929,6 +932,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
 
     // BLASTER DEFLECTION
+    // 1 Button
 #if NUM_BUTTONS == 1
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
       swing_blast_ = false;
@@ -936,6 +940,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       return true;
 #endif
 
+    // 2 Button
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
 #ifdef SABERSENSE_BLAST_MAIN_AND_AUX
@@ -1037,7 +1042,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 
     // RESTORE FACTORY DEFAULTS
     // Deletes all save files in root and first-level directories.
-#ifdef SABERSENSE_ENABLE_RESET
+#ifndef SABERSENSE_DISABLE_RESET
     case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD, MODE_OFF): {
       // Lock SD card to prevent other operations during deletion.
       LOCK_SD(true);
@@ -1087,7 +1092,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 
       if (SFX_reset) {  // Optional confirmation sound file 'reset'.
         hybrid_font.PlayCommon(&SFX_reset);
-        while(IsSoundPlaying(&SFX_reset)); // Lock system while sound finishes.
+        while(IsSoundPlaying(&SFX_reset));  // Lock system while sound finishes.
       } else {
         beeper.Beep(0.5, 2000); // Generate beep to confirm reset.
         delay(800); // Allow beep to play.

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -4,7 +4,6 @@
 ================            by            ==================
 ================       CHRIS CARTER       ==================
 ============================================================
-V.8-142.
 
 Built on Matthew McGeary's SA22C button prop file for one
 and two button replica lightsabers. Modified by Chris
@@ -50,22 +49,22 @@ states, subject to inevitable and obvious variants.
 
 Hence:
   ONE AND TWO BUTTON:
-      Single click MAIN always lights the blade...
+      Single click POWER always lights the blade...
         Short click lights blade with sound
         Long click lights blade mute
 
-      Double click MAIN always plays a sound file...
+      Double click POWER always plays a sound file...
         Character Quote or Music track with blade OFF
         Character Quote or Force Effect with blade ON
         Battery level announcement if held down on second click
 
-      Holding down MAIN (1-button) or AUX (2-button)
+      Holding down POWER (1-button) or AUX (2-button)
       and waiting with blade OFF always skips to specific preset...
         Hilt pointing up - first preset
         Hilt horizontal - middle preset
         Hilt pointing down - last preset
 
-      Triple-clicking MAIN is always a saber management feature...
+      Triple-clicking POWER is always a saber management feature...
         Colour change with blade ON
         BladeID/Array Switch with blade OFF
 
@@ -76,14 +75,14 @@ Hence:
         Double short click - five presets
         Triple short click - ten presets
 
-      Holding MAIN and short clicking AUX always enters a control menu...
+      Holding POWER and short clicking AUX always enters a control menu...
         Colour change with blade ON
         Volume menu with blade OFF
 
 ==========================================================
 =================== 1 BUTTON CONTROLS ====================
 
-MAIN FUNCTIONS
+POWER FUNCTIONS
   Activate blade            Short click while OFF. *
   Activate blade mute       Long click while OFF, hilt horizontal.
                               (Hold for one second then release).
@@ -136,15 +135,15 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 ============================================================
 ===================== 2 BUTTON CONTROLS ====================
 
-MAIN FUNCTIONS
-  Activate blade            Short click MAIN. *
-  Activate blade mute       Long click MAIN (hold for one second then release).
-  Deactivate blade          Press and hold MAIN and wait until blade is off.
+POWER FUNCTIONS
+  Activate blade            Short click POWER. *
+  Activate blade mute       Long click POWER (hold for one second then release).
+  Deactivate blade          Press and hold POWER and wait until blade is off.
 
 FUNCTIONS WITH BLADE OFF
   Next preset               Short click AUX, hilt pointing upwards.
   Previous preset           Short click AUX, hilt pointing downwards.
-  Previous preset           Hold AUX and short click MAIN.
+  Previous preset           Hold AUX and short click POWER.
                               (Duplicate legacy command).
   Skip to first preset      Press and hold any button until it switches, hilt upwards.
   Skip to middle preset     Press and hold any button until it switches, hilt horizontal.
@@ -153,15 +152,15 @@ FUNCTIONS WITH BLADE OFF
   Skip back 5 presets       Fast double-click AUX, hilt pointing downwards.
   Skip forward 10 presets   Fast triple-click AUX, hilt pointing upwards.
   Skip back 10 presets      Fast triple-click AUX, hilt pointing downwards.
-  Play Character Quote      Fast double-click MAIN, hilt pointing up, plays sequentially. **
-  Play Music Track          Fast double-click MAIN, pointing down. **
-  Speak battery voltage     Fast double-click-and-hold MAIN.
+  Play Character Quote      Fast double-click POWER, hilt pointing up, plays sequentially. **
+  Play Music Track          Fast double-click POWER, pointing down. **
+  Speak battery voltage     Fast double-click-and-hold POWER.
   Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
-  Restore Factory Defaults  Fast four-clicks MAIN, hold on last click.
+  Restore Factory Defaults  Fast four-clicks POWER, hold on last click.
                               Release once announcement starts.
-  Enter/Exit VOLUME MENU    Hold MAIN then quickly click AUX and release both simultaneously.
-    Volume up               Click MAIN while in VOLUME MENU, hilt pointing up.
-    Volume down             Click MAIN while in VOLUME MENU, hilt pointing down, OR click
+  Enter/Exit VOLUME MENU    Hold POWER then quickly click AUX and release both simultaneously.
+    Volume up               Click POWER while in VOLUME MENU, hilt pointing up.
+    Volume down             Click POWER while in VOLUME MENU, hilt pointing down, OR click
                               AUX while in VOLUME MENU.
                               Volume adjusts in increments per click.
                               You must exit VOLUME MENU to resume using saber normally.
@@ -169,19 +168,19 @@ FUNCTIONS WITH BLADE OFF
 FUNCTIONS WITH BLADE ON
   Blade lockup              Press and hold AUX.
   Blade tip drag            Press and hold AUX while blade is pointing down.
-  Play Character Quote      Fast double-click MAIN, hilt pointing up, plays sequentially. **
-  Force Effect              Fast double-click MAIN, hilt pointing down, plays randomly. **
-  Lightning block           Double-click MAIN and hold.
-  Melt                      Hold MAIN and stab blade tip against wall. Rotate for heat colours.
-  Blaster blocks            Short click AUX. (Add Short click MAIN using define).
-  Enter multi-blast mode    Hold MAIN while swinging for one second and release.
+  Play Character Quote      Fast double-click POWER, hilt pointing up, plays sequentially. **
+  Force Effect              Fast double-click POWER, hilt pointing down, plays randomly. **
+  Lightning block           Double-click POWER and hold.
+  Melt                      Hold POWER and stab blade tip against wall. Rotate for heat colours.
+  Blaster blocks            Short click AUX. (Add Short click POWER using define).
+  Enter multi-blast mode    Hold POWER while swinging for one second and release.
                               Saber will play two quick blasts confirming mode.
                               Swing blade to trigger blaster block.
                               To exit multi-blast mode, fast single click AUX.
 
 COLOUR CHANGE FUNCTIONS WITH BLADE ON
-  Enter COLOUR MENU         Hold MAIN then quickly click AUX and release both
-                            buttons simultaneously. Or fast triple-click MAIN.
+  Enter COLOUR MENU         Hold POWER then quickly click AUX and release both
+                            buttons simultaneously. Or fast triple-click POWER.
                               Announcement confirms you are in the COLOUR MENU.
   Cycle to next colour      Rotate hilt whilst in COLOUR MENU until desired colour is reached.
                               Most Sabersense presets have 12 colour options.
@@ -197,9 +196,12 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
 =================== SABERSENSE DEFINES ====================
 
 #define SABERSENSE_BLADE_ID
-  Replaces regular BladeID (which relies on continuous ID
-  scanning) with on-demand ID scanning.
-  Triple-click MAIN will run the scan, identify the blade
+  Replaces regular BladeID with on-demand ID scanning.
+  Normal BladeID relies either on continuous ID scanning,
+  or it only runs at specific times like bootup
+  or when changing fonts. Sabersense BladeID makes
+  BladeID scanning available as a button press.
+  Triple-click POWER will run the scan, identify the blade
   and switch to its associated array. This system prevents
   spurious ID readings switching blade when you don't want
   it to, especially if using SnapshotID.
@@ -225,11 +227,11 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   FORCE effect (ON) and music TRACK (OFF). Define acts on
   both ON and OFF states for consistency.
 
-#define SABERSENSE_BLAST_MAIN_AND_AUX
-  Adds blaster block button to MAIN as well as AUX in
-  2-button mode. Improves 1 and 2-button harmonization,
-  but makes accidental blasts more likely when double-clicking
-  MAIN for Quotes or Force Effect.
+#define SABERSENSE_BLAST_PWR_AND_AUX
+  Adds blaster block button to POWER button as well as AUX
+  in 2-button mode. Improves 1 and 2-button harmonization,
+  but makes accidental blasts more likely when double-
+  clicking POWER for Quotes or Force Effect.
 
 #define SABERSENSE_BUTTON_CLICKER
   Button Clicker to play press/release wav files when
@@ -238,16 +240,16 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Requires press.wav and release.wav files to work.
 
 #define SABERSENSE_DISABLE_RESET
-  By default, all save files can be deleted with
-  button press, effectively restoring 'factory' defaults.
+  By default, all save files can be deleted on demand with
+  a button press, effectively restoring 'factory' defaults.
   This define disables that feature.
 
 #define SABERSENSE_NO_COLOR_CHANGE
   Use instead of DISABLE_COLOR_CHANGE.
 
 #define SABERSENSE_NO_LOCKUP_HOLD
-  Applicable to two-button mode only, reverts to lockup being
-  triggered by clash while holding aux.
+  Applicable to two-button mode only, reverts to lockup
+  being triggered by clash while holding aux.
 
 GESTURE CONTROLS
   There are four gesture types: Twist, Stab, Swing and Thrust.
@@ -347,7 +349,7 @@ public:
           !swinging_ &&
           fusor.swing_speed() > 60 &&
           millis() - clash_impact_millis_ > SABERSENSE_LOCKUP_DELAY &&
-        SaberBase::Lockup()) {
+          SaberBase::Lockup()) {
         SaberBase::DoEndLockup();
         SaberBase::SetLockup(SaberBase::LOCKUP_NONE);
         auto_melt_on_ = false;
@@ -355,9 +357,9 @@ public:
 
       // EVENT_PUSH
       if (fabs(mss.x) < 3.0 &&
-        mss.y * mss.y + mss.z * mss.z > 70 &&
-            fusor.swing_speed() < 30 &&
-            fabs(fusor.gyro().x) < 10) {
+          mss.y * mss.y + mss.z * mss.z > 70 &&
+          fusor.swing_speed() < 30 &&
+          fabs(fusor.gyro().x) < 10) {
         if (millis() - push_begin_millis_ > SABERSENSE_FORCE_PUSH_LENGTH) {
           Event(BUTTON_NONE, EVENT_PUSH);
           push_begin_millis_ = millis();
@@ -389,17 +391,18 @@ public:
         thrust_begin_millis_ = millis();
       }
     }
-    // Enables sequential sounds and processes on array handling.
-    // Prop only permits one of these defines at a time.
-#ifdef SABERSENSE_BLADE_ID
-    if (do_font_after_sound_ && !IsBladeidSoundPlaying()) {
-      SaberBase::DoNewFont();
-      do_font_after_sound_ = false;
-    }
-#endif
 
+  // Enables sequential sounds and processes on array handling.
+  // Prop only permits one of these defines at a time.
+#if defined(SABERSENSE_BLADE_ID) || defined(SABERSENSE_ARRAY_SELECTOR)
+  if (do_font_after_sound_
+#ifdef SABERSENSE_BLADE_ID
+      && !GetWavPlayerPlaying(&SFX_bladeid)
+#endif
 #ifdef SABERSENSE_ARRAY_SELECTOR
-    if (do_font_after_sound_ && !IsArraySoundPlaying()) {
+      && !GetWavPlayerPlaying(&SFX_array)
+#endif
+  ) {
       SaberBase::DoNewFont();
       do_font_after_sound_ = false;
     }
@@ -420,35 +423,12 @@ public:
       STDOUT.print("Volume Up - Current Volume: ");
       STDOUT.println(dynamic_mixer.get_volume());
     } else {
-      // Cycle through ends of Volume Menu option
-#ifdef SABERSENSE_VOLUME_MENU
-      if (!max_vol_reached_) {
-        if (SFX_volmax) {
-          hybrid_font.PlayCommon(&SFX_volmax);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        STDOUT.print("Maximum Volume: ");
-        max_vol_reached_ = true;
-      } else {
-        dynamic_mixer.set_volume(std::max<int>(VOLUME * 0.1,
-            dynamic_mixer.get_volume() - VOLUME * 0.90));
-        if (SFX_volmin) {
-          hybrid_font.PlayCommon(&SFX_volmin);
-        } else {
-          beeper.Beep(0.5, 1000);
-        }
-        STDOUT.print("Minimum Volume: ");
-        max_vol_reached_ = false;
-      }
-#else
       if (SFX_volmax) {
         hybrid_font.PlayCommon(&SFX_volmax);
       } else {
         beeper.Beep(0.5, 3000);
       }
       STDOUT.print("Maximum Volume: ");
-#endif
     }
   }
 
@@ -465,33 +445,12 @@ public:
       STDOUT.print("Volume Down - Current Volume: ");
       STDOUT.println(dynamic_mixer.get_volume());
     } else {
-#ifdef SABERSENSE_VOLUME_MENU
-      if (!min_vol_reached_) {
-        if (SFX_volmin) {
-          hybrid_font.PlayCommon(&SFX_volmin);
-        } else {
-          beeper.Beep(0.5, 1000);
-        }
-        STDOUT.print("Minimum Volume: ");
-        min_vol_reached_ = true;
-      } else {
-        dynamic_mixer.set_volume(VOLUME);
-        if (SFX_volmax) {
-          hybrid_font.PlayCommon(&SFX_volmax);
-        } else {
-          beeper.Beep(0.5, 3000);
-        }
-        STDOUT.print("Maximum Volume: ");
-        min_vol_reached_ = false;
-      }
-#else
       if (SFX_volmin) {
         hybrid_font.PlayCommon(&SFX_volmin);
       } else {
         beeper.Beep(0.5, 1000);
       }
       STDOUT.print("Minimum Volume: ");
-#endif
     }
   }
 
@@ -501,10 +460,6 @@ public:
 #ifndef ENABLE_POWER_FOR_ID
 #error "SABERSENSE_BLADE_ID requires ENABLE_POWER_FOR_ID to be defined."
 #endif
-
-  bool IsBladeidSoundPlaying() {
-    return !!GetWavPlayerPlaying(&SFX_bladeid);
-  }
 
   void TriggerBladeID() {
     FindBladeAgain();
@@ -519,6 +474,10 @@ public:
     if (SFX_bladeid) {
       SFX_bladeid.Select(current_config - blades);
       hybrid_font.PlayCommon(&SFX_bladeid);  // Play 'bladeid' sound file if available.
+      int saved_volume = SFX_font.GetVolume();
+      SFX_font.SetVolume(0);  // Mute volume for font ident so that system can...
+      SaberBase::DoNewFont();  // ...run DoNewFont to ensure various initializations.
+      SFX_font.SetVolume(saved_volume);
     } else {
       SaberBase::DoNewFont();  // Play font ident if 'bladeid' sound file missing.
     }
@@ -531,9 +490,6 @@ public:
 #ifdef SABERSENSE_BLADE_ID    // Only one Sabersense BladeID standard permitted.
 #error "SABERSENSE_ARRAY_SELECTOR and SABERSENSE_BLADE_ID cannot be defined at the same time."
 #endif
-  bool IsArraySoundPlaying() {
-    return !!GetWavPlayerPlaying(&SFX_array);
-  }
 
   void NextBladeArray() {
     FakeFindBladeAgain();
@@ -548,6 +504,10 @@ public:
     if (SFX_array) {
       SFX_array.Select(current_config - blades);
       hybrid_font.PlayCommon(&SFX_array);  // Play 'array' sound file if available.
+      int saved_volume = SFX_font.GetVolume();
+      SFX_font.SetVolume(0);  // Mute volume for font ident so that system can...
+      SaberBase::DoNewFont();  // ...run DoNewFont to ensure various initializations.
+      SFX_font.SetVolume(saved_volume);
     } else {
       SaberBase::DoNewFont();  // Play font ident if 'array' sound file missing.
     }
@@ -563,6 +523,8 @@ public:
   current_config->blade##N->Activate(N);      \
 } while(0);
 
+// Runs FindBladeAgain, but ignores BladeID scan value
+// and instead simply advances to next blade array.
 void FakeFindBladeAgain() {
   ONCEPERBLADE(UNSET_BLADE_STYLE)
 #undef DEACTIVATE
@@ -942,7 +904,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     // 2 Button
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
+#ifdef SABERSENSE_BLAST_PWR_AND_AUX
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
 #endif
       swing_blast_ = false;
@@ -1063,7 +1025,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       }
       // Iterate over the save directories listed in blades[].
       for (const BladeConfig& blade : blades) {
-        const char* saveDirName = blade.save_dir; // Replace with the correct field.
+        const char* saveDirName = blade.save_dir; // Replace with correct field.
 
         if (saveDirName && strlen(saveDirName) > 0) {
           // Construct the path to the save directory.
@@ -1078,10 +1040,9 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
             // If the file exists in this directory, delete it.
             if (LSFS::Exists(filePath)) {
               LSFS::Remove(filePath);
-              Serial.print("Deleted from ");
-              Serial.print(saveDirPath);
-              Serial.print(": ");
-              Serial.println(targetFile);
+              STDOUT << "Deleted from "   \
+                  << saveDirPath << ": "  \
+                  << targetFile <<"\n";   \
             }
           }
         }

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1090,10 +1090,7 @@ return true;
         "preset.ini",
         "preset.tmp",
         "global.ini",
-        "global.tmp",
-        "tester.rtf",
-        "andme.rtf",
-        "world.rtf"
+        "global.tmp"
         };
       // Delete files from the root directory.
           for (const char* targetFile : filesToDelete) {

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/*
+/* V.8-145.
 ============================================================
 ================   SABERSENSE PROP FILE   ==================
 ================            by            ==================
@@ -468,7 +468,6 @@ public:
     hybrid_font.PlayCommon(&SFX_bladeid);
     // Calls Loop function to handle waiting for effect before running DoNewFont.
     do_font_after_sound_ = true;
-  }
 #else
   // Plays 'bladeid' sound only, or 'font' sound if no 'bladeid' sound available.
     if (SFX_bladeid) {
@@ -481,8 +480,8 @@ public:
     } else {
       SaberBase::DoNewFont();  // Play font ident if 'bladeid' sound file missing.
     }
-  }
 #endif
+  }
 #endif
 
   // Manual Array Selector, switches on-demand to next array, plays 'array' ident sound.
@@ -815,24 +814,15 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     // With Blade ON - UP for Character Quote, plays sequentially.
     // With Blade ON - DOWN for Force Effect, plays randomly.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_ON):
+      if (SFX_quote) {
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
       //  Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio player.
       //  Quote player points upwards.
-      if (SFX_quote) {
         if (fusor.angle1() > 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          SaberBase::DoForce();  // Force effect for hilt pointed DOWN.
-        }
-      } else {
-        SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
-      }
-      return true;
 #else
-      //  Quote player points downwards.
-      if (SFX_quote) {
+      // Quote player points downwards.
         if (fusor.angle1() < 0) {
+#endif
           SFX_quote.SelectNext();
           SaberBase::DoEffect(EFFECT_QUOTE, 0);
         } else {
@@ -842,29 +832,19 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         SaberBase::DoForce();  // Fallback: play force effect if no quotes are available.
       }
       return true;
-#endif
 
     //  With Blade OFF - UP for Character Quote, plays sequentially.
     //  With Blade OFF - DOWN for Music Track.
     case EVENTID(BUTTON_POWER, EVENT_SECOND_SAVED_CLICK_SHORT, MODE_OFF):
+      if (SFX_quote) {
 #ifndef SABERSENSE_FLIP_AUDIO_PLAYERS
       // Define reverses UP/DOWN options for all QUOTE/FORCE/TRACK audio players.
       //  Quote player points upwards.
-      if (SFX_quote) {
         if (fusor.angle1() > 0) {
-          SFX_quote.SelectNext();
-          SaberBase::DoEffect(EFFECT_QUOTE, 0);
-        } else {
-          StartOrStopTrack();  // Play track for hilt pointed DOWN.
-        }
-      } else {
-        StartOrStopTrack();  // Fallback: play track if no quotes are available.
-      }
-      return true;
 #else
       // Quote player points downwards.
-      if (SFX_quote) {
         if (fusor.angle1() < 0) {
+#endif
           SFX_quote.SelectNext();
           SaberBase::DoEffect(EFFECT_QUOTE, 0);
         } else {
@@ -874,7 +854,6 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         StartOrStopTrack();  // Fallback: play track if no quotes are available.
       }
       return true;
-#endif
 
     // COLOUR CHANGE.
 #ifdef DISABLE_COLOR_CHANGE
@@ -1040,9 +1019,9 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
             // If the file exists in this directory, delete it.
             if (LSFS::Exists(filePath)) {
               LSFS::Remove(filePath);
-              STDOUT << "Deleted from "   \
-                  << saveDirPath << ": "  \
-                  << targetFile <<"\n";   \
+              STDOUT << "Deleted from "
+                  << saveDirPath << ": "
+                  << targetFile <<"\n";
             }
           }
         }


### PR DESCRIPTION
INTRODUCING THE UPDATED SABERSENSE™
LIGHTSABER SWITCH CONTROL SYSTEM

OVERVIEW The Sabersense Button System has been engineered with simplicity in mind. It is designed to be very easy to use, bomb-proof and consistent in terms of ‘rules’. It doesn’t require a ‘knack’ to access certain features, and it avoids tricky combinations like holding a button while simultaneously twisting or making other active gestures which can be difficult to execute.

HARMONIZED ONE-BUTTON AND TWO-BUTTON CONTROLS By default, basic features like normal ignition, track playing, force effects, mute ignition, quotes etc. all have the same button controls on both one-button and two-button setups. This means users with large hilt collections which include one-button and two-button sabers don’t need to remember different sets of controls for these core features.

CONSISTENT ‘RULES’ This again means the user has less to remember. For example, one click of POWER with blade off always lights the blade - short click for normal, long click for muted; double clicking POWER always plays a sound effect - track, character quote or force effect depending hilt status (see next paragraph). This is all intended to make it easier to remember the various controls.

COMPREHENSIVE SOUND FONT NAVIGATION One-button and two-button setups both allow users to move forwards or backwards one font at a time, or to skip to first font, last font or middle font. Two-button setups include additional navigation features which allow the user to skip forwards or backwards five and ten fonts at a time.

SEPARATE FORCE EFFECT AND CHARACTER QUOTE PLAYER This allows users to access separate force effects, character quotes and music tracks depending on hilt orientation and status. Tracks can be pIayed with the blade OFF, hilt pointing down, Force effects can be played with blade ON, hilt pointing down, and Character Quotes can be played in both blade ON and OFF states with hilt pointing up. If desired, these orientations can be reversed using #define SABERSENSE_FLIP_AUDIO_PLAYERS. Character Quotes are always played sequentially while Force Effects are played randomly.  

ON DEMAND BLADE ID AND MANUAL ARRAY SELECTOR This allows users to run Blade ID on demand with a button press, eliminating potential blade ID scan errors that might occur under constant automatic scanning when blades are lit. Alternatively the BladeID engine can be reconfigured with a simple define allowing you to cycle through all blade and preset arrays manually, regardless of the actual BladeID status. This is useful if you have a number of different blades, for instance, that all return the same BladeID values and therefore cannot be differentiated by the system. Alternatively it can be used to divide sound fonts into separate arrays; for instance all light side fonts could be on array 1,  all dark side fonts on array 2 and all diagnostic and engineering fonts on array 3.

RESTORE 'FACTORY' DEFAULTS
If you've ever found yourself stuck with settings changes you don't like, you will appreciate this feature. Using a simple, but unlikely, button press (to prevent accidental triggering) the system will delete all user-modified settings such as volume, blade colour and font selection and revert to the settings that were uploaded onto your saber.

OPTIONAL BUTTON ‘CLICKER’ DEFINE For hilts that have buttons with poor tactile feedback (KR’s Scavenger for instance, with the emitter wheel button setup), simply adding a press.wav and release.wav of a clicking sound to the appropriate font folder, and including the #define SABERSENSE_BUTTON_CLICKER in your config will play those effects with their respective button actions to aid in feature navigation. Suitable wav files are included to download from the Sabersense website.