### PR TITLE
Exit Colour Change Tweak.h

### DIFF
--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-201.
+/* V7/8-201c.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -932,28 +932,39 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
 
     // BLASTER DEFLECTION
-    // 1 Button
-    // or 2 button with extra define.
-#if NUM_BUTTONS == 1 || defined(SABERSENSE_BLAST_MAIN_AND_AUX)
+    // 1 Button (and 2 button with extra define).
+#if NUM_BUTTONS == 1
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
       // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
         ToggleColorChangeMode();
       } else {
-        // Fires blast in all OSs.
         swing_blast_ = false;
         SaberBase::DoBlast();
       }
       return true;
+
+#elif NUM_BUTTONS == 2
+    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+      // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
+      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        ToggleColorChangeMode();
+      }
+#ifdef SABERSENSE_BLAST_MAIN_AND_AUX  // Add Blaster Block to POWER as well as AUX.
+      else {
+        swing_blast_ = false;
+        SaberBase::DoBlast();
+      }
+#endif
+      return true;
 #endif
 
-    // 2 Button
 #if NUM_BUTTONS == 2
-    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-      swing_blast_ = false;
-      SaberBase::DoBlast();
-      return true;
-#endif  
+case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+    swing_blast_ = false;
+    SaberBase::DoBlast();
+    return true;
+#endif
 
     // Multi-Blaster Deflection mode
     case EVENTID(BUTTON_NONE, EVENT_SWING, MODE_ON | BUTTON_POWER):

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-201d.
+/* V7/8-201e.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -934,30 +934,30 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
     // BLASTER DEFLECTION
     // 1 Button (and 2 button with extra define).
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
-#if NUM_BUTTONS == 1
-      // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
+        // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8 due to Modes.
         ToggleColorChangeMode();
-      } else {
-        swing_blast_ = false;
-        SaberBase::DoBlast();
+        return true;
       }
+      
+#if NUM_BUTTONS == 1
+      // If NOT in color change mode and 1 button system, do blast.
+      swing_blast_ = false;
+      SaberBase::DoBlast();
       return true;
+      
+#elif NUM_BUTTONS == 2
+      // If NOT in color change mode and 2 button system, do Blast only if defined.
+#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+      return true;
+#else
+      return true;
+#endif
 #endif
 
 #if NUM_BUTTONS == 2
-      // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
-      if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        ToggleColorChangeMode();
-      }
-#ifdef SABERSENSE_BLAST_MAIN_AND_AUX  // Add Blaster Block to POWER as well as AUX.
-      else {
-        swing_blast_ = false;
-        SaberBase::DoBlast();
-      }
-#endif
-      return true;
-
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
       swing_blast_ = false;
       SaberBase::DoBlast();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-201c.
+/* V7/8-201d.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -933,8 +933,8 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 
     // BLASTER DEFLECTION
     // 1 Button (and 2 button with extra define).
-#if NUM_BUTTONS == 1
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+#if NUM_BUTTONS == 1
       // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
         ToggleColorChangeMode();
@@ -943,9 +943,9 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         SaberBase::DoBlast();
       }
       return true;
+#endif
 
-#elif NUM_BUTTONS == 2
-    case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
+#if NUM_BUTTONS == 2
       // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8.
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
         ToggleColorChangeMode();
@@ -957,13 +957,11 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       }
 #endif
       return true;
-#endif
 
-#if NUM_BUTTONS == 2
-case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
-    swing_blast_ = false;
-    SaberBase::DoBlast();
-    return true;
+    case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):
+      swing_blast_ = false;
+      SaberBase::DoBlast();
+      return true;
 #endif
 
     // Multi-Blaster Deflection mode

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -931,7 +931,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
 #endif
 
-    // BLASTER DEFLECTION
+   // BLASTER DEFLECTION
     // 1 Button (and 2 button with extra define).
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
@@ -951,10 +951,8 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #ifdef SABERSENSE_BLAST_MAIN_AND_AUX
       swing_blast_ = false;
       SaberBase::DoBlast();
-      return true;
-#else
-      return true;
 #endif
+      return true;
 #endif
 
 #if NUM_BUTTONS == 2

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -931,29 +931,21 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #endif
 #endif
 
-   // BLASTER DEFLECTION
+    // BLASTER DEFLECTION
     // 1 Button (and 2 button with extra define).
     case EVENTID(BUTTON_POWER, EVENT_FIRST_SAVED_CLICK_SHORT, MODE_ON):
       if (SaberBase::GetColorChangeMode() != SaberBase::COLOR_CHANGE_MODE_NONE) {
-        // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8 due to Modes.
-        ToggleColorChangeMode();
-        return true;
-      }
-      
-#if NUM_BUTTONS == 1
-      // If NOT in color change mode and 1 button system, do blast.
-      swing_blast_ = false;
-      SaberBase::DoBlast();
+      // For harmonized 'Exit Colour Menu' control in OS-7.x. Ignored in OS-8 due to Modes.
+      ToggleColorChangeMode();
       return true;
-      
-#elif NUM_BUTTONS == 2
-      // If NOT in color change mode and 2 button system, do Blast only if defined.
-#ifdef SABERSENSE_BLAST_MAIN_AND_AUX
+    }
+
+#if NUM_BUTTONS == 1 || defined(SABERSENSE_BLAST_MAIN_AND_AUX)
+      // If NOT in color change mode and 1 button system (or 2 button with define) do blast.
       swing_blast_ = false;
       SaberBase::DoBlast();
 #endif
       return true;
-#endif
 
 #if NUM_BUTTONS == 2
     case EVENTID(BUTTON_AUX, EVENT_CLICK_SHORT, MODE_ON):


### PR DESCRIPTION
Not so much a  bug, but the prop is designed for same behaviour when exiting colour change in OS-7 (without modes) and OS-8 (with modes). However a mistake meant short press POWER didn't exit colour change in two button setup.
Now fixed.