### PR TITLE
Sabersense Prop OS-7 Compatibility...

### DIFF
--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* OS8-v160.
+/* V7/8-166.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -10,15 +10,14 @@ and two button replica lightsabers. Modified by Chris
 Carter with substantial support and contributions from
 Fredrik Hubinette and Brian Conner.
 
+This prop file has been optimized for, and is included
+with, ProffieOS 8.x or later, but is also fully
+backwards compatible with ProffieOS 7.x.
+
 This prop file references certain custom sound files
 to aid in saber function navigation. These sound files
 are optional and are available as a free download from
 the Sabersense website. (Link below).
-
-This prop file has been optimized for ProffieOS 8.x
-or later. A ProffieOS 7.x compatible version of this 
-prop file is available as a free download from the 
-Sabersense website.
 
 https://sabersense.square.site/downloads
 
@@ -358,6 +357,9 @@ EFFECT(blstend);  // for End Multi-Blast
 EFFECT(array);    // for playing array idents
 EFFECT(bladeid);  // for playing bladeid idents
 EFFECT(reset);    // for playing factory default reset completed
+#ifndef MODES_MODE_H  // Modes not part of OS7.x, so define used to differentiate systems.
+EFFECT(quote);    // for playing quotes with ProffieOS 7.x.
+#endif
 
 // The Saber class implements the basic states and actions
 // for the saber.
@@ -532,14 +534,14 @@ public:
 
 #ifndef SABERSENSE_DISABLE_SAVE_ARRAY
   void SaveArrayState() {
-    PVLOG_STATUS << "Saving Array State\n";
+    STDOUT.print("Saving Array State\n");
     SaveArrayStateFile saved_state;
     saved_state.sabersense_array_index = SabersenseArraySelector::return_value;  // Save current array.
     saved_state.WriteToRootDir("arraysve");
   }
 
   void RestoreArrayState() {
-    PVLOG_STATUS << "Restoring Array State\n";
+    STDOUT.print("Restoring Array State\n");
     SaveArrayStateFile saved_state;
     saved_state.ReadINIFromDir(NULL, "arraysve");
     // Restore saved array index.
@@ -884,41 +886,70 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       }
       return true;
 
-    // COLOUR CHANGE.
+    //  Colour Change and Blast sections designed for identical user
+    //  operation under both OS-7 (without Modes) and OS-8 (with Modes).
+    //  COLOUR CHANGE.
 #ifdef DISABLE_COLOR_CHANGE
-#error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
+  #error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
 #endif
 
-    // 1 and 2 button modes.
+    //  1 and 2 button modes.
 #ifndef SABERSENSE_NO_COLOR_CHANGE
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
-    // 2 button mode only.
+      ToggleColorChangeMode();
+      return true;
+    //  2 button mode only.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
-#endif
       ToggleColorChangeMode();
       return true;
 #endif
+#endif
 
-    // BLASTER DEFLECTION
-    // 1 Button
+    //  BLASTER DEFLECTION
+    //  1 Button
 #if NUM_BUTTONS == 1
+    //  1 button
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-      swing_blast_ = false;
-      SaberBase::DoBlast();
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode();
+      } else {
+        //  Fires blast in all OSs.
+        swing_blast_ = false;
+        SaberBase::DoBlast();
+      }
       return true;
 #endif
 
-    // 2 Button
+    //  2 Button
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-#ifdef SABERSENSE_BLAST_PWR_AND_AUX
-    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-#endif
       swing_blast_ = false;
       SaberBase::DoBlast();
       return true;
-#endif
+
+    //  Add blast to MAIN on 2-button sabers, 
+    //  plus harmonized 'Exit Colour Menu' control under OS-7.x.
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode();          
+      } else {  
+        //  Fires blast in all OSs.
+        swing_blast_ = false;
+        SaberBase::DoBlast();
+      }
+      return true;
+#else
+      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode(); 
+      }
+      return true;
+#endif 
+#endif  // End of Colour/Blast OS-7 compatibility section.
 
     // Multi-Blaster Deflection mode
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):
@@ -1111,8 +1142,16 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     return false;
   }
 
-  void SB_Effect(EffectType effect, EffectLocation location) override {
-    switch (effect) {
+#ifndef MODES_MODE_H  // Modes not part of OS7.x, so define used to differentiate systems.
+  void SB_Effect(EffectType effect, float location) override  //  Required for ProffieOS 7.x.
+#else
+  void SB_Effect(EffectType effect, EffectLocation location) override  //  For ProffieOS 8.x.
+#endif  
+  {
+  switch (effect) {
+#ifndef MODES_MODE_H
+    case EFFECT_QUOTE: hybrid_font.PlayCommon(&SFX_quote); return; 
+#endif
       case EFFECT_POWERSAVE:
         if (SFX_dim) {
           hybrid_font.PlayCommon(&SFX_dim);

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-166.
+/* V7/8-167.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -886,19 +886,20 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       }
       return true;
 
-    //  Colour Change and Blast sections designed for identical user
-    //  operation under both OS-7 (without Modes) and OS-8 (with Modes).
-    //  COLOUR CHANGE.
+    // COLOUR CHANGE.
+    // Colour Change and Blast OS-7 Compatibility Section.
+    // Designed for identical user operation under both
+    // OS-7 (without Modes) and OS-8 (with Modes).
 #ifdef DISABLE_COLOR_CHANGE
-  #error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
+#error "DISABLE_COLOR_CHANGE is not supported. Use SABERSENSE_NO_COLOR_CHANGE instead."
 #endif
 
-    //  1 and 2 button modes.
+    // 1 and 2 button modes.
 #ifndef SABERSENSE_NO_COLOR_CHANGE
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_ON):
       ToggleColorChangeMode();
       return true;
-    //  2 button mode only.
+    // 2 button mode only.
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON | BUTTON_POWER):
       ToggleColorChangeMode();
@@ -906,50 +907,29 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
 #endif
 
-    //  BLASTER DEFLECTION
-    //  1 Button
-#if NUM_BUTTONS == 1
-    //  1 button
+    // BLASTER DEFLECTION
+    // 1 Button
+    // or 2 button with extra define.
+#if NUM_BUTTONS == 1 || defined(SABERSENSE_BLAST_MAIN_AND_AUX)
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
         ToggleColorChangeMode();
       } else {
-        //  Fires blast in all OSs.
+        // Fires blast in all OSs.
         swing_blast_ = false;
         SaberBase::DoBlast();
       }
       return true;
 #endif
 
-    //  2 Button
+    // 2 Button
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
       swing_blast_ = false;
       SaberBase::DoBlast();
       return true;
-
-    //  Add blast to MAIN on 2-button sabers, 
-    //  plus harmonized 'Exit Colour Menu' control under OS-7.x.
-    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode();          
-      } else {  
-        //  Fires blast in all OSs.
-        swing_blast_ = false;
-        SaberBase::DoBlast();
-      }
-      return true;
-#else
-      //  For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode(); 
-      }
-      return true;
-#endif 
-#endif  // End of Colour/Blast OS-7 compatibility section.
+#endif  
 
     // Multi-Blaster Deflection mode
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):


### PR DESCRIPTION
I've revisited OS-7 compatibility and, following your suggestion, used a better way of achieving it that requires no user input such as defines - it just works as is with either OS. To differentiate systems, I've used the "Modes" define. Since modes are new to OS-8 but don't exist in OS-7, this is what tells the prop which system it's in. I've also tweaked the Colour Change and Blaster Block code so that exiting the colour menu in OS-7 can be done with a short click of Power, the same as in OS-8.