### PR TITLE
Add Blade Detect functionality to manual Sabersense Array Selector...

### DIFF
--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -297,7 +297,7 @@ GESTURE CONTROLS
   constexpr size_t NUM_ARRAYS = sizeof(blades) / sizeof(blades[0]);
   static_assert(SABERSENSE_DEFAULT_ARRAY >= 1 && SABERSENSE_DEFAULT_ARRAY <= NUM_ARRAYS,
 
-    // Show error below if array number is invalid. (Returns and indents for readability).
+    // Show error below if array number is invalid. (Returns and indents for IDE readability).
     "\n  ERROR:\n    SABERSENSE_DEFAULT_ARRAY number invalid. Ensure array number specified "
     "does not exceed number of blade arrays in config.\n "
     "   Arrays should be numbered sequentially. First array should be zero (or NO_BLADE if "

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -213,20 +213,20 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Plays array-specific arrayX.wav files when switching.
   Arrays should be numbered consecutively, starting at
   zero (0) in the field that would otherwise contain
-  BladeID. If used with Blade Detect, NO_BLADE array
-  replaces zero. NO_BLADE array also gets ignored
-  by Array Selector and will only be accessed by the
-  Blade Detect process.
+  BladeID values. If used with Blade Detect, the
+  NO_BLADE array replaces the array numbered zero.
+  NO_BLADE array also gets ignored by Array Selector
+  and will only be accessed by the Blade Detect process.
   
 #define SABERSENSE_DEFAULT_ARRAY 3
-  If using SABERSENSE_ARRAY_SELECTOR, this define selects
-  the default array on first boot or if no save file
+  If using SABERSENSE_ARRAY_SELECTOR, this optional define
+  selects the default array on first boot or if no save file
   is present.
   Arrays should be numbered sequentially starting at 0 (or 
   NO_BLADE if using Blade Detect), and system defaults
   to first "bladed" array if define is not used.
   Note that the number specified refers to the array
-  location in the array list, NOT th array index number.
+  location in the array list, NOT the array index number.
   It also ignores NO_BLADE but does not ignore zero.
   
 #define SABERSENSE_DISABLE_SAVE_ARRAY


### PR DESCRIPTION
Adds Blade Detect functionality when using SABERSENSE_ARRAY_SELECTOR. When using Blade Detect, the manual array selector skips the NO_BLADE array. 
Also allows the user to set a default blade array via a define. This can be useful if using arrays to set different blade lengths, as you can have a logical progression of arrays from long to short for example, then set a default for the most often used blade or the blade supplied with the hilt.