### PR TITLE
EDIT_SETTINGS_MENU bug fix for OS7 & 8

### DIFF
--- a/props/saber_fett263_buttons.h
+++ b/props/saber_fett263_buttons.h
@@ -5657,7 +5657,11 @@ SaberFett263Buttons() : PropBase() {}
             sound_library_.SayExit();
             menu_ = false;
           } else {
+#ifdef FETT263_EDIT_SETTINGS_MENU
+            menu_type_ = MENU_SETTING_SUB;
+#else
             menu_type_ = MENU_TOP;
+#endif
             MenuCancel();
           }
           return true;
@@ -6106,7 +6110,11 @@ case EVENTID(BUTTON_POWER, EVENT_FOURTH_HELD_LONG, MODE_OFF):
             sound_library_.SayExit();
             menu_ = false;
           } else {
+#ifdef FETT263_EDIT_SETTINGS_MENU
+            menu_type_ = MENU_SETTING_SUB;
+#else
             menu_type_ = MENU_TOP;
+#endif
             MenuCancel();
           }
           return true;


### PR DESCRIPTION
Users get stuck in wrong menu using the "Cancel" control, was reported on theCrucible, hadn't been noticed or reported prior but should probably be applied to OS7 as a bug fix on top on including in OS8.