### PR TITLE
Add Two-Way Array Cycling.

### DIFF
--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -346,7 +346,7 @@ GESTURE CONTROLS
 #endif
 #endif
 
-  // Check that Default Array is valid.
+  // Check that Default Array is valid at compile time.
   static_assert(
     SABERSENSE_DEFAULT_BLADE_ARRAY < NELEM(blades),
     "SABERSENSE_DEFAULT_BLADE_ARRAY must reference a valid array (note zero-based counting)."

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-276.
+/* V7/8-277.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -346,7 +346,7 @@ GESTURE CONTROLS
 #endif
 #endif
 
-  //  Check user-defined array is valid at compile time.
+  // Check user-defined array is valid at compile time.
   static_assert(
     SABERSENSE_DEFAULT_BLADE_ARRAY < NELEM(blades),
     "SABERSENSE_DEFAULT_BLADE_ARRAY must reference a valid array (note zero-based counting)."
@@ -357,13 +357,12 @@ GESTURE CONTROLS
     SABERSENSE_DEFAULT_BLADE_ARRAY != 0,
     "[Sabersense] ERROR: Default array index must be 1 or higher when using Blade Detect."
   );
-  
   constexpr int min_blades_required = 3;
 #else
   constexpr int min_blades_required = 2;
 #endif
 
-  // Check that Array Selector is needed (prevents unexpected behaviour).
+  // Check that Array Selector is actually needed (prevents possible unexpected behaviour).
   static_assert(
     NELEM(blades) >= min_blades_required,
     "[Sabersense] ERROR: Array Selector is not required with only one selectable blade array. "
@@ -382,10 +381,10 @@ public:
 
   struct SabersenseArraySelector {
     static int return_value;
-
     float id() {
       if (return_value < 0 || return_value >= NELEM(blades)) {
-        Serial.println("[Sabersense] ALERT: Invalid array index. Resetting to default.");
+        Serial.println("[Sabersense] ALERT: User or externally-specified array index invalid. "
+                       "Resetting to default.");
         return_value = SABERSENSE_DEFAULT_BLADE_ARRAY;
       }
       return return_value;
@@ -409,18 +408,17 @@ public:
     }
   };
 
-// Set initial index based on Blade Detect mode
+    // Set initial index based on Blade Detect mode.
 #ifndef BLADE_DETECT_PIN
-int SabersenseArraySelector::return_value = 0;
+    int SabersenseArraySelector::return_value = 0;
 #else
-int SabersenseArraySelector::return_value = 1;
+    int SabersenseArraySelector::return_value = 1;
 #endif
 
 #undef BLADE_ID_CLASS_INTERNAL
 #define BLADE_ID_CLASS_INTERNAL SabersenseArraySelector
 #undef BLADE_ID_CLASS
 #define BLADE_ID_CLASS SabersenseArraySelector
-
 #endif
 
 #include "prop_base.h"
@@ -1034,7 +1032,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       return true;
 #endif
 
-// Manual blade array selector.
+    // Manual blade array selector.
 #ifdef SABERSENSE_ARRAY_SELECTOR
     case EVENTID(BUTTON_POWER, EVENT_THIRD_SAVED_CLICK_SHORT, MODE_OFF):
       // Check for blade present if using Blade Detect.

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-275.
+/* V7/8-276.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -346,7 +346,7 @@ GESTURE CONTROLS
 #endif
 #endif
 
-  // Check that Default Array is valid at compile time.
+  //  Check user-defined array is valid at compile time.
   static_assert(
     SABERSENSE_DEFAULT_BLADE_ARRAY < NELEM(blades),
     "SABERSENSE_DEFAULT_BLADE_ARRAY must reference a valid array (note zero-based counting)."

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-278.
+/* V7/8-283.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -392,21 +392,15 @@ public:
       return return_value;
     }
 
-    static void cycle_directional(bool forward) {
-#ifndef BLADE_DETECT_PIN
-      const int size = NELEM(blades);
-      return_value = (return_value + (forward ? 1 : size - 1)) % size;
-#else
-      const int min_index = 1;
-      const int max_index = NELEM(blades) - 1;
-      if (forward) {
-        return_value++;
-        if (return_value > max_index) return_value = min_index;
-      } else {
-        return_value--;
-        if (return_value < min_index) return_value = max_index;
-      }
+    static void cycle_array(bool forward) {
+      int size = NELEM(blades);
+      int offset = 0;
+#ifdef BLADE_DETECT_PIN
+      offset = 1;
+      size--;
 #endif
+      return_value += forward ? 1 : (size - 1);
+      return_value = (return_value + size - offset) % size + offset;
     }
   };
 
@@ -421,7 +415,7 @@ public:
 #define BLADE_ID_CLASS_INTERNAL SabersenseArraySelector
 #undef BLADE_ID_CLASS
 #define BLADE_ID_CLASS SabersenseArraySelector
-#endif
+#endif  // SABERSENSE_ARRAY_SELECTOR
 
 #include "prop_base.h"
 
@@ -1044,7 +1038,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
       {
         // Cycles through blade arrays regardless of BladeID status.
         bool forward = fusor.angle1() > 0;
-        SabersenseArraySelector::cycle_directional(forward);
+        SabersenseArraySelector::cycle_array(forward);
       }
       FindBladeAgain();
       IdentBladeArray();

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1072,7 +1072,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
 #ifndef SABERSENSE_DISABLE_SAVE_ARRAY
       SaveArrayState();
 #endif
-  return true;
+      return true;
 #endif
 
     // SOUND EFFECT PLAYERS.

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-283.
+/* V7/8-284.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -735,7 +735,7 @@ public:
   }
 #endif
 
-  void IdentBladeArray() {  // Plays associated arrayx.wav to ident array landed on.
+  void PlayArraySound() {
 #ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'array' sound AND 'font' sound.
     SFX_array.Select(current_config - blades);
     hybrid_font.PlayCommon(&SFX_array);
@@ -1041,7 +1041,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         SabersenseArraySelector::cycle_array(forward);
       }
       FindBladeAgain();
-      IdentBladeArray();  // Plays associated arrayx.wav to ident array landed on.
+      PlayArraySound();  // Plays associated arrayx.wav to ident array landed on.
 #ifndef SABERSENSE_DISABLE_SAVE_ARRAY
       SaveArrayState();
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-277.
+/* V7/8-278.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -101,7 +101,8 @@ FUNCTIONS WITH BLADE OFF
   Play Character Quote      Fast double-click, hilt pointing up, plays sequentially. **
   Play Music Track          Fast double-click, hilt pointing down. **
   Speak battery voltage     Fast double-click-and-hold, hilt horizontal.
-  Run BladeID/Array Select  Fast triple-click while OFF. (Applicable installs only).
+  Run BladeID/Array Select  Fast triple-click while OFF. (Configurable, applicable installs only).
+                              Array Selector is point up for forwards, down for backwards.
   Restore Factory Defaults  Fast four-clicks while OFF, hold on last click.
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold and clash while OFF.
@@ -157,7 +158,8 @@ FUNCTIONS WITH BLADE OFF
   Play Character Quote      Fast double-click POWER, hilt pointing up, plays sequentially. **
   Play Music Track          Fast double-click POWER, pointing down. **
   Speak battery voltage     Fast double-click-and-hold POWER.
-  Run BladeID/Array Select  Fast triple-click. (Applicable installs only).
+  Run BladeID/Array Select  Fast triple-click POWER. (Configurable, applicable installs only).
+                              Array Selector is point up for forwards, down for backwards.
   Restore Factory Defaults  Fast four-clicks POWER, hold on last click.
                               Release once announcement starts.
   Enter/Exit VOLUME MENU    Hold POWER then quickly click AUX and release both simultaneously.
@@ -210,13 +212,13 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Plays array-specific bladeidX.wav files when switching.
 
 #define SABERSENSE_ARRAY_SELECTOR
-  Replaces regular BladeID and allows cycling between
-  different blade/preset arrays manually, regardless
-  of actual BladeID status. Plays array-specific
-  arrayX.wav files when switching.
+  Replaces regular BladeID and allows forwards or
+  backwards cycling between different blade/preset
+  arrays manually, regardless of actual BladeID status.
+  Plays array-specific arrayX.wav files when switching.
   Requires arrays to be numbered consecutively,
-  starting at zero, in the field that would otherwise
-  contain BladeID values. Like this:
+  starting at zero, in the field that would
+  otherwise contain BladeID values. Like this:
       { 0, ... }
       { 1, ... }
       { 2, ... }
@@ -230,8 +232,8 @@ COLOUR CHANGE FUNCTIONS WITH BLADE ON
   Note that you can have any number of Blade-In arrays
   in your config, but only one NO_BLADE array is supported.
   Note also that NO_BLADE replaces the zero array,
-  meaning that Blade-In array numbering must be consecutive
-  starting at 1. Like this:
+  meaning that Blade-In array numbering must be
+  consecutive starting at 1. Like this:
       { NO_BLADE, ... }
       { 1, ... }
       { 2, ... }

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1041,7 +1041,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         SabersenseArraySelector::cycle_array(forward);
       }
       FindBladeAgain();
-      PlayArraySound();  // Plays associated arrayx.wav to ident array landed on.
+      PlayArraySound();
 #ifndef SABERSENSE_DISABLE_SAVE_ARRAY
       SaveArrayState();
 #endif

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -1,4 +1,4 @@
-/* V7/8-270.
+/* V7/8-271.
 ============================================================
 =================   SABERSENSE PROP FILE   =================
 =================            by            =================
@@ -373,8 +373,8 @@ GESTURE CONTROLS
     "[Sabersense] ERROR: Two-way selector requires 3 or more valid arrays."
   );
   static_assert(
-    SABERSENSE_NUM_ARRAYS_TWO_WAY_SELECTOR <= NELEM(blades),
-    "[Sabersense] ERROR: Two-way selector value exceeds number of blade arrays present."
+    SABERSENSE_NUM_ARRAYS_TWO_WAY_SELECTOR == NELEM(blades),
+    "[Sabersense] ERROR: Two-way selector value must match total number of blade arrays present."
   );
 #endif
 

--- a/props/saber_sabersense_buttons.h
+++ b/props/saber_sabersense_buttons.h
@@ -735,7 +735,7 @@ public:
   }
 #endif
 
-  void IdentBladeArray() {
+  void IdentBladeArray() {  // Plays associated arrayx.wav to ident array landed on.
 #ifdef SABERSENSE_ENABLE_ARRAY_FONT_IDENT  // Plays 'array' sound AND 'font' sound.
     SFX_array.Select(current_config - blades);
     hybrid_font.PlayCommon(&SFX_array);
@@ -1041,7 +1041,7 @@ bool Event2(enum BUTTON button, EVENT event, uint32_t modifiers) override {
         SabersenseArraySelector::cycle_array(forward);
       }
       FindBladeAgain();
-      IdentBladeArray();
+      IdentBladeArray();  // Plays associated arrayx.wav to ident array landed on.
 #ifndef SABERSENSE_DISABLE_SAVE_ARRAY
       SaveArrayState();
 #endif


### PR DESCRIPTION
This has been touched on before, but always abandoned because it requires a define telling the system how many arrays are present. So this time I've wrapped the feature in a define so that it's there if people want it but doesn't place extra demands if they don't, with the define itself specifying the number of arrays. I've also included a couple of safeguards to prevent invalid NUM_ARRAY values.

The only thing not covered is if people define fewer arrays than are present. But that's a fairly simple thing to trace in the config once they notice that behaviour does not match expectation. 
_*** EDIT: I've now tweaked the alert to include low as well as high values. ***_

I've also tweaked the UP/DOWN angles to make them less strict, and then changed the single-preset UP/DOWN forward/backward parameter to match.

Lastly Two-Way array cycling meant NextBladeArray was no longer accurate as it would apply to previous blade arrays too. Since all it really does is play the array idents, I changed it to be a more accurately descriptive IdentBladeArray.

Hope this all OK, and sorry to keep bombarding you with PRs - at least there is only a relatively small amount of code involved!

Thanks as always.
:)