### PR TITLE
revert SD error report from scan directory

### DIFF
--- a/sound/effect.h
+++ b/sound/effect.h
@@ -610,7 +610,6 @@ class Effect {
 #endif
 
 #ifdef ENABLE_SD
-    if (!LSFS::Begin()) ProffieOSErrors::sd_card_not_found();
     if (LSFS::Exists(dir)) {
       Scanner scanner;
       scanner.Scan(dir);


### PR DESCRIPTION
This is playing SD error for every font in the preset, and it's overkill.
Maybe we let it behave the way it was without this and just do the SD error once at boot, and preset changes just report fonts missing?
The Serial monitor is already riddled with
Failed to mount SD card.
Failed to mount SD card.
Failed to mount SD card.