### PR TITLE
Fix mount sd

### DIFF
--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -409,6 +409,7 @@ void EnableAmplifier();
 bool AmplifierIsActive();
 void MountSDCard();
 const char* GetSaveDir();
+bool GetAllowMountSD();
 
 #include "common/lsfs.h"
 #include "common/strfun.h"

--- a/common/sd_card.h
+++ b/common/sd_card.h
@@ -86,4 +86,14 @@ inline void MountSDCard() { sdcard.Mount(); }
 inline void MountSDCard() {  }
 #endif // v4 && enable_sd
 
+#ifdef USB_CLASS_MSC
+inline bool GetAllowMountSD() {
+  return LSFS::GetAllowMount();
+}
+#else
+inline bool GetAllowMountSD() {
+  return false;
+}
+#endif  // USB_CLASS_MSC
+
 #endif

--- a/display/ssd1306.h
+++ b/display/ssd1306.h
@@ -409,7 +409,7 @@ public:
 
 #ifdef USB_CLASS_MSC
   bool EscapeIdleIfNeeded() {
-    return looped_idle_ == Tristate::True && USBD_Configured();
+    return looped_idle_ == Tristate::True && GetAllowMountSD();
   }
 #else
   bool EscapeIdleIfNeeded() { return false; }

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1642,8 +1642,9 @@ public:
 	if (mountable) {
 	  // Trigger the IDLE_OFF_TIME behavior to turn off idle sounds and animations.
 	  // (Otherwise we can't mount the sd card).
-	  if (!SaberBase::IsOn()) SaberBase::DoOff(OFF_IDLE, 0);
-	}
+          if (IsOn()) Off();
+          SaberBase::DoOff(OFF_IDLE, 0);
+        }
       }
       STDOUT << "SD Access " 
              << (LSFS::GetAllowMount() ? "ON" : "OFF") 

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -483,7 +483,9 @@ public:
     bool most_blades = location.on_blade(0);
     // SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
 #ifdef ENABLE_IDLE_SOUND
-    if (most_blades) {
+    if (LSFS::GetAllowMount()) {
+      SFX_in.SetFollowing(nullptr);
+    } else if (most_blades) {
         if (SFX_pstoff) {
             SFX_in.SetFollowing(&SFX_pstoff);
             SFX_pstoff.SetFollowing(&SFX_idle);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -483,7 +483,7 @@ public:
     bool most_blades = location.on_blade(0);
     // SFX_in.SetFollowing( most_blades ?  &SFX_pstoff : nullptr );
 #ifdef ENABLE_IDLE_SOUND
-    if (LSFS::GetAllowMount()) {
+    if (GetAllowMountSD()) {
       SFX_in.SetFollowing(nullptr);
     } else if (most_blades) {
         if (SFX_pstoff) {


### PR DESCRIPTION
Forces turning OFF if ON when Mount SD is allowed via `sd 1` command.
Also prevents idle.wav from playing if enabled and exists when `sd 1` was issued while ON.
