### PR TITLE
bug fix for 1 button Edit Settings Menu

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -5421,7 +5421,11 @@ SaberFett263Buttons() : PropBase() {}
             sound_library_.SayExit();
             menu_ = false;
           } else {
+#ifdef FETT263_EDIT_SETTINGS_MENU
+            menu_type_ = MENU_SETTING_SUB;
+#else
             menu_type_ = MENU_TOP;
+#endif
             MenuCancel();
           }
           return true;


### PR DESCRIPTION
User reported bug in theCrucible, causes uses to be unable to exit when EDIT_SETTINGS_MENU define used.