### PR TITLE
BCprop account for newer idle sound handling

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1147,21 +1147,18 @@ struct BCScrollPresetsMode : public SPEC::SteppedMode {
 
   void next() override {
     beeper.Beep(0.05, 4000);
-#ifdef ENABLE_IDLE_SOUND
-    SFX_font.SetFollowing(nullptr);
-#endif 
     prop_next_preset();
   }
 
   void prev() override {
     beeper.Beep(0.05, 3000);
-#ifdef ENABLE_IDLE_SOUND
-    SFX_font.SetFollowing(nullptr);
-#endif 
    prop_previous_preset();
   }
 
   void update() override {  // Overridden to substitute the tick sound
+#ifdef ENABLE_IDLE_SOUND
+    SFX_font.SetFollowing(nullptr);
+#endif 
   }
 
   void exit() override {

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1390,7 +1390,6 @@ struct BCMenuSpec {
 };
 
 
-
 class DelayTimer {
 public:
   DelayTimer() : triggered_(false), trigger_time_(0), duration_(0) {}

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -2512,6 +2512,9 @@ any # of buttons
 // Enter OS System Menu
 // Enter BC Blade Length Mode
       case EVENTID(BUTTON_POWER, EVENT_SECOND_HELD_MEDIUM, MODE_OFF):
+#ifdef ENABLE_IDLE_SOUND
+        hybrid_font.StopIdleSound();
+#endif
 #ifdef MENU_SPEC_TEMPLATE
         PVLOG_NORMAL << "** Entering ProffieOS Menu System\n";
         EnterMenu();

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1283,6 +1283,24 @@ struct BCVolumeMode : public SPEC::SteppedMode {
     SPEC::SteppedMode::exit();
   }
 
+  bool Parse(const char *cmd, const char* arg) override {
+    if (PropBase::Parse(cmd, arg)) return true;
+
+    if (!strcmp(cmd, "twist")) {
+        Event(BUTTON_NONE, EVENT_TWIST);
+        return true;
+    }
+    if (!strcmp(cmd, "left")) {
+        Event(BUTTON_NONE, EVENT_TWIST_LEFT);
+        return true;
+    }
+    if (!strcmp(cmd, "right")) {
+        Event(BUTTON_NONE, EVENT_TWIST_RIGHT);
+        return true;
+    }
+    return false;
+  }
+
   bool mode_Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     switch (EVENTID(button, event, 0)) {
       // Custom button controls for BCVolumeMode

--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1152,7 +1152,7 @@ struct BCScrollPresetsMode : public SPEC::SteppedMode {
 
   void prev() override {
     beeper.Beep(0.05, 3000);
-   prop_previous_preset();
+    prop_previous_preset();
   }
 
   void update() override {  // Overridden to substitute the tick sound


### PR DESCRIPTION
Also in here:
- Since STEPS_PER_REVOLUTION is now a user define setting, BCmodes don't need to override that function.
- Removed some dead comment lines, and added a few spacing newlines.