### PR TITLE
Fix errors not playing wavs

### DIFF
--- a/common/errors.h
+++ b/common/errors.h
@@ -2,6 +2,9 @@
 #ifndef COMMON_ERROR_H_DECLARED
 #define COMMON_ERROR_H_DECLARED
 
+extern bool font_dir_missing_;
+extern bool error_in_font_dir_;
+
 #ifdef ENABLE_AUDIO
 void DodgeSound(uint32_t millis);
 #else
@@ -22,6 +25,8 @@ public:
 #endif // COMMON_ERROR_H_DECLARED
 
 #ifdef PROFFIEOS_DEFINE_FUNCTION_STAGE
+bool font_dir_missing_ = false;
+bool error_in_font_dir_ = false;
 
 void ProffieOSErrors::sd_card_not_found() {
   SaberBase::DoEffect(EFFECT_SD_CARD_NOT_FOUND, 0);

--- a/sound/effect.h
+++ b/sound/effect.h
@@ -615,7 +615,7 @@ class Effect {
       scanner.Scan(dir);
       STDOUT.println(" done");
     } else {
-      if (strlen(dir)) ProffieOSErrors::font_directory_not_found();
+      if (strlen(dir)) font_dir_missing_ = true;
     }
 #endif   // ENABLE_SD
   }
@@ -637,7 +637,7 @@ class Effect {
         if (!warned) {
           warned = true;
           PVLOG_ERROR <<"\nWARNING: A font seems to be missing some files!!\n";
-          ProffieOSErrors::error_in_font_directory();
+          error_in_font_dir_ = true;
         }
         e->Show();
       }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -166,10 +166,21 @@ public:
 
     STDOUT.println(" font.");
     SaberBase::Link(this);
+
+    if (font_dir_missing_) {
+      font_dir_missing_ = false;
+      ProffieOSErrors::font_directory_not_found();
+    }
+    if (error_in_font_dir_) {
+      error_in_font_dir_ = false;
+      ProffieOSErrors::error_in_font_directory();
+    }
+
     Looper::Link();
     SetHumVolume(1.0);
     state_ = STATE_OFF;
   }
+
 
   enum State {
     STATE_OFF,


### PR DESCRIPTION
If we wait until after the call to SaberBase::Link(this); in Activate() to call the errors, it plays the wavs.