### PR TITLE
Better error wav use

### DIFF
--- a/common/delay_timer.h
+++ b/common/delay_timer.h
@@ -1,0 +1,26 @@
+#ifndef DELAY_TIMER_H
+#define DELAY_TIMER_H
+// Returns a reference to the shared deadline timestamp (milliseconds).
+inline uint32_t& delay_until_ms() {
+  static uint32_t ts = 0;
+  return ts;
+}
+// Set the timer to expire `duration_ms` from now, overwriting any
+// existing deadline.  Use when only one error source is active.
+inline void StartDelayTimer(uint32_t duration_ms) {
+  delay_until_ms() = millis() + duration_ms;
+}
+// Extend the deadline by `duration_ms` from wherever it currently sits
+// (or from now if it has already expired).  Use when multiple error
+// sources may fire in quick succession so that their delays stack rather
+// than reset.
+inline void AppendToDelayTimer(uint32_t duration_ms) {
+  uint32_t now = millis();
+  if (delay_until_ms() < now) delay_until_ms() = now;
+  delay_until_ms() += duration_ms;
+}
+// Returns true while the deadline is still in the future.
+inline bool DelayTimerActive() {
+  return millis() < delay_until_ms();
+}
+#endif  // DELAY_TIMER_H

--- a/common/delay_timer.h
+++ b/common/delay_timer.h
@@ -1,15 +1,18 @@
 #ifndef DELAY_TIMER_H
 #define DELAY_TIMER_H
+
 // Returns a reference to the shared deadline timestamp (milliseconds).
 inline uint32_t& delay_until_ms() {
   static uint32_t ts = 0;
   return ts;
 }
+
 // Set the timer to expire `duration_ms` from now, overwriting any
 // existing deadline.  Use when only one error source is active.
 inline void StartDelayTimer(uint32_t duration_ms) {
   delay_until_ms() = millis() + duration_ms;
 }
+
 // Extend the deadline by `duration_ms` from wherever it currently sits
 // (or from now if it has already expired).  Use when multiple error
 // sources may fire in quick succession so that their delays stack rather
@@ -19,8 +22,19 @@ inline void AppendToDelayTimer(uint32_t duration_ms) {
   if (delay_until_ms() < now) delay_until_ms() = now;
   delay_until_ms() += duration_ms;
 }
+
 // Returns true while the deadline is still in the future.
 inline bool DelayTimerActive() {
   return millis() < delay_until_ms();
 }
+
+// Flag set by PlayErrorMessage() when an error wav is queued, cleared by
+// SoundQueueSingleton::Loop() when the queue drains.  Allows hybrid_font.h
+// to defer boot/font sounds until the error wav actually finishes playing
+// without depending on SoundQueueSingleton (defined later in the build).
+inline bool& error_sound_active() {
+  static bool s = false;
+  return s;
+}
+
 #endif  // DELAY_TIMER_H

--- a/common/delay_timer.h
+++ b/common/delay_timer.h
@@ -28,13 +28,4 @@ inline bool DelayTimerActive() {
   return millis() < delay_until_ms();
 }
 
-// Flag set by PlayErrorMessage() when an error wav is queued, cleared by
-// SoundQueueSingleton::Loop() when the queue drains.  Allows hybrid_font.h
-// to defer boot/font sounds until the error wav actually finishes playing
-// without depending on SoundQueueSingleton (defined later in the build).
-inline bool& error_sound_active() {
-  static bool s = false;
-  return s;
-}
-
 #endif  // DELAY_TIMER_H

--- a/common/delay_timer.h
+++ b/common/delay_timer.h
@@ -8,15 +8,13 @@ inline uint32_t& delay_until_ms() {
 }
 
 // Set the timer to expire `duration_ms` from now, overwriting any
-// existing deadline.  Use when only one error source is active.
+// existing deadline.  Used when only one error source is active.
 inline void StartDelayTimer(uint32_t duration_ms) {
   delay_until_ms() = millis() + duration_ms;
 }
 
-// Extend the deadline by `duration_ms` from wherever it currently sits
-// (or from now if it has already expired).  Use when multiple error
-// sources may fire in quick succession so that their delays stack rather
-// than reset.
+// Extend the expiration. Used for multiple errors
+// so that their delays stack rather than reset.
 inline void AppendToDelayTimer(uint32_t duration_ms) {
   uint32_t now = millis();
   if (delay_until_ms() < now) delay_until_ms() = now;

--- a/common/errors.h
+++ b/common/errors.h
@@ -9,7 +9,6 @@ void DodgeSound(uint32_t millis);
 #else
 #define DodgeSound(X) X
 #endif
-#include "delay_timer.h"
 
 class ProffieOSErrors {
 public:

--- a/common/errors.h
+++ b/common/errors.h
@@ -4,6 +4,7 @@
 
 #include "delay_timer.h"
 
+// Keep around for use for other things
 #ifdef ENABLE_AUDIO
 void DodgeSound(uint32_t millis);
 #else
@@ -52,7 +53,6 @@ void ProffieOSErrors::font_directory_not_found() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_font_directory_15, 15);
   talkie.Say(talkie_not_found_15, 15);
-  // DodgeSound(2000);
   AppendToDelayTimer(2000);
 #else
   beeper.Beep(0.5,   261.63 * 2); // C5 - Font
@@ -62,7 +62,6 @@ void ProffieOSErrors::font_directory_not_found() {
   beeper.Beep(0.5,   174.61 * 2); // F4 - y
   beeper.Beep(0.5,   146.83 * 2); // D4 - not
   beeper.Beep(0.5,   130.81 * 2); // C4 - found
-  // DodgeSound(2530);
   AppendToDelayTimer(2530);
 #endif
 #endif
@@ -77,14 +76,12 @@ void ProffieOSErrors::voice_pack_not_found() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_voice_pack_15, 25);
   talkie.Say(talkie_not_found_15, 15);
-  // DodgeSound(2000);
   AppendToDelayTimer(2000);
 #else
   beeper.Beep(1.0, 220.00 * 2); // A4 - Voice
   beeper.Beep(0.5, 130.81 * 2); // C4 - pack
   beeper.Beep(0.5, 146.83 * 2); // D4 - not
   beeper.Beep(1.0, 130.81 * 2); // C4 - found
-  // DodgeSound(3000);
   AppendToDelayTimer(3000);
 #endif
 #endif
@@ -99,7 +96,6 @@ void ProffieOSErrors::error_in_blade_array() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_blade_array_15, 15);
-  // DodgeSound(2000);
   AppendToDelayTimer(2000);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
