### PR TITLE
Add fast preset switching to serial commands

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1578,10 +1578,7 @@ public:
       SaberBase::IsOn() ? previous_preset_fast() : previous_preset();
       return true;
     }
-    if (!strcmp(cmd, "f") || (!strcmp(cmd, "first") && arg && (!strcmp(arg, "preset") || !strcmp(arg, "pre")))) {
-      SaberBase::IsOn() ? first_preset_fast() : first_preset();
-      return true;
-    }
+
     if (!strcmp(cmd, "rotate")) {
       rotate_presets();
       return true;

--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1571,11 +1571,15 @@ public:
       return true;
     }
     if (!strcmp(cmd, "n") || (!strcmp(cmd, "next") && arg && (!strcmp(arg, "preset") || !strcmp(arg, "pre")))) {
-      next_preset();
+      SaberBase::IsOn() ? next_preset_fast() : next_preset();
       return true;
     }
     if (!strcmp(cmd, "p") || (!strcmp(cmd, "prev") && arg && (!strcmp(arg, "preset") || !strcmp(arg, "pre")))) {
-      previous_preset();
+      SaberBase::IsOn() ? previous_preset_fast() : previous_preset();
+      return true;
+    }
+    if (!strcmp(cmd, "f") || (!strcmp(cmd, "first") && arg && (!strcmp(arg, "preset") || !strcmp(arg, "pre")))) {
+      SaberBase::IsOn() ? first_preset_fast() : first_preset();
       return true;
     }
     if (!strcmp(cmd, "rotate")) {


### PR DESCRIPTION
The way it is before this patch, led to some confusion in testing the bgnidle stuff.
You have to physically do the button event on the saber to get a next/prev_preset_fast.
I was using Serial Monitor, so I was getting "font.wav" playing, which caused a series of unnecessary coding of a workaround, for an issue that didn't exist. (see https://github.com/profezzorn/ProffieOS/pull/833/commits/b2c351b71ab12a3334e431f6824c4d6a43167c27)
Also adding in first_preset jump as it's a convenient shortcut.
That part can go away if it's not approved. I can always just use it on my end.
