### PR TITLE
Allow idle to fade in

### DIFF
--- a/sound/effect.h
+++ b/sound/effect.h
@@ -712,14 +712,12 @@ EFFECT(preon);
 EFFECT(pstoff);
 
 // Monophonic fonts
+// Idle effect, plays when blade is off.
 #ifdef ENABLE_IDLE_SOUND
 EFFECT2(idle, idle);
-EFFECT2(boot, idle);
-EFFECT2(font, idle);
-#else
+#endif
 EFFECT(boot);
 EFFECT(font);      // also polyphonic
-#endif
 EFFECT(bladein);   // also polyphonic
 EFFECT(bladeout);  // also polyphonic
 EFFECT2(hum, hum);

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -868,6 +868,7 @@ public:
   }
 
   void StartIdleSound() {
+#ifdef ENABLE_IDLE_SOUND
     // if PlayPolyphonic(&SFX_bgnidle) return;
     PlayCommon(&SFX_idle);
     RefPtr<BufferedWavPlayer> idlePlayer = GetWavPlayerPlaying(&SFX_idle);
@@ -878,6 +879,7 @@ public:
    } else {
       STDOUT.println("Out of WAV players!");
     }
+#endif
   }
 
   void StopIdleSound() {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -23,8 +23,9 @@ public:
     CONFIG_VARIABLE2(ProffieOSSpinDegrees, 360.0f);
 #endif
     CONFIG_VARIABLE2(ProffieOSSmoothSwingHumstart, 0);
+#ifdef ENABLE_IDLE_SOUND
     CONFIG_VARIABLE2(ProffieOSIdleFadeIn, 3.0f);
-
+#endif
     for (Effect* e = all_effects; e; e = e->next_) {
       char name[32];
       strcpy(name, "ProffieOS.");

--- a/sound/volume_overlay.h
+++ b/sound/volume_overlay.h
@@ -10,7 +10,7 @@ const uint32_t kDefaultSpeed = 500 * kMaxVolume / AUDIO_RATE;
 template<class T>
 class VolumeOverlay : public T {
 public:
-  VolumeOverlay() : volume_(kMaxVolume / 100), stop_when_zero_(false) {
+  VolumeOverlay() : volume_(kMaxVolume / 100), stop_when_zero_(false), use_fractional_fade_(false), fractional_speed_(0.0f), fractional_accum_(0.0f) {
     volume_.set(kDefaultVolume);
     volume_.set_target(kDefaultVolume);
     volume_.set_speed(kDefaultSpeed);
@@ -24,8 +24,8 @@ public:
         // Do nothing
       } else if (mult == 0) {
         if (stop_when_zero_.get()) {
-	  volume_.set_speed(kDefaultSpeed);
-	  T::StopFromReader();
+          volume_.set_speed(kDefaultSpeed);
+          T::StopFromReader();
         }
         for (int i = 0; i < elements; i++) data[i] = 0;
       } else {
@@ -37,7 +37,14 @@ public:
       for (int i = 0; i < elements; i++) {
         int32_t v = (data[i] * (int32_t)volume_.value()) >> kVolumeShift;
         data[i] = clamptoi16(v);
-        volume_.advance();
+        if (use_fractional_fade_) {
+          fractional_accum_ += fractional_speed_;
+          int steps = (int)fractional_accum_;
+          fractional_accum_ -= steps;
+          for (int s = 0; s < steps; s++) volume_.advance();
+        } else {
+          volume_.advance();
+        }
       }
     }
     return elements;
@@ -70,7 +77,11 @@ public:
     volume_.set_speed(speed);
   }
   void set_fade_time(float t) {
-    set_speed(std::max<int>(1, (int)(kMaxVolume / t / AUDIO_RATE)));
+    // Prevent zero or too-small fade times
+    if (t <= 0.01f) { t = 0.01f; }
+    fractional_accum_ = 0.0f;
+    fractional_speed_ = (float)kMaxVolume / (t * AUDIO_RATE);
+    use_fractional_fade_ = true;
   }
   float fade_speed() const {
     return (kMaxVolume / (float)volume_.speed_) / AUDIO_RATE;
@@ -84,6 +95,15 @@ public:
     stop_when_zero_.set(true);
   }
 
+  void StartAndFade() {
+    if (use_fractional_fade_) {
+      volume_.set_speed(1);
+    }
+    volume_.set(0);
+    volume_.set_target(kDefaultVolume);
+    stop_when_zero_.set(false);
+  }
+
   void ResetStopWhenZero() {
     stop_when_zero_.set(false);
   }
@@ -91,6 +111,9 @@ public:
 private:
   ClickAvoiderLin volume_;
   POAtomic<bool> stop_when_zero_;
+  bool use_fractional_fade_;
+  float fractional_speed_;
+  float fractional_accum_;
 };
 
 #endif


### PR DESCRIPTION
This is to handle a one time fade-in of the looping idle sound when it begins, without having a fade directly in the idle sound (and hearing a fade-in on each restart) nor having to bake in a manual "bgn-idle" fade to the end of boot, font, in, or postoff.

This is based on my original proposal for idle, where a boolean gets flipped for one cycle in loop() to trigger idle to start  playing.
We ended up (the current way) leveraging file linking in effect.h to have it follow boot and font, and used SetFollowing() in SB_Off so that in.wav and preon could finish before it auto-started playing.
That does work, but to make it fade in, we need to start it manually with a fade time set, and I didn't see a way to intercept that linking routine cleanly just for this small "feature".
This does not address adding bgnidle yet. If that becomes a thing, we can check if it exists, and bypass the fade-in part.
I added a font.config parameter so users can edit the fade time, and also kept the AvoidIdleSDAccess() check.

Lastly, in volume_overlay, the fade speed was clamped to a slowest speed of 1 unit/sample. 
I added a fractional stepping to allow for longer fade times, and I tested it with various times, some as long as 10 seconds. It uses a quadratic ease-in curve on each sample, because trying basic linear sounded too sudden to my ear.

It's working well in my opinion. I should be low on additional cycles/memory consumption, and safe from integer truncation by allowing a minimum of 10ms.

If this can be done better, by all means let me know. If it's horrible, also please let me know. :)

P.S. I also added the parameter (and a few other OS8.x ones) to the POD for review
https://github.com/profezzorn/ProffieOSDocs/pull/70
