### PR TITLE
add "ERROR" to sound lib version printout

### DIFF
--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -75,7 +75,7 @@ private:
       PVLOG_STATUS << "Sound library version " << found_version << " found.\n";
     }
     if (found_version < required_version_) {
-      PVLOG_ERROR << "Sound library version " << required_version_ << " required.\n";
+      PVLOG_ERROR << "ERROR - Sound library version " << required_version_ << " required.\n";
       ProffieOSErrors::error_in_font_directory(); // Make new error for voice pack?
     }
   }


### PR DESCRIPTION
Currently, "Error in font directory" plays.
Instinctively (for me anyway) is to first do `effects` to see what the problem is.
However, if all looks fine, one is left wondering what the issue is until it dawns on you that it might be a Sound Library version mismatch.
So for now, this change at least helps when visually scanning the serial messages until such time we make an appropriate error message.

