### PR TITLE
Add set_preset_fast to serial cmds

### DIFF
--- a/props/prop_base.h
+++ b/props/prop_base.h
@@ -1754,6 +1754,13 @@ public:
       return true;
     }
 
+    if (!strcmp(cmd, "set_preset_fast") && arg) {
+      int preset = strtol(arg, NULL, 0);
+      SaveState(preset);
+      SetPreset(preset, false);
+      return true;
+    }
+
     if (!strcmp(cmd, "change_preset") && arg) {
       int preset = strtol(arg, NULL, 0);
       if (preset != current_preset_.preset_num) {


### PR DESCRIPTION
Primarily for Forcesync app use, this bypasses font.wav from playing while on