@@ -110,7 +106,6 @@ void ProffieOSErrors::error_in_blade_array() {
   beeper.Beep(0.2,  0);          // Silence
   beeper.Beep(0.5,  146.83 * 2); // D4 - ar
   beeper.Beep(1.0,  130.81 * 2); // C4 - ray
-  // DodgeSound(3000);
   AppendToDelayTimer(3000);
 #endif
 #endif
@@ -125,7 +120,6 @@ void ProffieOSErrors::error_in_font_directory() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_font_directory_15, 15);
-  // DodgeSound(1300);
   AppendToDelayTimer(1300);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
@@ -137,7 +131,6 @@ void ProffieOSErrors::error_in_font_directory() {
   beeper.Beep(0.5,  196.00 * 2); // G4 - rec
   beeper.Beep(0.5,  246.94 * 2); // B4 - tor
   beeper.Beep(0.5,  261.63 * 2); // C5 - y
-  // DodgeSound(3500);
   AppendToDelayTimer(3500);
 #endif
 #endif
@@ -153,7 +146,6 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_voice_pack_15, 15);
   talkie.Say(talkie_version_15, 15);
-  // DodgeSound(1500);
   AppendToDelayTimer(1500);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
@@ -164,7 +156,6 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   beeper.Beep(0.5,  146.83 * 2); // D4 - pack
   beeper.Beep(1.0,  196.00 * 2); // G4 - ver
   beeper.Beep(0.5,  130.81 * 2); // C4 - sion
-  // DodgeSound(3500);
   AppendToDelayTimer(3500);
 #endif
 #endif

--- a/common/errors.h
+++ b/common/errors.h
@@ -2,11 +2,14 @@
 #ifndef COMMON_ERROR_H_DECLARED
 #define COMMON_ERROR_H_DECLARED
 
+#include "delay_timer.h"
+
 #ifdef ENABLE_AUDIO
 void DodgeSound(uint32_t millis);
 #else
 #define DodgeSound(X) X
 #endif
+#include "delay_timer.h"
 
 class ProffieOSErrors {
 public:
@@ -50,7 +53,8 @@ void ProffieOSErrors::font_directory_not_found() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_font_directory_15, 15);
   talkie.Say(talkie_not_found_15, 15);
-  DodgeSound(2000);
+  // DodgeSound(2000);
+  StartDelayTimer(2000);
 #else
   beeper.Beep(0.5,   261.63 * 2); // C5 - Font
   beeper.Beep(0.5/3, 246.94 * 2); // B4 - di
@@ -59,7 +63,8 @@ void ProffieOSErrors::font_directory_not_found() {
   beeper.Beep(0.5,   174.61 * 2); // F4 - y
   beeper.Beep(0.5,   146.83 * 2); // D4 - not
   beeper.Beep(0.5,   130.81 * 2); // C4 - found
-  DodgeSound(2530);
+  // DodgeSound(2530);
+  StartDelayTimer(2530);
 #endif
 #endif
 }
@@ -73,13 +78,15 @@ void ProffieOSErrors::voice_pack_not_found() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_voice_pack_15, 25);
   talkie.Say(talkie_not_found_15, 15);
-  DodgeSound(2000);
+  // DodgeSound(2000);
+  StartDelayTimer(2000);
 #else
   beeper.Beep(1.0, 220.00 * 2); // A4 - Voice
   beeper.Beep(0.5, 130.81 * 2); // C4 - pack
   beeper.Beep(0.5, 146.83 * 2); // D4 - not
   beeper.Beep(1.0, 130.81 * 2); // C4 - found
-  DodgeSound(3000);
+  // DodgeSound(3000);
+  StartDelayTimer(3000);
 #endif
 #endif
 }
@@ -93,7 +100,8 @@ void ProffieOSErrors::error_in_blade_array() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_blade_array_15, 15);
-  DodgeSound(2000);
+  // DodgeSound(2000);
+  StartDelayTimer(2000);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -103,7 +111,8 @@ void ProffieOSErrors::error_in_blade_array() {
   beeper.Beep(0.2,  0);          // Silence
   beeper.Beep(0.5,  146.83 * 2); // D4 - ar
   beeper.Beep(1.0,  130.81 * 2); // C4 - ray
-  DodgeSound(3000);
+  // DodgeSound(3000);
+  StartDelayTimer(3000);
 #endif
 #endif
 }
@@ -117,7 +126,8 @@ void ProffieOSErrors::error_in_font_directory() {
 #ifndef DISABLE_TALKIE
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_font_directory_15, 15);
-  DodgeSound(1300);
+  // DodgeSound(1300);
+  StartDelayTimer(1300);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -128,7 +138,8 @@ void ProffieOSErrors::error_in_font_directory() {
   beeper.Beep(0.5,  196.00 * 2); // G4 - rec
   beeper.Beep(0.5,  246.94 * 2); // B4 - tor
   beeper.Beep(0.5,  261.63 * 2); // C5 - y
-  DodgeSound(3500);
+  // DodgeSound(3500);
+  StartDelayTimer(3500);
 #endif
 #endif
 }
@@ -143,7 +154,8 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_voice_pack_15, 15);
   talkie.Say(talkie_version_15, 15);
-  DodgeSound(1500);
+  // DodgeSound(1500);
+  StartDelayTimer(1500);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -153,14 +165,15 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   beeper.Beep(0.5,  146.83 * 2); // D4 - pack
   beeper.Beep(1.0,  196.00 * 2); // G4 - ver
   beeper.Beep(0.5,  130.81 * 2); // C4 - sion
