### PR TITLE
Add mclick

### DIFF
--- a/modes/color_change_modes.h
+++ b/modes/color_change_modes.h
@@ -12,10 +12,10 @@
 namespace mode {
 
 template<class SPEC>
-struct SteppedVariationMode : public SPEC::SteppedMode {
+struct SteppedVariationMode : public SPEC::SteppedModeBase {
   void mode_activate(bool onreturn) override {
     saved_ = get();
-    SPEC::SteppedMode::mode_activate(onreturn);
+    SPEC::SteppedModeBase::mode_activate(onreturn);
     SaberBase::SetColorChangeMode(SaberBase::COLOR_CHANGE_MODE_STEPPED);
   }
   void exit() override {
@@ -29,10 +29,6 @@ struct SteppedVariationMode : public SPEC::SteppedMode {
   }
   void next() override { SaberBase::UpdateVariation(1); }
   void prev() override { SaberBase::UpdateVariation(-1); }
-
-  void update() override {
-    hybrid_font.PlayPolyphonic(&SFX_ccchange);
-   }
 
   int get() { return SaberBase::GetCurrentVariation(); }
   void set(int x) { SaberBase::SetVariation(x); }

--- a/modes/color_change_modes.h
+++ b/modes/color_change_modes.h
@@ -67,7 +67,7 @@ struct SmoothVariationMode : public SPEC::SmoothWraparoundMode {
       if (tick_sound_angle_smooth > M_PI)  tick_sound_angle_smooth -= 2.0f * M_PI;
       if (tick_sound_angle_smooth < -M_PI) tick_sound_angle_smooth += 2.0f * M_PI;
 
-      if (!hybrid_font.PlayPolyphonic(&SFX_mclick)) beeper.Beep(0.03, 5000);;
+      hybrid_font.PlayPolyphonic(&SFX_mclick);
     }
 #endif
   }

--- a/modes/color_change_modes.h
+++ b/modes/color_change_modes.h
@@ -30,6 +30,10 @@ struct SteppedVariationMode : public SPEC::SteppedMode {
   void next() override { SaberBase::UpdateVariation(1); }
   void prev() override { SaberBase::UpdateVariation(-1); }
 
+  void update() override {
+    hybrid_font.PlayPolyphonic(&SFX_ccchange);
+   }
+
   int get() { return SaberBase::GetCurrentVariation(); }
   void set(int x) { SaberBase::SetVariation(x); }
 private:

--- a/modes/color_change_modes.h
+++ b/modes/color_change_modes.h
@@ -67,7 +67,7 @@ struct SmoothVariationMode : public SPEC::SmoothWraparoundMode {
       if (tick_sound_angle_smooth > M_PI)  tick_sound_angle_smooth -= 2.0f * M_PI;
       if (tick_sound_angle_smooth < -M_PI) tick_sound_angle_smooth += 2.0f * M_PI;
 
-      hybrid_font.PlayPolyphonic(&SFX_ccchange);
+      if (!hybrid_font.PlayPolyphonic(&SFX_mclick)) beeper.Beep(0.03, 5000);;
     }
 #endif
   }

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -778,6 +778,9 @@ EFFECT(ccchange);
 EFFECT(altchng);
 EFFECT(chhum);
 
+// menu sounds
+EFFECT(mclick);
+
 // Blaster effects
 // hum, boot and font are reused from sabers and already defined.
 EFFECT(bgnauto); // Doesn't exist in fonts, but I expect there may be use for autofire transitions

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -547,7 +547,7 @@ public:
     switch (effect) {
       default: return;
       case EFFECT_MENU_CHANGE:
-        if (!PlayPolyphonic(&SFX_ccchange)) {
+        if (!PlayPolyphonic(&SFX_mclick)) {
           SaberBase::sound_length = 0.2;
           beeper.Beep(0.05, 2000.0);
         }


### PR DESCRIPTION
The ticking smoothmode option doesn't need to "take over" ccchange that might be used elsewhere.
A click sound might not be appropriate/desired, such as in stepped mode, or menu change etc...
Since I already incorporated mclick in the V2 voicepacks, this can work "out of the box".
Lastly, if no mclick exists, a similar sound in the form of a beep is used.
All of this of course if the define to use a sound in smoothmode is active).
