### PR TITLE
BCprop - fix vol menu sounds

### DIFF
--- a/props/saber_BC_buttons.h
+++ b/props/saber_BC_buttons.h
@@ -1268,7 +1268,6 @@ struct BCVolumeMode : public SPEC::SteppedMode {
         sound_library_.fadeout(0.2);
         mode::getSL<SPEC>()->SayVolumeUp();
       }
-      // Always update the volume even if we skipped SayVolumeUp
       dynamic_mixer.set_volume(current_volume_);
     }
   }


### PR DESCRIPTION
Sounds would "pile up" in the queue due to new calls accruing during old sound playback.
Now they are not queued if sounds are playing or if rotating very fast.
Maximum and minimum sounds take precedence.