-  DodgeSound(3500);
+  // DodgeSound(3500);
+  StartDelayTimer(3500);
 #endif
 #endif
 }
 
 void ProffieOSErrors::low_battery() {
 #ifdef ENABLE_AUDIO
-  // play the fonts low battery sound if it exists
+  // play the font's low battery sound if it exists
   if (SFX_lowbatt) {
     hybrid_font.PlayCommon(&SFX_lowbatt);
     return;

--- a/common/errors.h
+++ b/common/errors.h
@@ -54,7 +54,7 @@ void ProffieOSErrors::font_directory_not_found() {
   talkie.Say(talkie_font_directory_15, 15);
   talkie.Say(talkie_not_found_15, 15);
   // DodgeSound(2000);
-  StartDelayTimer(2000);
+  AppendToDelayTimer(2000);
 #else
   beeper.Beep(0.5,   261.63 * 2); // C5 - Font
   beeper.Beep(0.5/3, 246.94 * 2); // B4 - di
@@ -64,7 +64,7 @@ void ProffieOSErrors::font_directory_not_found() {
   beeper.Beep(0.5,   146.83 * 2); // D4 - not
   beeper.Beep(0.5,   130.81 * 2); // C4 - found
   // DodgeSound(2530);
-  StartDelayTimer(2530);
+  AppendToDelayTimer(2530);
 #endif
 #endif
 }
@@ -79,14 +79,14 @@ void ProffieOSErrors::voice_pack_not_found() {
   talkie.Say(talkie_voice_pack_15, 25);
   talkie.Say(talkie_not_found_15, 15);
   // DodgeSound(2000);
-  StartDelayTimer(2000);
+  AppendToDelayTimer(2000);
 #else
   beeper.Beep(1.0, 220.00 * 2); // A4 - Voice
   beeper.Beep(0.5, 130.81 * 2); // C4 - pack
   beeper.Beep(0.5, 146.83 * 2); // D4 - not
   beeper.Beep(1.0, 130.81 * 2); // C4 - found
   // DodgeSound(3000);
-  StartDelayTimer(3000);
+  AppendToDelayTimer(3000);
 #endif
 #endif
 }
@@ -101,7 +101,7 @@ void ProffieOSErrors::error_in_blade_array() {
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_blade_array_15, 15);
   // DodgeSound(2000);
-  StartDelayTimer(2000);
+  AppendToDelayTimer(2000);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -112,7 +112,7 @@ void ProffieOSErrors::error_in_blade_array() {
   beeper.Beep(0.5,  146.83 * 2); // D4 - ar
   beeper.Beep(1.0,  130.81 * 2); // C4 - ray
   // DodgeSound(3000);
-  StartDelayTimer(3000);
+  AppendToDelayTimer(3000);
 #endif
 #endif
 }
@@ -127,7 +127,7 @@ void ProffieOSErrors::error_in_font_directory() {
   talkie.Say(talkie_error_in_15, 15);
   talkie.Say(talkie_font_directory_15, 15);
   // DodgeSound(1300);
-  StartDelayTimer(1300);
+  AppendToDelayTimer(1300);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -139,7 +139,7 @@ void ProffieOSErrors::error_in_font_directory() {
   beeper.Beep(0.5,  246.94 * 2); // B4 - tor
   beeper.Beep(0.5,  261.63 * 2); // C5 - y
   // DodgeSound(3500);
-  StartDelayTimer(3500);
+  AppendToDelayTimer(3500);
 #endif
 #endif
 }
@@ -155,7 +155,7 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   talkie.Say(talkie_voice_pack_15, 15);
   talkie.Say(talkie_version_15, 15);
   // DodgeSound(1500);
-  StartDelayTimer(1500);
+  AppendToDelayTimer(1500);
 #else
   beeper.Beep(0.25, 174.61 * 2); // F4 - Err
   beeper.Beep(0.25, 196.00 * 2); // G4 - or
@@ -166,7 +166,7 @@ void ProffieOSErrors::error_in_voice_pack_version() {
   beeper.Beep(1.0,  196.00 * 2); // G4 - ver
   beeper.Beep(0.5,  130.81 * 2); // C4 - sion
   // DodgeSound(3500);
-  StartDelayTimer(3500);
+  AppendToDelayTimer(3500);
 #endif
 #endif
 }

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -902,7 +902,7 @@ public:
     }
 // \/\/\/\/ this is BC only because I think this is how it should work
       // Delay boot.wav for error talkie/beeps to finish..
-    if (!DelayTimerActive()) {
+    if (!DelayTimerActive() && !error_sound_active()) {
       if (pending_boot_) {
         pending_boot_ = false;
         if (!PlayPolyphonic(&SFX_boot)) {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -1,7 +1,7 @@
 #ifndef SOUND_HYBRID_FONT_H
 #define SOUND_HYBRID_FONT_H
 #include "../common/fuse.h"
-#include "../common/delay_timer.h"  // this is BC only because I think this is how it should work
+#include "../common/delay_timer.h"
 
 class FontConfigFile : public ConfigFile {
 public:
@@ -616,16 +616,16 @@ public:
       case EFFECT_BOOT:
         if (DelayTimerActive()) {
           pending_boot_ = true;
-          PVLOG_NORMAL << "*** BOOT deferred — waiting for error sound to finish\n";
+          PVLOG_DEBUG << "*** BOOT deferred — waiting for error sound to finish\n";
           return;
         }
         if (PlayPolyphonic(&SFX_boot)) return;
-        // If no boot sounds are found, fall through to font.
+        // If no boot sounds are found, fall through to font. - This is not how it currently works.
         [[gnu::fallthrough]];
       case EFFECT_NEWFONT:
         if (DelayTimerActive()) {
           pending_newfont_ = true;
-          PVLOG_NORMAL << "*** NEWFONT deferred — waiting for error sound to finish\n";
+          PVLOG_DEBUG << "*** NEWFONT deferred — waiting for error sound to finish\n";
           return;
         }
         SB_NewFont();
@@ -900,13 +900,12 @@ public:
         SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
       }
     }
-// \/\/\/\/ this is BC only because I think this is how it should work
       // Delay boot.wav for error talkie/beeps to finish..
     if (!DelayTimerActive()) {
       if (pending_boot_) {
         pending_boot_ = false;
         if (!PlayPolyphonic(&SFX_boot)) {
-          // No boot sound — fall through to font
+          // No boot sound — fall through to font - not how it works currently
           pending_newfont_ = true;
         }
       }
@@ -915,7 +914,6 @@ public:
         SB_NewFont();
       }
     }
-// /\/\/\/\ this is BC only because I think this is how it should work
   }
 
   void StopIdleSound() {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -1,6 +1,7 @@
 #ifndef SOUND_HYBRID_FONT_H
 #define SOUND_HYBRID_FONT_H
 #include "../common/fuse.h"
+#include "../common/delay_timer.h"  // this is BC only because I think this is how it should work
 
 class FontConfigFile : public ConfigFile {
 public:
@@ -612,8 +613,23 @@ public:
       case EFFECT_FORCE: PlayCommon(&SFX_force); return;
       case EFFECT_BLAST: Play(&SFX_blaster, &SFX_blst); return;
       case EFFECT_QUOTE: PlayCommon(&SFX_quote); return;
-      case EFFECT_BOOT: PlayPolyphonic(&SFX_boot); return;
-      case EFFECT_NEWFONT: SB_NewFont(); return;
+      case EFFECT_BOOT:
+        if (DelayTimerActive()) {
+          pending_boot_ = true;
+          PVLOG_NORMAL << "*** BOOT deferred — waiting for error sound to finish\n";
+          return;
+        }
+        if (PlayPolyphonic(&SFX_boot)) return;
+        // If no boot sounds are found, fall through to font.
+        [[gnu::fallthrough]];
+      case EFFECT_NEWFONT:
+        if (DelayTimerActive()) {
+          pending_newfont_ = true;
+          PVLOG_NORMAL << "*** NEWFONT deferred — waiting for error sound to finish\n";
+          return;
+        }
+        SB_NewFont();
+        return;
       case EFFECT_LOCKUP_BEGIN: SB_BeginLockup(); return;
       case EFFECT_LOCKUP_END: SB_EndLockup(); return;
       case EFFECT_LOW_BATTERY: SB_LowBatt(); return;
@@ -867,6 +883,8 @@ public:
   }
 
   bool check_postoff_ = false;
+  bool pending_boot_ = false;
+  bool pending_newfont_ = false;
   void Loop() override {
     if (state_ == STATE_WAIT_FOR_ON) {
       if (!GetWavPlayerPlaying(&SFX_preon)) {
@@ -882,6 +900,22 @@ public:
         SaberBase::DoEffect(EFFECT_POSTOFF, saved_location_);
       }
     }
+// \/\/\/\/ this is BC only because I think this is how it should work
+      // Delay boot.wav for error talkie/beeps to finish..
+    if (!DelayTimerActive()) {
+      if (pending_boot_) {
+        pending_boot_ = false;
+        if (!PlayPolyphonic(&SFX_boot)) {
+          // No boot sound — fall through to font
+          pending_newfont_ = true;
+        }
+      }
+      if (pending_newfont_) {
+        pending_newfont_ = false;
+        SB_NewFont();
+      }
+    }
+// /\/\/\/\ this is BC only because I think this is how it should work
   }
 
   void StopIdleSound() {

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -614,7 +614,7 @@ public:
       case EFFECT_BLAST: Play(&SFX_blaster, &SFX_blst); return;
       case EFFECT_QUOTE: PlayCommon(&SFX_quote); return;
       case EFFECT_BOOT:
-        if (DelayTimerActive()) {
+        if (DelayTimerActive() || error_sound_active()) {
           pending_boot_ = true;
           PVLOG_NORMAL << "*** BOOT deferred — waiting for error sound to finish\n";
           return;
@@ -623,7 +623,7 @@ public:
         // If no boot sounds are found, fall through to font.
         [[gnu::fallthrough]];
       case EFFECT_NEWFONT:
-        if (DelayTimerActive()) {
+        if (DelayTimerActive() || error_sound_active()) {
           pending_newfont_ = true;
           PVLOG_NORMAL << "*** NEWFONT deferred — waiting for error sound to finish\n";
           return;

--- a/sound/hybrid_font.h
+++ b/sound/hybrid_font.h
@@ -614,7 +614,7 @@ public:
       case EFFECT_BLAST: Play(&SFX_blaster, &SFX_blst); return;
       case EFFECT_QUOTE: PlayCommon(&SFX_quote); return;
       case EFFECT_BOOT:
-        if (DelayTimerActive() || error_sound_active()) {
+        if (DelayTimerActive()) {
           pending_boot_ = true;
           PVLOG_NORMAL << "*** BOOT deferred — waiting for error sound to finish\n";
           return;
@@ -623,7 +623,7 @@ public:
         // If no boot sounds are found, fall through to font.
         [[gnu::fallthrough]];
       case EFFECT_NEWFONT:
-        if (DelayTimerActive() || error_sound_active()) {
+        if (DelayTimerActive()) {
           pending_newfont_ = true;
           PVLOG_NORMAL << "*** NEWFONT deferred — waiting for error sound to finish\n";
           return;
@@ -902,7 +902,7 @@ public:
     }
 // \/\/\/\/ this is BC only because I think this is how it should work
       // Delay boot.wav for error talkie/beeps to finish..
-    if (!DelayTimerActive() && !error_sound_active()) {
+    if (!DelayTimerActive()) {
       if (pending_boot_) {
         pending_boot_ = false;
         if (!PlayPolyphonic(&SFX_boot)) {

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -132,21 +132,21 @@ void DodgeSound(uint32_t millis) {
   undodge.start(millis);
 }
 
-bool PlayErrorMessage(const char* filename) {
-  RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
-  if (!ret) return false;
-  if (!ret->PlayInCurrentDir(filename) &&
-      !ret->PlayInDir("errors", filename)) {
-    return false;
-  }
+// bool PlayErrorMessage(const char* filename) {
+//   RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
+//   if (!ret) return false;
+//   if (!ret->PlayInCurrentDir(filename) &&
+//       !ret->PlayInDir("errors", filename)) {
+//     return false;
+//   }
 
-  // DodgeSound(ret->length() * 1000.0);
-  // ret->set_dodge(false);
-  ret->UpdateSaberBaseSoundInfo();
-  AppendToDelayTimer(ret->length() * 1000 + 200);  // +200ms tail buffer before boot/font sounds resume
-  ret->set_dodge(false);
-  return true;
-}
+//   // DodgeSound(ret->length() * 1000.0);
+//   // ret->set_dodge(false);
+//   ret->UpdateSaberBaseSoundInfo();
+//   AppendToDelayTimer(ret->length() * 1000 + 200);  // +200ms tail buffer before boot/font sounds resume
+//   ret->set_dodge(false);
+//   return true;
+// }
 
 // Defined in sound_library.h after SoundQueueSingleton and SOUNDQ are available.
 bool PlayErrorMessage(const char* filename);

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -132,7 +132,6 @@ void DodgeSound(uint32_t millis) {
   undodge.start(millis);
 }
 
-bool PlayErrorMessage(const char* filename);
 // bool PlayErrorMessage(const char* filename) {
 //   RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
 //   if (!ret) return false;
@@ -146,6 +145,9 @@ bool PlayErrorMessage(const char* filename);
 //   ret->UpdateSaberBaseSoundInfo();
 //   return true;
 // }
+
+// Defined in sound_library.h after SoundQueueSingleton and SOUNDQ are available.
+bool PlayErrorMessage(const char* filename);
 
 size_t WhatUnit(class BufferedWavPlayer* player) {
   if (!player) return -1;

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -132,19 +132,21 @@ void DodgeSound(uint32_t millis) {
   undodge.start(millis);
 }
 
-// bool PlayErrorMessage(const char* filename) {
-//   RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
-//   if (!ret) return false;
-//   if (!ret->PlayInCurrentDir(filename) &&
-//       !ret->PlayInDir("errors", filename)) {
-//     return false;
-//   }
+bool PlayErrorMessage(const char* filename) {
+  RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
+  if (!ret) return false;
+  if (!ret->PlayInCurrentDir(filename) &&
+      !ret->PlayInDir("errors", filename)) {
+    return false;
+  }
 
-//   DodgeSound(ret->length() * 1000.0);
-//   ret->set_dodge(false);
-//   ret->UpdateSaberBaseSoundInfo();
-//   return true;
-// }
+  // DodgeSound(ret->length() * 1000.0);
+  // ret->set_dodge(false);
+  ret->UpdateSaberBaseSoundInfo();
+  AppendToDelayTimer(ret->length() * 1000 + 200);  // +200ms tail buffer before boot/font sounds resume
+  ret->set_dodge(false);
+  return true;
+}
 
 // Defined in sound_library.h after SoundQueueSingleton and SOUNDQ are available.
 bool PlayErrorMessage(const char* filename);

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -132,23 +132,7 @@ void DodgeSound(uint32_t millis) {
   undodge.start(millis);
 }
 
-// bool PlayErrorMessage(const char* filename) {
-//   RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
-//   if (!ret) return false;
-//   if (!ret->PlayInCurrentDir(filename) &&
-//       !ret->PlayInDir("errors", filename)) {
-//     return false;
-//   }
-
-//   // DodgeSound(ret->length() * 1000.0);
-//   // ret->set_dodge(false);
-//   ret->UpdateSaberBaseSoundInfo();
-//   AppendToDelayTimer(ret->length() * 1000 + 200);  // +200ms tail buffer before boot/font sounds resume
-//   ret->set_dodge(false);
-//   return true;
-// }
-
-// Defined in sound_library.h after SoundQueueSingleton and SOUNDQ are available.
+// Fwd declaration - Defined in sound_library.h after SoundQueueSingleton and SOUNDQ are available.
 bool PlayErrorMessage(const char* filename);
 
 size_t WhatUnit(class BufferedWavPlayer* player) {

--- a/sound/sound.h
+++ b/sound/sound.h
@@ -132,19 +132,20 @@ void DodgeSound(uint32_t millis) {
   undodge.start(millis);
 }
 
-bool PlayErrorMessage(const char* filename) {
-  RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
-  if (!ret) return false;
-  if (!ret->PlayInCurrentDir(filename) &&
-      !ret->PlayInDir("errors", filename)) {
-    return false;
-  }
+bool PlayErrorMessage(const char* filename);
+// bool PlayErrorMessage(const char* filename) {
+//   RefPtr<BufferedWavPlayer> ret = GetFreeWavPlayer();
+//   if (!ret) return false;
+//   if (!ret->PlayInCurrentDir(filename) &&
+//       !ret->PlayInDir("errors", filename)) {
+//     return false;
+//   }
 
-  DodgeSound(ret->length() * 1000.0);
-  ret->set_dodge(false);
-  ret->UpdateSaberBaseSoundInfo();
-  return true;
-}
+//   DodgeSound(ret->length() * 1000.0);
+//   ret->set_dodge(false);
+//   ret->UpdateSaberBaseSoundInfo();
+//   return true;
+// }
 
 size_t WhatUnit(class BufferedWavPlayer* player) {
   if (!player) return -1;

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -4,6 +4,7 @@
 #ifdef ENABLE_AUDIO
 
 #include "sound_queue.h"
+#include "../common/delay_timer.h"
 
 // Sound library
 EFFECT(mnum); // menu numbers
@@ -58,6 +59,29 @@ public:
   const char* name() { return "SoundQueue"; }
   void Loop() override {
     PollSoundQueue(wav_player_);
+    // While an error WAV is playing, keep the delay timer just ahead of the
+    // sound's end so hybrid_font.h defers boot/newfont until the queue drains.
+    // We track remaining playback time instead of appending a fixed value on
+    // every tick: the fixed approach grows the deadline far into the future
+    // (100 ms × loop-rate ms/s) and prevents boot/font sounds from ever firing.
+    if (busy() && wav_player_) {
+      float pos = wav_player_->pos();
+      float len = wav_player_->length();
+      // pos() can return a small negative value when the wav file has been fully
+      // read but the audio buffer is still draining (playwav::pos() returns 0.0
+      // once isPlaying() is false, making buffered_wav_player::pos() go negative
+      // by ~buffer_duration).  Without this guard, remaining = len - (-buf) > len,
+      // which pushes the deadline ~len+0.5 s into the future and causes a 2–3 s
+      // extra wait after the error sound finishes.  Clamp pos to 0 so that
+      // remaining is treated as ≈ 0 in that end-of-file drain phase.
+      if (pos < 0.0f) pos = 0.0f;
+      float remaining = len - pos;
+      if (remaining < 0.0f) remaining = 0.0f;
+      uint32_t needed_until = millis() + (uint32_t)(remaining * 1000) + 500;
+      if (needed_until > delay_until_ms()) {
+        delay_until_ms() = needed_until;
+      }
+    }
   }
 
   void require_version(int version) {
@@ -103,6 +127,49 @@ private:
 };
 
 #define SOUNDQ (getPtr<SoundQueueSingleton>())
+
+// Play an error WAV from the current font directory, falling back to the root-level
+// "errors/" folder on the SD card.  Returns false when the file cannot be found so
+// that errors.h falls through to the talkie/beeper.  When the file IS found the sound
+// is queued via SoundQueueSingleton (sequential, not simultaneous) and a sentinel is
+// set on SaberBase::sound_length so the "if (sound_length > 0) return;" guard in
+// errors.h fires immediately, suppressing the talkie even before the queue drains and
+// the WAV header is parsed.
+inline bool PlayErrorMessage(const char* filename) {
+  // Pre-check: confirm the file exists in a font directory or the root "errors/" folder.
+  // This must be done before queuing so we only suppress the talkie when we know a WAV
+  // will actually play.  (SoundToPlayErrorFile repeats the same search at play time.)
+  bool found = false;
+  bool in_font = false;
+  for (const char* dir = current_directory; dir; dir = next_current_directory(dir)) {
+    PathHelper full_name(dir, filename);
+    if (LSFS::Exists(full_name)) { found = true; in_font = true; break; }
+  }
+  if (!found) {
+    PathHelper err_path("errors", filename);
+    found = LSFS::Exists(err_path);
+  }
+  if (!found) {
+    PVLOG_NORMAL << "*** Error wav not found: " << filename
+                 << " — falling through to talkie/beeper\n";
+    return false;  // No WAV found — let talkie/beeper handle it
+  }
+  PVLOG_NORMAL << "*** Error wav found in "
+               << (in_font ? "font" : "errors/") << " folder: " << filename << "\n";
+  // File confirmed.  Queue for sequential async playback.
+  if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
+  // Sentinel: the queue hasn't started playing yet so sound_length is still 0.
+  // Set a non-zero value now so errors.h suppresses the talkie immediately.
+  if (SaberBase::sound_length < 0.001f) SaberBase::sound_length = 0.001f;
+  // Initial hold — keeps hybrid_font.h's DelayTimerActive() check true until the
+  // first Loop() tick, when SoundQueueSingleton::Loop() takes over and sets the
+  // deadline to millis() + remaining_playback + 500 ms.  Use 500 ms (not 200 ms)
+  // to cover Activate2() config.ini reads and EFFECT_CHDIR observer calls, which
+  // can take >200 ms on slow SD cards and would otherwise let DoBoot/DoNewFont
+  // slip past the guard and start simultaneously with the queued error sound.
+  AppendToDelayTimer(500);
+  return true;
+}
 
 class SoundLibrary  {
 public:

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -59,6 +59,7 @@ public:
   const char* name() { return "SoundQueue"; }
   void Loop() override {
     PollSoundQueue(wav_player_);
+    if (!busy()) error_sound_active() = false;
   }
 
   void require_version(int version) {
@@ -114,13 +115,16 @@ inline bool PlayErrorMessage(const char* filename) {
   // ("if (SaberBase::sound_length > 0) return;") fire immediately and
   // suppress the Talkie fallback.
   if (SaberBase::sound_length == 0.0f) SaberBase::sound_length = 0.001f;
-  // Append 3 s to the delay timer so that hybrid_font.h defers boot/font
-  // sounds until the error wav finishes.  Multiple back-to-back errors
-  // stack their estimates (AppendToDelayTimer adds on top of any existing
-  // deadline rather than resetting it).
-  AppendToDelayTimer(SaberBase::sound_length * 1000);
+  // Signal that an error wav is playing.  hybrid_font.h Loop() checks
+  // error_sound_active() to defer boot/font sounds until the queue drains.
+  // SoundQueueSingleton::Loop() clears this flag when busy() goes false.
+  error_sound_active() = true;
+  // Short sentinel so that the pending_boot_ / pending_newfont_ bools are
+  // set before Loop() first evaluates !DelayTimerActive().
+  AppendToDelayTimer(200);
   return true;
 }
+
 
 class SoundLibrary  {
 public:

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -109,6 +109,27 @@ private:
 // PlayErrorMessage is declared in sound.h (before hybrid_font.h) but defined
 // here where SOUNDQ and SoundToPlayErrorFile are both available.
 inline bool PlayErrorMessage(const char* filename) {
+  // Pre-check: verify the file exists in the current font directory or in the
+  // root-level "errors/" folder on the SD card before queuing playback.
+  // This mirrors the legacy synchronous behaviour: if the file is not found
+  // anywhere we return false so the talkie/beeper fallback in errors.h runs.
+  // (LOCK_SD is a no-op in this codebase, so the check is safe to call from
+  // any context including Effect::ScanCurrentDirectory.)
+  bool found = false;
+  for (const char* dir = current_directory; dir; dir = next_current_directory(dir)) {
+    PathHelper full_name(dir, filename);
+    if (LSFS::Exists(full_name)) { found = true; break; }
+  }
+  if (!found) {
+    // Fall back to the global root-level "errors/" folder.
+    PathHelper err_path("errors", filename);
+    found = LSFS::Exists(err_path);
+  }
+  if (!found) return false;
+  // File confirmed to exist; enqueue async playback.
+  // SoundToPlayErrorFile repeats the same two-location search when the queue
+  // drains so that the correct file is played even if current_directory
+  // changes between now and when Loop() fires.
   if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
   // SOUNDQ is asynchronous — the wav header isn't parsed until Loop() fires.
   // Set a non-zero sentinel now so the guards in errors.h

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -118,9 +118,7 @@ private:
 #define SOUNDQ (getPtr<SoundQueueSingleton>())
 
 inline bool PlayErrorMessage(const char* filename) {
-  // Confirm the file exists in a font directory or the root "errors/" folder
-  // before queuing so we only suppress Talkie when we know a WAV
-  // will actually play. (SoundToPlayErrorFile repeats the same search at play time.)
+  // Check font dirs, then errors folder before queuing so Talkie is suppressed only if WAV exists.
   bool found = false;
   bool in_font = false;
   for (const char* dir = current_directory; dir; dir = next_current_directory(dir)) {
@@ -141,12 +139,7 @@ inline bool PlayErrorMessage(const char* filename) {
   if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
   // Sound_length is still 0. Set a non-zero value now so errors.h suppresses Talkie immediately.
   if (SaberBase::sound_length < 0.001f) SaberBase::sound_length = 0.001f;
-  // Initial hold — keeps hybrid_font.h's DelayTimerActive() check true until the
-  // first Loop() tick, when SoundQueueSingleton::Loop() takes over and sets the
-  // deadline to millis() + remaining_playback + 500 ms.  Used 500 ms
-  // to cover Activate2() config.ini reads and EFFECT_CHDIR calls, which
-  // could take some time on slow SD cards, which could let DoBoot/DoNewFont
-  // slip past the guard and start simultaneously with the queued error sound.
+  // Short initial hold until Loop() updates delay from actual remaining playback.
   AppendToDelayTimer(500);
   return true;
 }

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -59,22 +59,11 @@ public:
   const char* name() { return "SoundQueue"; }
   void Loop() override {
     PollSoundQueue(wav_player_);
-    // While an error WAV is playing, keep the delay timer just ahead of the
-    // sound's end so hybrid_font.h defers boot/newfont until the queue drains.
-    // We track remaining playback time instead of appending a fixed value on
-    // every tick: the fixed approach grows the deadline far into the future
-    // (100 ms × loop-rate ms/s) and prevents boot/font sounds from ever firing.
+    // Keep delay_until_ms just past current WAV end so boot/font waits for queue drain.
     if (busy() && wav_player_) {
       float pos = wav_player_->pos();
       float len = wav_player_->length();
-      // pos() goes negative when the wav file has been fully decoded but the
-      // audio buffer is still draining: wav.pos() returns 0.0 once the decoder
-      // is done while buffered()/AUDIO_RATE is still > 0, so pos() = -drain_time.
-      // The correct remaining time in that phase is -pos (the actual drain, ≈ 6 ms).
-      // The previous code clamped pos to 0, which made remaining = len - 0 = len
-      // (the full wav duration) and pushed the timer ~len+500 ms into the future
-      // on every Loop tick during the 6 ms drain window — producing the 2–3 s
-      // silence gap observed between the error sound and the boot/font wav.
+      // pos() is negative while output buffer drains after decode; then remaining is -pos.
       float remaining = (pos < 0.0f) ? -pos : (len - pos);
       if (remaining < 0.0f) remaining = 0.0f;
       uint32_t needed_until = millis() + (uint32_t)(remaining * 1000) + 500;

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -4,7 +4,6 @@
 #ifdef ENABLE_AUDIO
 
 #include "sound_queue.h"
-#include "../common/delay_timer.h"
 
 // Sound library
 EFFECT(mnum); // menu numbers
@@ -59,7 +58,6 @@ public:
   const char* name() { return "SoundQueue"; }
   void Loop() override {
     PollSoundQueue(wav_player_);
-    if (!busy()) error_sound_active() = false;
   }
 
   void require_version(int version) {
@@ -105,47 +103,6 @@ private:
 };
 
 #define SOUNDQ (getPtr<SoundQueueSingleton>())
-
-// PlayErrorMessage is declared in sound.h (before hybrid_font.h) but defined
-// here where SOUNDQ and SoundToPlayErrorFile are both available.
-inline bool PlayErrorMessage(const char* filename) {
-  // Pre-check: verify the file exists in the current font directory or in the
-  // root-level "errors/" folder on the SD card before queuing playback.
-  // This mirrors the legacy synchronous behaviour: if the file is not found
-  // anywhere we return false so the talkie/beeper fallback in errors.h runs.
-  // (LOCK_SD is a no-op in this codebase, so the check is safe to call from
-  // any context including Effect::ScanCurrentDirectory.)
-  bool found = false;
-  for (const char* dir = current_directory; dir; dir = next_current_directory(dir)) {
-    PathHelper full_name(dir, filename);
-    if (LSFS::Exists(full_name)) { found = true; break; }
-  }
-  if (!found) {
-    // Fall back to the global root-level "errors/" folder.
-    PathHelper err_path("errors", filename);
-    found = LSFS::Exists(err_path);
-  }
-  if (!found) return false;
-  // File confirmed to exist; enqueue async playback.
-  // SoundToPlayErrorFile repeats the same two-location search when the queue
-  // drains so that the correct file is played even if current_directory
-  // changes between now and when Loop() fires.
-  if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
-  // SOUNDQ is asynchronous — the wav header isn't parsed until Loop() fires.
-  // Set a non-zero sentinel now so the guards in errors.h
-  // ("if (SaberBase::sound_length > 0) return;") fire immediately and
-  // suppress the Talkie fallback.
-  if (SaberBase::sound_length == 0.0f) SaberBase::sound_length = 0.001f;
-  // Signal that an error wav is playing.  hybrid_font.h Loop() checks
-  // error_sound_active() to defer boot/font sounds until the queue drains.
-  // SoundQueueSingleton::Loop() clears this flag when busy() goes false.
-  error_sound_active() = true;
-  // Short sentinel so that the pending_boot_ / pending_newfont_ bools are
-  // set before Loop() first evaluates !DelayTimerActive().
-  AppendToDelayTimer(200);
-  return true;
-}
-
 
 class SoundLibrary  {
 public:

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -4,6 +4,7 @@
 #ifdef ENABLE_AUDIO
 
 #include "sound_queue.h"
+#include "../common/delay_timer.h"
 
 // Sound library
 EFFECT(mnum); // menu numbers
@@ -103,6 +104,23 @@ private:
 };
 
 #define SOUNDQ (getPtr<SoundQueueSingleton>())
+
+// PlayErrorMessage is declared in sound.h (before hybrid_font.h) but defined
+// here where SOUNDQ and SoundToPlayErrorFile are both available.
+inline bool PlayErrorMessage(const char* filename) {
+  if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
+  // SOUNDQ is asynchronous — the wav header isn't parsed until Loop() fires.
+  // Set a non-zero sentinel now so the guards in errors.h
+  // ("if (SaberBase::sound_length > 0) return;") fire immediately and
+  // suppress the Talkie fallback.
+  if (SaberBase::sound_length == 0.0f) SaberBase::sound_length = 0.001f;
+  // Append 3 s to the delay timer so that hybrid_font.h defers boot/font
+  // sounds until the error wav finishes.  Multiple back-to-back errors
+  // stack their estimates (AppendToDelayTimer adds on top of any existing
+  // deadline rather than resetting it).
+  AppendToDelayTimer(SaberBase::sound_length * 1000);
+  return true;
+}
 
 class SoundLibrary  {
 public:

--- a/sound/sound_library.h
+++ b/sound/sound_library.h
@@ -67,15 +67,15 @@ public:
     if (busy() && wav_player_) {
       float pos = wav_player_->pos();
       float len = wav_player_->length();
-      // pos() can return a small negative value when the wav file has been fully
-      // read but the audio buffer is still draining (playwav::pos() returns 0.0
-      // once isPlaying() is false, making buffered_wav_player::pos() go negative
-      // by ~buffer_duration).  Without this guard, remaining = len - (-buf) > len,
-      // which pushes the deadline ~len+0.5 s into the future and causes a 2–3 s
-      // extra wait after the error sound finishes.  Clamp pos to 0 so that
-      // remaining is treated as ≈ 0 in that end-of-file drain phase.
-      if (pos < 0.0f) pos = 0.0f;
-      float remaining = len - pos;
+      // pos() goes negative when the wav file has been fully decoded but the
+      // audio buffer is still draining: wav.pos() returns 0.0 once the decoder
+      // is done while buffered()/AUDIO_RATE is still > 0, so pos() = -drain_time.
+      // The correct remaining time in that phase is -pos (the actual drain, ≈ 6 ms).
+      // The previous code clamped pos to 0, which made remaining = len - 0 = len
+      // (the full wav duration) and pushed the timer ~len+500 ms into the future
+      // on every Loop tick during the 6 ms drain window — producing the 2–3 s
+      // silence gap observed between the error sound and the boot/font wav.
+      float remaining = (pos < 0.0f) ? -pos : (len - pos);
       if (remaining < 0.0f) remaining = 0.0f;
       uint32_t needed_until = millis() + (uint32_t)(remaining * 1000) + 500;
       if (needed_until > delay_until_ms()) {
@@ -128,17 +128,10 @@ private:
 
 #define SOUNDQ (getPtr<SoundQueueSingleton>())
 
-// Play an error WAV from the current font directory, falling back to the root-level
-// "errors/" folder on the SD card.  Returns false when the file cannot be found so
-// that errors.h falls through to the talkie/beeper.  When the file IS found the sound
-// is queued via SoundQueueSingleton (sequential, not simultaneous) and a sentinel is
-// set on SaberBase::sound_length so the "if (sound_length > 0) return;" guard in
-// errors.h fires immediately, suppressing the talkie even before the queue drains and
-// the WAV header is parsed.
 inline bool PlayErrorMessage(const char* filename) {
-  // Pre-check: confirm the file exists in a font directory or the root "errors/" folder.
-  // This must be done before queuing so we only suppress the talkie when we know a WAV
-  // will actually play.  (SoundToPlayErrorFile repeats the same search at play time.)
+  // Confirm the file exists in a font directory or the root "errors/" folder
+  // before queuing so we only suppress Talkie when we know a WAV
+  // will actually play. (SoundToPlayErrorFile repeats the same search at play time.)
   bool found = false;
   bool in_font = false;
   for (const char* dir = current_directory; dir; dir = next_current_directory(dir)) {
@@ -150,22 +143,20 @@ inline bool PlayErrorMessage(const char* filename) {
     found = LSFS::Exists(err_path);
   }
   if (!found) {
-    PVLOG_NORMAL << "*** Error wav not found: " << filename
+    PVLOG_DEBUG << "*** Error wav not found: " << filename
                  << " — falling through to talkie/beeper\n";
-    return false;  // No WAV found — let talkie/beeper handle it
+    return false;
   }
-  PVLOG_NORMAL << "*** Error wav found in "
+  PVLOG_DEBUG << "*** Error wav found in "
                << (in_font ? "font" : "errors/") << " folder: " << filename << "\n";
-  // File confirmed.  Queue for sequential async playback.
   if (!SOUNDQ->Play(SoundToPlayErrorFile(filename))) return false;
-  // Sentinel: the queue hasn't started playing yet so sound_length is still 0.
-  // Set a non-zero value now so errors.h suppresses the talkie immediately.
+  // Sound_length is still 0. Set a non-zero value now so errors.h suppresses Talkie immediately.
   if (SaberBase::sound_length < 0.001f) SaberBase::sound_length = 0.001f;
   // Initial hold — keeps hybrid_font.h's DelayTimerActive() check true until the
   // first Loop() tick, when SoundQueueSingleton::Loop() takes over and sets the
-  // deadline to millis() + remaining_playback + 500 ms.  Use 500 ms (not 200 ms)
-  // to cover Activate2() config.ini reads and EFFECT_CHDIR observer calls, which
-  // can take >200 ms on slow SD cards and would otherwise let DoBoot/DoNewFont
+  // deadline to millis() + remaining_playback + 500 ms.  Used 500 ms
+  // to cover Activate2() config.ini reads and EFFECT_CHDIR calls, which
+  // could take some time on slow SD cards, which could let DoBoot/DoNewFont
   // slip past the guard and start simultaneously with the queued error sound.
   AppendToDelayTimer(500);
   return true;

--- a/sound/sound_queue.h
+++ b/sound/sound_queue.h
@@ -41,8 +41,13 @@ class SoundToPlayErrorFile : public SoundToPlayBase {
 public:
   SoundToPlayErrorFile(const char* filename) : filename_(filename) {}
   bool Play(BufferedWavPlayer* player) override {
-    return player->PlayInCurrentDir(filename_) ||
-           player->PlayInDir("errors", filename_);
+    if (player->PlayInCurrentDir(filename_)) return true;
+    // Font directory lookup missed; try the root-level errors/ folder.
+    PVLOG_NORMAL << "Trying errors/ folder for " << filename_ << "\n";
+    if (player->PlayInDir("errors", filename_)) return true;
+    PVLOG_NORMAL << "*** Error wav " << filename_
+                 << " not found at play time (SD remount/path change?)\n";
+    return false;
   }
 private:
   const char* filename_;

--- a/sound/sound_queue.h
+++ b/sound/sound_queue.h
@@ -33,6 +33,23 @@ private:
   const char* filename_;
 };
 
+
+// Like SoundToPlayInCurrentDir but also searches the "errors/" directory
+// as a fallback.  Used by PlayErrorMessage() so that error wavs stored in
+// the global "errors/" folder work regardless of the current font dir.
+class SoundToPlayErrorFile : public SoundToPlayBase {
+public:
+  SoundToPlayErrorFile(const char* filename) : filename_(filename) {}
+  bool Play(BufferedWavPlayer* player) override {
+    return player->PlayInCurrentDir(filename_) ||
+           player->PlayInDir("errors", filename_);
+  }
+private:
+  const char* filename_;
+};
+
+
+
 class SoundToPlayFileID : public SoundToPlayBase {
 public:
   SoundToPlayFileID(Effect::FileID id) : file_id_(id) {}

--- a/sound/sound_queue.h
+++ b/sound/sound_queue.h
@@ -34,18 +34,16 @@ private:
 };
 
 
-// Like SoundToPlayInCurrentDir but also searches the "errors/" directory
-// as a fallback.  Used by PlayErrorMessage() so that error wavs stored in
-// the global "errors/" folder work regardless of the current font dir.
+// Like SoundToPlayInCurrentDir but also searches the "errors" directory
+// as a fallback.  Used by PlayErrorMessage()
 class SoundToPlayErrorFile : public SoundToPlayBase {
 public:
   SoundToPlayErrorFile(const char* filename) : filename_(filename) {}
   bool Play(BufferedWavPlayer* player) override {
     if (player->PlayInCurrentDir(filename_)) return true;
-    // Font directory lookup missed; try the root-level errors/ folder.
-    PVLOG_NORMAL << "Trying errors/ folder for " << filename_ << "\n";
+    PVLOG_DEBUG << "Trying errors/ folder for " << filename_ << "\n";
     if (player->PlayInDir("errors", filename_)) return true;
-    PVLOG_NORMAL << "*** Error wav " << filename_
+    PVLOG_DEBUG << "*** Error wav " << filename_
                  << " not found at play time (SD remount/path change?)\n";
     return false;
   }


### PR DESCRIPTION
Overlapping WAV files are unintelligible. Use SOUNDQ instead for them.
Also fixes a freezing issue caused by checking sound length before it’s loaded in PlayErrorMessage().