### PR TITLE
BCprop - speakBladeId add say "blade"

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1524,6 +1524,7 @@ public:
 #ifdef SPEAK_BLADE_ID
   void SpeakBladeID(float id) override {
     if (&SFX_mnum) {
+      sound_library_v2.SayBlade();
       sound_library_.SayNumber(id, SAY_WHOLE);
     } else {
       PVLOG_NORMAL << "** No mnum.wav number prompts found.\n";


### PR DESCRIPTION
Is this a backward compatibility issue? (if non-V2 Voicepack)