### PR TITLE
Add tick option to smooth color change 

### DIFF
--- a/modes/color_change_modes.h
+++ b/modes/color_change_modes.h
@@ -5,6 +5,10 @@
 #include "stepped_mode.h"
 #include "smooth_mode.h"
 
+#if defined(SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION) && SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION > 0
+  #define SOUND_TICK_ANGLE (M_PI * 2 / SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION)
+#endif
+
 namespace mode {
 
 template<class SPEC>
@@ -43,6 +47,30 @@ struct SmoothVariationMode : public SPEC::SmoothWraparoundMode {
   }
   int get() override { return SaberBase::GetCurrentVariation(); }
   void set(int x) override { SaberBase::SetVariation(x); }
+
+  void mode_Loop() override {
+    SPEC::SmoothWraparoundMode::mode_Loop();
+
+#ifdef SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION
+    static float tick_sound_angle_smooth = 0.0f; 
+    float current_angle = fusor.angle2();
+    float diff = current_angle - tick_sound_angle_smooth;
+
+    if (diff > M_PI)  diff -= (2.0f * M_PI);
+    if (diff < -M_PI) diff += (2.0f * M_PI);
+
+    if (fabsf(diff) >= SOUND_TICK_ANGLE) {
+      int steps = (int)floorf(fabsf(diff) / SOUND_TICK_ANGLE);
+      if (diff < 0) steps = -steps;
+
+      tick_sound_angle_smooth += steps * SOUND_TICK_ANGLE;
+      if (tick_sound_angle_smooth > M_PI)  tick_sound_angle_smooth -= 2.0f * M_PI;
+      if (tick_sound_angle_smooth < -M_PI) tick_sound_angle_smooth += 2.0f * M_PI;
+
+      hybrid_font.PlayPolyphonic(&SFX_ccchange);
+    }
+#endif
+  }
 };
 
 template<class SPEC>

--- a/modes/smooth_mode.h
+++ b/modes/smooth_mode.h
@@ -5,8 +5,8 @@
 #include "select_cancel_mode.h"
 #include "../common/angle.h"
 
-#if defined(SMOOTH_COLORCHANGE_TICK_SOUND_SENS) && SMOOTH_COLORCHANGE_TICK_SOUND_SENS > 0
-#define SOUND_TICK_ANGLE ((M_PI * 2 / 12) / SMOOTH_COLORCHANGE_TICK_SOUND_SENS)
+#if defined(SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION) && SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION > 0
+#define SOUND_TICK_ANGLE (M_PI * 2 / SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION)
 #endif
 
 namespace mode {
@@ -74,7 +74,7 @@ struct SmoothWraparoundMode : public SmoothBase<SPEC> {
     this->angle_ += this->delta_.get() / this->revolutions();
     this->set(this->angle_.fixed());
 
-#ifdef SMOOTH_COLORCHANGE_TICK_SOUND_SENS
+#ifdef SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION
     if (SaberBase::GetColorChangeMode() == SaberBase::COLOR_CHANGE_MODE_SMOOTH) {
       // Tick Sound in Smooth Mode ---
       static float tick_sound_angle_smooth = 0.0f; 

--- a/modes/smooth_mode.h
+++ b/modes/smooth_mode.h
@@ -5,10 +5,6 @@
 #include "select_cancel_mode.h"
 #include "../common/angle.h"
 
-#if defined(SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION) && SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION > 0
-#define SOUND_TICK_ANGLE (M_PI * 2 / SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION)
-#endif
-
 namespace mode {
 
 class DeltaAngle {
@@ -73,31 +69,6 @@ struct SmoothWraparoundMode : public SmoothBase<SPEC> {
   void mode_Loop() override {
     this->angle_ += this->delta_.get() / this->revolutions();
     this->set(this->angle_.fixed());
-
-#ifdef SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION
-    if (SaberBase::GetColorChangeMode() == SaberBase::COLOR_CHANGE_MODE_SMOOTH) {
-      // Tick Sound in Smooth Mode ---
-      static float tick_sound_angle_smooth = 0.0f; 
-      float current_angle = fusor.angle2();
-      float diff = current_angle - tick_sound_angle_smooth;
-
-      // Normalize angle to (-PI, PI)
-      if (diff > M_PI)  diff -= (2.0f * M_PI);
-      if (diff < -M_PI) diff += (2.0f * M_PI);
-
-      if (fabsf(diff) >= SOUND_TICK_ANGLE) {
-        int steps = (int)floorf(fabsf(diff) / SOUND_TICK_ANGLE);
-        if (diff < 0) steps = -steps;
-
-        tick_sound_angle_smooth += steps * SOUND_TICK_ANGLE;
-        if (tick_sound_angle_smooth > M_PI)  tick_sound_angle_smooth -= 2.0f * M_PI;
-        if (tick_sound_angle_smooth < -M_PI) tick_sound_angle_smooth += 2.0f * M_PI;
-
-        hybrid_font.PlayPolyphonic(&SFX_ccchange);
-      }
-    }
-#endif
-
   }
 };
 


### PR DESCRIPTION
Apparently the "ipod clickwheel" feel is popular. This is optional with a define and only affects color change mode.

```cpp
// Use this define to turn on an optional "iPod® Clickwheel" sound when rotating the hilt in smooth colorchange mode (Color Wheel).
// ccchange.wav will play, so the sound should probably be a very subtle "tick" sound.
// The value is the number of ticks per 360 hilt rotation. Higher number = more ticks per angle change.
// Suggested Range 50 - 120. Using zero or not defining will turn ticks off.

#define SMOOTH_COLORCHANGE_TICKS_PER_REVOLUTION 120
```

*Updated to reflect new usage as of https://github.com/profezzorn/ProffieOS/pull/731/commits/874f09090a63cb7732169819fe0682d3005adfc1