### PR TITLE
Add Blackpower for Blade Plug Charging

### DIFF
--- a/ProffieOS.ino
+++ b/ProffieOS.ino
@@ -522,6 +522,7 @@ struct is_same_type<T, T> { static const bool value = true; };
 #include "styles/edit_mode.h"
 #include "styles/pixelate.h"
 #include "styles/display.h"
+#include "styles/blackpower.h"
 
 // functions
 #include "functions/ifon.h"

--- a/styles/blackpower.h
+++ b/styles/blackpower.h
@@ -6,8 +6,9 @@
 // Usage:
 // Provides blade style that keeps pogo
 // pins live for Blade Plug Charging.
-// Use with ChargingStylePtr tp prevent
-// IDLE_OFF_TIME shutting down LED power.
+// Use with ChargingStylePtr to prevent
+// IDLE_OFF_TIME globally shutting down
+// LED power pads.
 
 class BlackPower : public BladeStyle {
 public:

--- a/styles/blackpower.h
+++ b/styles/blackpower.h
@@ -1,0 +1,32 @@
+#ifndef STYLES_BLACKPOWER_H
+#define STYLES_BLACKPOWER_H
+
+#include "blade_style.h"
+
+// Usage:
+// Provides blade style that keeps pogo
+// pins live for Blade Plug Charging.
+// Use with ChargingStylePtr tp prevent
+// IDLE_OFF_TIME shutting down LED power.
+
+class BlackPower : public BladeStyle {
+public:
+    void run(BladeBase* base) override {
+    }
+
+    OverDriveColor getColor(int led) override {
+      return OverDriveColor(Color16(0, 0, 0));
+    }
+
+    bool NoOnOff() override {
+      return true;  // Pins stay live for blade plug charging.
+    }
+
+    bool IsHandled(HandledFeature effect) override {
+      return false;
+    }
+  };
+
+StyleFactoryImpl<BlackPower> black_power;
+
+#endif


### PR DESCRIPTION
Blackpower leaves the pogo pins on a neopixel blade connector live without displaying anything on the blade.
Used for blade plug charging to keep the FETs powered.

This has long been possible by using a few lines of code in the user's config, but since ChargingStylePtr is now baked into ProffieOS, I figured it would be good to have Blackpower as part of it too.